### PR TITLE
Add configuration from command line via YAML

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,3 @@
 include machine_learning_hep/data/database_ml_parameters.yml
+include machine_learning_hep/data/database_ml_gridsearch.yml
+include machine_learning_hep/data/config_ml_parameters.yml

--- a/machine_learning_hep/config.py
+++ b/machine_learning_hep/config.py
@@ -1,0 +1,95 @@
+#############################################################################
+##  © Copyright CERN 2018. All rights not expressly granted are reserved.  ##
+##                 Author: Gian.Michele.Innocenti@cern.ch                  ##
+## This program is free software: you can redistribute it and/or modify it ##
+##  under the terms of the GNU General Public License as published by the  ##
+## Free Software Foundation, either version 3 of the License, or (at your  ##
+## option) any later version. This program is distributed in the hope that ##
+##  it will be useful, but WITHOUT ANY WARRANTY; without even the implied  ##
+##     warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.    ##
+##           See the GNU General Public License for more details.          ##
+##    You should have received a copy of the GNU General Public License    ##
+##   along with this program. if not, see <https://www.gnu.org/licenses/>. ##
+#############################################################################
+
+"""
+Methods to: configure parameters
+"""
+
+import sys
+import os.path
+from pkg_resources import resource_stream
+import yaml
+
+def get_default_config():
+    """
+    Load the default ML parameters
+    """
+    stream = resource_stream("machine_learning_hep.data", "config_ml_parameters.yml")
+    return yaml.safe_load(stream)
+
+def assert_config(config: dict):
+    """
+    Validate and return the configuration
+    Args:
+        config: The configuration dictionary to be checked
+    """
+    # Get defaults
+    parameters = get_default_config()
+
+    # Check for unknown parameters and abort since running entire machinery with wrong
+    # setting (e.g. 'dotaining' instead of 'dotraining' might happen just by accident)
+    # could be just overhead.
+    for k in config:
+        if k not in parameters:
+            print(f"ERROR: Unkown parameter {k} in config")
+            sys.exit(1)
+        elif config[k] is None:
+            print(f"ERROR: Missing value for parameter {k} in config")
+            sys.exit(1)
+
+    # Merge with defaults
+    # NOTE Could be done via #config = {**configDefeaults, **config}
+    #      but we want to inform the user if a default was used.
+    for k in parameters:
+        if k not in config:
+            config[k] = parameters[k]["default"]
+            print(f"Use default value {parameters[k]['default']} for parameter {k}")
+        # If parameter is already set, check if consistent
+        elif "choices" in parameters[k]:
+            if config[k] not in parameters[k]["choices"]:
+                print(f"ERROR: Invalid value {config[k]} for parameter {k}")
+                sys.exit(1)
+
+    # Can so far only depend on one parameter, change to combination
+    # of parameters. Do we need to check for circular dependencies?
+    for k in parameters:
+        # check whether key k depends on anything
+        if "depends" in parameters[k]:
+            # get the depending value in the current config and check the
+            # value against the depending value and force resetting if
+            # necessary
+            if (config[parameters[k]["depends"]["parameter"]]
+                    == parameters[k]["depends"]["value"]
+                    and config[k] != parameters[k]["depends"]["set"]):
+                config[k] = parameters[k]["depends"]["set"]
+                print("INFO: Parameter %s = %s enforced since it is required for %s == %s"
+                      % (k, parameters[k]["depends"]["set"],
+                         parameters[k]["depends"]["parameter"],
+                         parameters[k]["depends"]["value"]))
+
+    return config
+
+def dump_default_config(path):
+    """
+    Write default configuration
+    Args:
+        path: full or relative path to where the config should be dumped
+    """
+
+    path = os.path.expanduser(path)
+    parameters = get_default_config()
+    config = {k: parameters[k]["default"] for k in parameters}
+
+    with open(path, "w") as stream:
+        yaml.safe_dump(config, stream, default_flow_style=False, allow_unicode=False)

--- a/machine_learning_hep/data/config_ml_parameters.yml
+++ b/machine_learning_hep/data/config_ml_parameters.yml
@@ -1,0 +1,111 @@
+nevt_sig:
+    default: 1000
+nevt_bkg:
+  default: 1000
+
+mltype:
+  choices: ["BinaryClassification", "Regression"]
+  default: "BinaryClassification"
+
+mlsubtype:
+  default: "HFmeson"
+
+case:
+  choices: ["Bplus", "Dplus", "Ds", "Lc", "PIDKaon", "PIDPion", "hypertritium", "lightquarkjet" ]
+  default: "Lc"
+
+var_skimming:
+  choices: [["pt_cand_ML"]]
+  default: ["pt_cand_ML"]
+
+varmin:
+  default: [2]
+
+varmax:
+  default: [4]
+
+test_frac:
+  default: 0.2
+
+rnd_splt:
+  default: 12
+
+rnd_shuffle:
+ default: 12
+
+nkfolds:
+  default: 5
+
+ncores:
+  default: -1
+
+loadsampleoption:
+  default: 1
+
+docorrelation:
+  default: 0
+
+dostandard:
+  default: 0
+
+dopca:
+  default: 0
+
+activate_scikit:
+  default: 0
+
+activate_xgboost:
+  default: 1
+
+activate_keras:
+  default: 0
+  depends:
+    parameter: "mltype"
+    value: "Regression"
+    set: 0
+
+dotraining:
+  default: 1
+
+dotesting:
+  default: 1
+
+applytodatamc:
+  default: 1
+
+docrossvalidation:
+  default: 1
+
+dolearningcurve:
+  default: 1
+
+doROC:
+  default: 1
+  depends:
+    parameter: "mltype"
+    value: "Regression"
+    set: 0
+
+doboundary:
+  default: 1
+  depends:
+    parameter: "mltype"
+    value: "Regression"
+    set: 0
+
+doimportance:
+  default: 1
+  depends:
+    parameter: "mltype"
+    value: "Regression"
+    set: 0
+
+dopltregressionxy:
+  default: 0
+  depends:
+    parameter: "mltype"
+    value: "BinaryClassification"
+    set: 0
+
+dogridsearch:
+  default: 0

--- a/machine_learning_hep/doclassification_regression.py
+++ b/machine_learning_hep/doclassification_regression.py
@@ -15,12 +15,16 @@
 """
 main macro for running the study
 """
+import argparse
+import sys
 from sklearn.utils import shuffle
 # from sklearn.metrics import make_scorer, accuracy_score
 from machine_learning_hep.general import get_database_ml_parameters, getdataframe
 from machine_learning_hep.general import get_database_ml_gridsearch
 from machine_learning_hep.general import checkdir, write_tree
 from machine_learning_hep.general import filterdataframe, split_df_sigbkg, createstringselection
+from machine_learning_hep.io import parse_yaml
+from machine_learning_hep.config import assert_config, dump_default_config
 from machine_learning_hep.preparesamples import prep_mlsamples
 from machine_learning_hep.correlations import vardistplot, scatterplot, correlationmatrix
 from machine_learning_hep.pca import getdataframe_standardised, get_pcadataframe_pca
@@ -36,23 +40,13 @@ from machine_learning_hep.mlperformance import precision_recall
 from machine_learning_hep.grid_search import do_gridsearch, read_grid_dict, perform_plot_gridsearch
 
 
-def doclassification_regression():  # pylint: disable=too-many-locals, too-many-statements, too-many-branches
-    data = get_database_ml_parameters()
-    nevt_sig = 1000
-    nevt_bkg = 1000
-    mltype = "BinaryClassification"
-    mlsubtype = "HFmeson"
-    case = "Lc"
-    var_skimming = ["pt_cand_ML"]
-    varmin = [2]
-    varmax = [4]
-    test_frac = 0.2
-    rnd_splt = 12
-    rnd_shuffle = 12
-    nkfolds = 5
-    ncores = -1
+def doclassification_regression(config): # pylint: disable=too-many-locals, too-many-statements, too-many-branches
 
-    print(nevt_sig, nevt_bkg, mltype, mlsubtype, case)
+    case = config['case']
+    print(config['nevt_sig'], config['nevt_bkg'], config['mltype'],
+          config['mlsubtype'], case)
+
+    data = get_database_ml_parameters()
     var_all = data[case]["var_all"]
     var_signal = data[case]["var_signal"]
     sel_signal = data[case]["sel_signal"]
@@ -61,48 +55,14 @@ def doclassification_regression():  # pylint: disable=too-many-locals, too-many-
     var_target = data[case]["var_target"]
     var_corr_x, var_corr_y = data[case]["var_correlation"]
 
-    loadsampleoption = 1
-    docorrelation = 0
-    dostandard = 0
-    dopca = 0
-    activate_scikit = 0
-    activate_xgboost = 1
-    activate_keras = 0
-    dotraining = 1
-    dotesting = 1
-    applytodatamc = 1
-    docrossvalidation = 1
-    dolearningcurve = 1
-    doROC = 1
-    doboundary = 1
-    doimportance = 1
-    dopltregressionxy = 0
-    dogridsearch = 0
+    string_selection = createstringselection(config['var_skimming'], config['varmin'],
+                                             config['varmax'])
+    suffix = f"nevt_sig{config['nevt_sig']}_nevt_bkg{config['nevt_bkg']}_" \
+             f"{config['mltype']}{case}_{string_selection}"
 
-    if mltype == "Regression":
-        print("these tests cannot be performed for regression:")
-        print("- doROCcurve")
-        print("- doOptimisation")
-        print("- doBinarySearch")
-        print("- doBoundary")
-        print("- doImportance")
-        doROC = 0
-        doboundary = 0
-        activate_keras = 0
-        doimportance = 0
-
-    if mltype == "BinaryClassification":
-        print("these tests cannot be performed for classification:")
-        print("- plotdistributiontargetregression")
-        dopltregressionxy = 0
-
-    string_selection = createstringselection(var_skimming, varmin, varmax)
-    suffix = "nevt_sig%d_nevt_sig%d_%s%s_%s" % \
-        (nevt_bkg, nevt_bkg, mltype, case, string_selection)
-
-    dataframe = "dataframes_%s" % (suffix)
-    plotdir = "plots_%s" % (suffix)
-    output = "output_%s" % (suffix)
+    dataframe = f"dataframes_{suffix}"
+    plotdir = f"plots_{suffix}"
+    output = f"output_{suffix}"
     checkdir(dataframe)
     checkdir(plotdir)
     checkdir(output)
@@ -122,19 +82,23 @@ def doclassification_regression():  # pylint: disable=too-many-locals, too-many-
     x_train = []
     y_train = []
 
-    if loadsampleoption == 1:
+    if config['loadsampleoption'] == 1:
         filesig, filebkg = data[case]["sig_bkg_files"]
         trename = data[case]["tree_name"]
         df_sig = getdataframe(filesig, trename, var_all)
         df_bkg = getdataframe(filebkg, trename, var_all)
-        df_sig = filterdataframe(df_sig, var_skimming, varmin, varmax)
-        df_bkg = filterdataframe(df_bkg, var_skimming, varmin, varmax)
+        df_sig = filterdataframe(df_sig, config['var_skimming'], config['varmin'],
+                                 config['varmax'])
+        df_bkg = filterdataframe(df_bkg, config['var_skimming'], config['varmin'],
+                                 config['varmax'])
         df_sig = df_sig.query(sel_signal)
         df_bkg = df_bkg.query(sel_bkg)
-        df_sig = shuffle(df_sig, random_state=rnd_shuffle)
-        df_bkg = shuffle(df_bkg, random_state=rnd_shuffle)
+        df_sig = shuffle(df_sig, random_state=config['rnd_shuffle'])
+        df_bkg = shuffle(df_bkg, random_state=config['rnd_shuffle'])
         df_ml_train, df_ml_test = \
-            prep_mlsamples(df_sig, df_bkg, var_signal, nevt_sig, nevt_bkg, test_frac, rnd_splt)
+            prep_mlsamples(df_sig, df_bkg, var_signal, config['nevt_sig'],
+                           config['nevt_bkg'], config['test_frac'],
+                           config['rnd_splt'])
         df_sig_train, df_bkg_train = split_df_sigbkg(df_ml_train, var_signal)
         df_sig_test, df_bkg_test = split_df_sigbkg(df_ml_test, var_signal)
         print("events for ml train %d and test %d" % (len(df_ml_train), len(df_ml_test)))
@@ -145,81 +109,88 @@ def doclassification_regression():  # pylint: disable=too-many-locals, too-many-
         x_test = df_ml_test[var_training]
         y_test = df_ml_test[var_signal]
 
-    if docorrelation == 1:
+    if config['docorrelation'] == 1:
         vardistplot(df_sig_train, df_bkg_train, var_all, plotdir)
         scatterplot(df_sig_train, df_bkg_train, var_corr_x, var_corr_y, plotdir)
         correlationmatrix(df_sig_train, plotdir, "signal")
         correlationmatrix(df_bkg_train, plotdir, "background")
 
-    if dostandard == 1:
+    if config['dostandard'] == 1:
         x_train = getdataframe_standardised(x_train)
 
-    if dopca == 1:
+    if config['dopca'] == 1:
         n_pca = 9
         x_train, pca = get_pcadataframe_pca(x_train, n_pca)
         plotvariance_pca(pca, plotdir)
 
-    if activate_scikit == 1:
-        classifiers_scikit, names_scikit = getclf_scikit(mltype)
+    if config['activate_scikit'] == 1:
+        classifiers_scikit, names_scikit = getclf_scikit(config['mltype'])
         classifiers = classifiers+classifiers_scikit
         names = names+names_scikit
 
-    if activate_xgboost == 1:
-        classifiers_xgboost, names_xgboost = getclf_xgboost(mltype)
+    if config['activate_xgboost'] == 1:
+        classifiers_xgboost, names_xgboost = getclf_xgboost(config['mltype'])
         classifiers = classifiers+classifiers_xgboost
         names = names+names_xgboost
 
-    if activate_keras == 1:
-        classifiers_keras, names_keras = getclf_keras(mltype, len(x_train.columns))
+    if config['activate_keras'] == 1:
+        classifiers_keras, names_keras = getclf_keras(config['mltype'], len(x_train.columns))
         classifiers = classifiers+classifiers_keras
         names = names+names_keras
 
-    if dotraining == 1:
+    if config['dotraining'] == 1:
         trainedmodels = fit(names, classifiers, x_train, y_train)
         savemodels(names, trainedmodels, output, suffix)
 
-    if dotesting == 1:
-        df_ml_test_dec = test(mltype, names, trainedmodels, df_ml_test, var_training, var_signal)
+    if config['dotesting'] == 1:
+        df_ml_test_dec = test(config['mltype'], names, trainedmodels, df_ml_test,
+                              var_training, var_signal)
         df_ml_test_dec_to_df = output+"/testsample_%s_mldecision.pkl" % (suffix)
         df_ml_test_dec_to_root = output+"/testsample_%s_mldecision.root" % (suffix)
         df_ml_test_dec.to_pickle(df_ml_test_dec_to_df)
         write_tree(df_ml_test_dec_to_root, trename, df_ml_test_dec)
 
-    if applytodatamc == 1:
+    if config['applytodatamc'] == 1:
         filedata, filemc = data[case]["data_mc_files"]
         trename = data[case]["tree_name"]
         df_data = getdataframe(filedata, trename, var_all)
         df_mc = getdataframe(filemc, trename, var_all)
-        df_data = filterdataframe(df_data, var_skimming, varmin, varmax)
-        df_mc = filterdataframe(df_mc, var_skimming, varmin, varmax)
-        df_data_dec = apply(mltype, names, trainedmodels, df_data, var_training)
-        df_mc_dec = apply(mltype, names, trainedmodels, df_mc, var_training)
+        df_data = filterdataframe(df_data, config['var_skimming'], config['varmin'],
+                                  config['varmax'])
+        df_mc = filterdataframe(df_mc, config['var_skimming'], config['varmin'],
+                                config['varmax'])
+        df_data_dec = apply(config['mltype'], names, trainedmodels, df_data, var_training)
+        df_mc_dec = apply(config['mltype'], names, trainedmodels, df_mc, var_training)
         df_data_dec_to_root = output+"/data_%s_mldecision.root" % (suffix)
         df_mc_dec_to_root = output+"/mc_%s_mldecision.root" % (suffix)
         write_tree(df_data_dec_to_root, trename, df_data_dec)
         write_tree(df_mc_dec_to_root, trename, df_mc_dec)
 
-    if docrossvalidation == 1:
+    if config['docrossvalidation'] == 1:
         df_scores = []
-        if mltype == "Regression":
+        if config['mltype'] == "Regression":
             df_scores = cross_validation_mse_continuous(
-                names, classifiers, x_train, y_train, nkfolds, ncores)
-        if mltype == "BinaryClassification":
+                names, classifiers, x_train, y_train, config['nkfolds'],
+                config['ncores'])
+        if config['mltype'] == "BinaryClassification":
             df_scores = cross_validation_mse(
-                names, classifiers, x_train, y_train, nkfolds, ncores)
+                names, classifiers, x_train, y_train, config['nkfolds'],
+                config['ncores'])
         plot_cross_validation_mse(names, df_scores, suffix, plotdir)
 
-    if dolearningcurve == 1:
-        #         confusion(names, classifiers, suffix, x_train, y_train, nkfolds, plotdir)
+    if config['dolearningcurve'] == 1:
+        #         confusion(names, classifiers, suffix, x_train, y_train, config['nkfolds'],
+        #                   plotdir)
         npoints = 10
         plot_learning_curves(names, classifiers, suffix, plotdir, x_train, y_train, npoints)
 
-    if doROC == 1:
-        precision_recall(names, classifiers, suffix, x_train, y_train, nkfolds, plotdir)
+    if config['doROC'] == 1:
+        precision_recall(names, classifiers, suffix, x_train, y_train, config['nkfolds'],
+                         plotdir)
 
-    if doboundary == 1:
-        classifiers_scikit_2var, names_2var = getclf_scikit(mltype)
-        classifiers_keras_2var, names_keras_2var = getclf_keras(mltype, 2)
+    if config['doboundary'] == 1:
+        classifiers_scikit_2var, names_2var = getclf_scikit(config['mltype'])
+        classifiers_keras_2var, names_keras_2var = getclf_keras(config['mltype'], 2)
         classifiers_2var = classifiers_scikit_2var+classifiers_keras_2var
         names_2var = names_2var+names_keras_2var
         x_test_boundary = x_test[data[case]["var_boundaries"]]
@@ -227,17 +198,17 @@ def doclassification_regression():  # pylint: disable=too-many-locals, too-many-
         decisionboundaries(
             names_2var, trainedmodels_2var, suffix+"2var", x_test_boundary, y_test, plotdir)
 
-    if doimportance == 1:
+    if config['doimportance'] == 1:
         importanceplotall(var_training, names_scikit+names_xgboost,
                           classifiers_scikit+classifiers_xgboost, suffix, plotdir)
 
-    if dopltregressionxy == 1:
+    if config['dopltregressionxy'] == 1:
         plotdistributiontarget(names, df_ml_test, var_target, suffix, plotdir)
         plotscattertarget(names, df_ml_test, var_target, suffix, plotdir)
 
-    if dogridsearch == 1:
+    if config['dogridsearch'] == 1:
         datasearch = get_database_ml_gridsearch()
-        analysisdb = datasearch[mltype]
+        analysisdb = datasearch[config['mltype']]
 
         #names_cv, clf_cv, par_grid_cv, refit_cv, var_param = read_grid_dict(analysisdb)
 #         scoring = {'AUC': 'roc_auc', 'Accuracy': make_scorer(accuracy_score)}
@@ -249,9 +220,27 @@ def doclassification_regression():  # pylint: disable=too-many-locals, too-many-
         names_cv, clf_cv, par_grid_cv, refit_cv, var_param, \
             par_grid_cv_keys = read_grid_dict(analysisdb)
         _, _, dfscore = do_gridsearch(
-            names_cv, clf_cv, par_grid_cv, refit_cv, x_train, y_train, nkfolds, ncores)
+            names_cv, clf_cv, par_grid_cv, refit_cv, x_train, y_train, config['nkfolds'],
+            config['ncores'])
         perform_plot_gridsearch(
             names_cv, dfscore, par_grid_cv, par_grid_cv_keys, var_param, plotdir, suffix, 0.1)
 
+def main():
+    parser = argparse.ArgumentParser()
+    # Require a config file with some plotting info
+    parser.add_argument("-c", "--config", help="config YAML file, do -d <path> to get " \
+                                               "YAML file with defaults at <path>")
+    parser.add_argument("--dump-default-config", help="get default YAML config file")
 
-doclassification_regression()
+    args = parser.parse_args()
+
+    if args.dump_default_config is not None:
+        dump_default_config(args.dump_default_config)
+        sys.exit(0)
+
+    user_config = {}
+    if args.config is not None:
+        user_config = parse_yaml(args.config)
+
+    # Pass config dictionary
+    doclassification_regression(assert_config(user_config))

--- a/machine_learning_hep/io.py
+++ b/machine_learning_hep/io.py
@@ -1,0 +1,32 @@
+#############################################################################
+##  © Copyright CERN 2018. All rights not expressly granted are reserved.  ##
+##                 Author: Gian.Michele.Innocenti@cern.ch                  ##
+## This program is free software: you can redistribute it and/or modify it ##
+##  under the terms of the GNU General Public License as published by the  ##
+## Free Software Foundation, either version 3 of the License, or (at your  ##
+## option) any later version. This program is distributed in the hope that ##
+##  it will be useful, but WITHOUT ANY WARRANTY; without even the implied  ##
+##     warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.    ##
+##           See the GNU General Public License for more details.          ##
+##    You should have received a copy of the GNU General Public License    ##
+##   along with this program. if not, see <https://www.gnu.org/licenses/>. ##
+#############################################################################
+
+"""
+Methods to: manage input/output
+"""
+
+import os
+import yaml
+
+def parse_yaml(filepath):
+    """
+    Parse a YAML file and return dictionary
+    Args:
+        filepath: Path to the YAML file to be parsed.
+    """
+    if not os.path.isfile(filepath):
+        print("YAML file %s does not exist." % filepath)
+        exit(1)
+    with open(filepath) as f:
+        return yaml.safe_load(f)

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,9 @@ setup(
   # installed, specify them here. Note that you need to specify those files in
   # MANIFEST.in as well, since Python tools behave inconsistently
   include_package_data=True,
-  package_data={ "machine_learning_hep.data": [ "database_ml_parameters.yml" ], "machine_learning_hep.data": [ "database_ml_gridsearch.yml" ] },
+  package_data={ "machine_learning_hep.data": [ "database_ml_parameters.yml",
+                                                "database_ml_gridsearch.yml",
+                                                "config_ml_parameters.yml"] },
 
   # Although 'package_data' is the preferred approach, in some case you may
   # need to place data files outside of your packages. See:
@@ -98,6 +100,8 @@ setup(
   # pip to create the appropriate form of executable for the target platform.
   # See: https://chriswarrick.com/blog/2014/09/15/python-apps-the-right-way-entry_points-and-scripts/
   entry_points={
-      "console_scripts": [ "ml-get-data = machine_learning_hep.ml_get_data:main" ]
+      "console_scripts": [ "ml-get-data = machine_learning_hep.ml_get_data:main",
+                           "ml-doclassification-regression = " \
+                           "machine_learning_hep.doclassification_regression:main"]
   }
 )


### PR DESCRIPTION
1) User can overwrite default configuration via YAML file e.g.
   $> doclassification_regression -c myConfig.yml

2) User can get default config in YAML via
   $> doclassification_regression -d $DEFAULT_CONFIG_YAML
   to path $DEFAULT_CONFIG_YAML

All missing parameters are replaced by default parameters. In case of an
unknown parameter or if a value is missing for a parameter the execution
is aborted. That can make sense if the user made a typo like 'dotaining'
instead of 'dotraining'.

Any parameter - value combination missing is set to default.

Parameter dependencies are checked to first order (such as ROC cannot
be calcualted for mltype == "Regression"). That means if a dependent
parameter has another dependency it will only check param1 -> param2
but not param1 -> param2 -> param3. Furthermore, cyclic dependencies
are not yet detected.