### PR TITLE
Fix Python version requirement to >=3.6 and <3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
   install_requires=[ "numpy", "pandas", "scipy", "matplotlib", "seaborn", "uproot", "scikit-learn",
                      "sklearn-evaluation", "xgboost", "keras", "tensorflow", "PyYaml", "pylint" ],
 
-  python_requires='>=3.6',
+  python_requires='>=3.6, <3.7',
 
   # List additional groups of dependencies here (e.g. development
   # dependencies). You can install these using the following syntax,


### PR DESCRIPTION
According to https://www.tensorflow.org/install/pip?lang=python3
Tensorflow installation via pip is compatible with Python version 3.4,
3.5 and 3.6. For now fix to (>=3.6 && <3.7) in view of having stable
version for first tag this year.