### PR TITLE
Reduce number of epochs in NN training

### DIFF
--- a/machine_learning_hep/models.py
+++ b/machine_learning_hep/models.py
@@ -95,7 +95,7 @@ def getclf_keras(ml_type, length_input):
             return model
 
         classifiers = [KerasClassifier(build_fn=create_model_sequential,
-                                       epochs=1000, batch_size=50, verbose=0)]
+                                       epochs=30, batch_size=50, verbose=0)]
         names = ["KerasSequential"]
 
     if ml_type == "Regression":


### PR DESCRIPTION
To speed-up the NN training the number of epochs is reduced. This should keep the computation time acceptable and permit to have a working NN example out-of-the-box.