### PR TITLE
Add logger utility

### DIFF
--- a/machine_learning_hep/doclassification_regression.py
+++ b/machine_learning_hep/doclassification_regression.py
@@ -37,9 +37,13 @@ from machine_learning_hep.mlperformance import plotdistributiontarget, plotscatt
 # from machine_learning_hep.mlperformance import confusion
 from machine_learning_hep.mlperformance import precision_recall
 from machine_learning_hep.grid_search import do_gridsearch, read_grid_dict, perform_plot_gridsearch
+from machine_learning_hep.logger import configure_logger, get_logger
 
 
 def doclassification_regression(config):  # pylint: disable=too-many-locals, too-many-statements, too-many-branches
+
+    logger = get_logger()
+    logger.info(f"Start classification_regression run")
 
     mltype = config['mltype']
     mlsubtype = config['mlsubtype']
@@ -85,11 +89,13 @@ def doclassification_regression(config):  # pylint: disable=too-many-locals, too
     var_corr_x, var_corr_y = data[case]["var_correlation"]
     var_boundaries = data[case]["var_boundaries"]
 
-    print(nevt_sig, nevt_bkg, mltype, mlsubtype, case)
+    summary_string = f"#sg events: {nevt_sig}\n#bkg events: {nevt_bkg}\nmltype: {mltype}\n" \
+                     f"mlsubtype: {mlsubtype}\ncase: {case}"
+    logger.debug(summary_string)
+
     string_selection = createstringselection(var_skimming, varmin, varmax)
     suffix = f"nevt_sig{nevt_sig}_nevt_bkg{nevt_bkg}_" \
              f"{mltype}{case}_{string_selection}"
-
     dataframe = f"dataframes_{suffix}"
     plotdir = f"plots_{suffix}"
     output = f"output_{suffix}"
@@ -222,8 +228,12 @@ def main():
     parser.add_argument("-c", "--config", help="config YAML file, do -d <path> to get " \
                                                "YAML file with defaults at <path>")
     parser.add_argument("--dump-default-config", help="get default YAML config file")
+    parser.add_argument("--debug", action="store_true", help="turn in debug information")
+    parser.add_argument("--logfile", help="specify path to log file")
 
     args = parser.parse_args()
+
+    configure_logger(args.debug, args.logfile)
 
     if args.dump_default_config is not None:
         dump_default_config(args.dump_default_config)

--- a/machine_learning_hep/functions.py
+++ b/machine_learning_hep/functions.py
@@ -20,6 +20,7 @@ from sklearn.utils import shuffle
 from machine_learning_hep.general import filterdataframe, split_df_sigbkg
 from machine_learning_hep.preparesamples import prep_mlsamples
 from machine_learning_hep.correlations import vardistplot, scatterplot, correlationmatrix
+from machine_learning_hep.logger import get_logger
 
 
 def create_mlsamples(df_sig, df_bkg, sel_signal, sel_bkg, rnd_shuffle,  # pylint: disable=too-many-arguments
@@ -35,9 +36,10 @@ def create_mlsamples(df_sig, df_bkg, sel_signal, sel_bkg, rnd_shuffle,  # pylint
                                              nevt_bkg, test_frac, rnd_splt)
     df_sig_train, df_bkg_train = split_df_sigbkg(df_ml_train, var_signal)
     df_sig_test, df_bkg_test = split_df_sigbkg(df_ml_test, var_signal)
-    print("events for ml train %d and test %d" % (len(df_ml_train), len(df_ml_test)))
-    print("events for signal train %d and test %d" % (len(df_sig_train), len(df_sig_test)))
-    print("events for bkg train %d and test %d" % (len(df_bkg_train), len(df_bkg_test)))
+    logger = get_logger()
+    logger.info("Events for ml train %d and test %d", len(df_ml_train), len(df_ml_test))
+    logger.info("Events for signal train %d and test %d", len(df_sig_train), len(df_sig_test))
+    logger.info("Events for bkg train %d and test %d", len(df_bkg_train), len(df_bkg_test))
     x_train = df_ml_train[var_training]
     y_train = df_ml_train[var_signal]
     x_test = df_ml_test[var_training]

--- a/machine_learning_hep/grid_search.py
+++ b/machine_learning_hep/grid_search.py
@@ -22,9 +22,11 @@ import pandas as pd
 import matplotlib.pyplot as plt
 from sklearn.model_selection import GridSearchCV
 from sklearn.ensemble import GradientBoostingClassifier, RandomForestClassifier, AdaBoostClassifier  # pylint: disable=unused-import
+from machine_learning_hep.logger import get_logger
 
 
 def do_gridsearch(names, classifiers, param_grid, refit_arr, x_train, y_train_, cv_, ncores):
+    logger = get_logger()
     grid_search_models_ = []
     grid_search_bests_ = []
     list_scores_ = []
@@ -34,7 +36,7 @@ def do_gridsearch(names, classifiers, param_grid, refit_arr, x_train, y_train_, 
         grid_search_model = grid_search.fit(x_train, y_train_)
         cvres = grid_search.cv_results_
         for mean_score, params in zip(cvres["mean_test_score"], cvres["params"]):
-            print(np.sqrt(-mean_score), params)
+            logger.info(np.sqrt(-mean_score), params)
         list_scores_.append(pd.DataFrame(cvres))
         grid_search_best = grid_search.best_estimator_.fit(x_train, y_train_)
         grid_search_models_.append(grid_search_model)
@@ -66,12 +68,13 @@ def perform_plot_gridsearch(names, scores, par_grid, keys, changeparameter, outp
     '''
     Function for grid scores plotting (working with scikit 0.20)
     '''
+    logger = get_logger()
     fig = plt.figure(figsize=(35, 15))
     for name, score_obj, pars, key, change in zip(names, scores, par_grid,
                                                   keys, changeparameter):
         change_par = "param_" + change
         if len(key) == 1:
-            print("### ADD AT LEAST 1 PARAMETER (even just 1 value) ###")
+            logger.warning("Add at least 1 parameter (even just 1 value)")
             continue
 
         dict_par = pars[0].copy()

--- a/machine_learning_hep/io.py
+++ b/machine_learning_hep/io.py
@@ -18,6 +18,7 @@ Methods to: manage input/output
 
 import os
 import yaml
+from machine_learning_hep.logger import get_logger
 
 def parse_yaml(filepath):
     """
@@ -26,8 +27,7 @@ def parse_yaml(filepath):
         filepath: Path to the YAML file to be parsed.
     """
     if not os.path.isfile(filepath):
-        print("YAML file %s does not exist." % filepath)
-        exit(1)
+        get_logger().critical("YAML file %s does not exist.", filepath)
     with open(filepath) as f:
         return yaml.safe_load(f)
 

--- a/machine_learning_hep/logger.py
+++ b/machine_learning_hep/logger.py
@@ -1,0 +1,127 @@
+#############################################################################
+##  © Copyright CERN 2018. All rights not expressly granted are reserved.  ##
+##                 Author: Gian.Michele.Innocenti@cern.ch                  ##
+## This program is free software: you can redistribute it and/or modify it ##
+##  under the terms of the GNU General Public License as published by the  ##
+## Free Software Foundation, either version 3 of the License, or (at your  ##
+## option) any later version. This program is distributed in the hope that ##
+##  it will be useful, but WITHOUT ANY WARRANTY; without even the implied  ##
+##     warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.    ##
+##           See the GNU General Public License for more details.          ##
+##    You should have received a copy of the GNU General Public License    ##
+##   along with this program. if not, see <https://www.gnu.org/licenses/>. ##
+#############################################################################
+
+"""
+Methods to: provide and manage central logging utility
+"""
+import logging
+import sys
+from copy import copy
+
+
+class ExitHandler(logging.Handler):
+    """
+    Add custom logging handler to exit on certain logging level
+    """
+    def emit(self, record):
+        logging.shutdown()
+        sys.exit(1)
+
+class MLLoggerFormatter(logging.Formatter):
+    """
+    A custom formatter that colors the levelname on request
+    """
+    # color names to indices
+    color_map = {
+        'black': 0,
+        'red': 1,
+        'green': 2,
+        'yellow': 3,
+        'blue': 4,
+        'magenta': 5,
+        'cyan': 6,
+        'white': 7,
+    }
+
+    level_map = {
+        logging.DEBUG: (None, 'blue', False),
+        logging.INFO: (None, 'black', False),
+        logging.WARNING: (None, 'yellow', False),
+        logging.ERROR: (None, 'red', False),
+        logging.CRITICAL: ('red', 'white', True),
+    }
+    csi = '\x1b['
+    reset = '\x1b[0m'
+
+    # Define default format string
+    def __init__(self, fmt='%(levelname)s in %(pathname)s:%(lineno)d:\n%(message)s',
+                 datefmt=None, style='%', color=False):
+        logging.Formatter.__init__(self, fmt, datefmt, style)
+        self.color = color
+
+    def format(self, record):
+        # Copy the record so the global format is kept
+        cached_record = copy(record)
+        requ_color = self.color
+        # Could be a lambda so check for callable property
+        if callable(self.color):
+            requ_color = self.color()
+        # Make sure levelname takes same space for all cases
+        cached_record.levelname = f"{cached_record.levelname:8}"
+        # Colorize if requested
+        if record.levelno in self.level_map and requ_color:
+            bg, fg, bold = self.level_map[record.levelno]
+            params = []
+            if bg in self.color_map:
+                params.append(str(self.color_map[bg] + 40))
+            if fg in self.color_map:
+                params.append(str(self.color_map[fg] + 30))
+            if bold:
+                params.append('1')
+            if params:
+                cached_record.levelname = "".join((self.csi, ';'.join(params), "m",
+                                                   cached_record.levelname,
+                                                   self.reset))
+        return logging.Formatter.format(self, cached_record)
+
+
+def configure_logger(debug, logfile=None):
+    """
+    Basic configuration adding a custom formatted StreamHandler and turning on
+    debug info if requested.
+    """
+    logger = logging.getLogger()
+    if logger.hasHandlers():
+        return
+
+    # Turn on debug info only on request
+    if debug:
+        logger.setLevel(logging.DEBUG)
+    else:
+        logger.setLevel(logging.INFO)
+
+    sh = logging.StreamHandler()
+    formatter = MLLoggerFormatter(color=lambda : getattr(sh.stream, 'isatty', None)) # pylint: disable=C0326
+
+    sh.setFormatter(formatter)
+    logger.addHandler(sh)
+
+    # Add logfile on request
+    if logfile is not None:
+        # Specify output format
+        fh = logging.FileHandler(logfile)
+        fh.setFormatter(MLLoggerFormatter())
+        logger.addHandler(fh)
+
+    # Add handler to exit at critical. Do this as the last step so all former
+    # logger flush before aborting
+    logger.addHandler(ExitHandler(logging.CRITICAL))
+
+
+def get_logger():
+    """
+    Get the global logger for this package and set handler together with formatters.
+    """
+    configure_logger(False, None)
+    return logging.getLogger()

--- a/machine_learning_hep/models.py
+++ b/machine_learning_hep/models.py
@@ -33,6 +33,7 @@ from keras.layers import Input, Dense
 from keras.models import Model
 from keras.wrappers.scikit_learn import KerasClassifier
 from xgboost import XGBClassifier
+from machine_learning_hep.logger import get_logger
 
 
 def getclf_scikit(ml_type):
@@ -70,18 +71,22 @@ def getclf_xgboost(ml_type):
     classifiers = []
     names = []
 
+    logger = get_logger()
+
     if ml_type == "BinaryClassification":
         classifiers = [XGBClassifier()]
         names = ["XGBoostXGBClassifier"]
 
     if ml_type == "Regression":
-        print("No XGBoost models implemented for Regression")
+        logger.info("No XGBoost models implemented for Regression")
     return classifiers, names
 
 
 def getclf_keras(ml_type, length_input):
     classifiers = []
     names = []
+
+    logger = get_logger()
 
     if ml_type == "BinaryClassification":
         def create_model_functional():
@@ -100,7 +105,7 @@ def getclf_keras(ml_type, length_input):
         names = ["KerasSequential"]
 
     if ml_type == "Regression":
-        print("No Keras models implemented for Regression")
+        logger.info("No Keras models implemented for Regression")
     return classifiers, names
 
 def fit(names_, classifiers_, x_train_, y_train_):

--- a/machine_learning_hep/preparesamples.py
+++ b/machine_learning_hep/preparesamples.py
@@ -17,20 +17,22 @@ Methods to load and prepare data for training
 """
 import pandas as pd
 from sklearn.model_selection import train_test_split
+from machine_learning_hep.logger import get_logger
 
 
 def prep_mlsamples(df_sig, df_bkg, namesig, nevt_sig, nevt_bkg, test_frac, rnd_splt):
 
+    logger = get_logger()
     if nevt_sig > len(df_sig):
-        print("there are not enough signal events ")
+        logger.warning("There are not enough signal events")
     if nevt_bkg > len(df_bkg):
-        print("there are not enough background events ")
+        logger.warning("There are not enough background events")
 
     nevt_sig = min(len(df_sig), nevt_sig)
     nevt_bkg = min(len(df_bkg), nevt_bkg)
 
-    print("used number of signal events are %d" % (nevt_sig))
-    print("used number of signal events are %d" % (nevt_bkg))
+    logger.info("Used number of signal events is %d", nevt_sig)
+    logger.info("Used number of background events is %d", nevt_bkg)
 
     df_sig = df_sig[:nevt_sig]
     df_bkg = df_bkg[:nevt_bkg]
@@ -40,5 +42,5 @@ def prep_mlsamples(df_sig, df_bkg, namesig, nevt_sig, nevt_bkg, test_frac, rnd_s
     df_ml = pd.concat([df_sig, df_bkg])
     df_ml_train, df_ml_test = train_test_split(df_ml, test_size=test_frac, random_state=rnd_splt)
 
-    print("%d events for training and %d for testing" % (len(df_ml_train), len(df_ml_test)))
+    logger.info("%d events for training and %d for testing", len(df_ml_train), len(df_ml_test))
     return df_ml_train, df_ml_test

--- a/machine_learning_hep/root.py
+++ b/machine_learning_hep/root.py
@@ -20,6 +20,7 @@ import array
 import ast
 import numpy as np
 from ROOT import TNtuple, TFile # pylint: disable=import-error,no-name-in-module
+from machine_learning_hep.logger import get_logger
 
 
 def read_ntuple(ntuple, variables):
@@ -28,6 +29,7 @@ def read_ntuple(ntuple, variables):
         ntuple : input TNtuple
         variables : list of ntuple variables to read
     """
+    logger = get_logger()
     code_list = []
     for v in variables:
         code_list += [compile("i.%s" % v, '<string>', 'eval')]
@@ -38,7 +40,7 @@ def read_ntuple(ntuple, variables):
         for m, v in enumerate(code_list):
             myarray[n][m] = ast.literal_eval(v)
         if n % 100000 == 0:
-            print(n, "/", nentries)
+            logger.info("%d/%d", n, nentries)
     return myarray
 
 
@@ -48,6 +50,7 @@ def read_ntuple_ml(ntuple, variablesfeatures, variablesothers, variabley):
         ntuple : input TNtuple
         variables : list of ntuple variables to read
     """
+    logger = get_logger()
     code_listfeatures = []
     code_listothers = []
     for v in variablesfeatures:
@@ -68,7 +71,7 @@ def read_ntuple_ml(ntuple, variablesfeatures, variablesothers, variabley):
             arrayothers[n][m] = ast.literal_eval(v)
         arrayy[n] = ast.literal_eval(codevariabley)
         if n % 100000 == 0:
-            print(n, "/", nentries)
+            logger.info("%d/%d", n, nentries)
     return arrayfeatures, arrayothers, arrayy
 
 

--- a/machine_learning_hep/test.py
+++ b/machine_learning_hep/test.py
@@ -19,6 +19,7 @@ from sklearn.utils import shuffle
 from machine_learning_hep.general import get_database_ml_parameters, getdataframe
 from machine_learning_hep.general import filterdataframe, split_df_sigbkg
 from machine_learning_hep.preparesamples import prep_mlsamples
+from machine_learning_hep.logger import get_logger
 
 def test():
     data = get_database_ml_parameters()
@@ -34,7 +35,11 @@ def test():
     rnd_splt = 12
     rnd_shuffle = 12
 
-    print(nevt_sig, nevt_bkg, mltype, mlsubtype, case)
+    logger = get_logger()
+    summary_string = f"#sg events: {nevt_sig}\n#bkg events: {nevt_bkg}\nmltype: {mltype}\n" \
+                     f"mlsubtype: {mlsubtype}\ncase: {case}"
+    logger.debug(summary_string)
+
     var_all = data[case]["var_all"]
     var_signal = data[case]["var_signal"]
     sel_signal = data[case]["sel_signal"]
@@ -61,8 +66,8 @@ def test():
             prep_mlsamples(df_sig, df_bkg, var_signal, nevt_sig, nevt_bkg, test_frac, rnd_splt)
         df_sig_train, df_bkg_train = split_df_sigbkg(df_ml_train, var_signal)
         df_sig_test, df_bkg_test = split_df_sigbkg(df_ml_test, var_signal)
-        print("events for ml train %d and test %d" % (len(df_ml_train), len(df_ml_test)))
-        print("events for signal train %d and test %d" % (len(df_sig_train), len(df_sig_test)))
-        print("events for bkg train %d and test %d" % (len(df_bkg_train), len(df_bkg_test)))
+        logger.info("events for ml train %d and test %d", len(df_ml_train), len(df_ml_test))
+        logger.info("events for signal train %d and test %d", len(df_sig_train), len(df_sig_test))
+        logger.info("events for bkg train %d and test %d", len(df_bkg_train), len(df_bkg_test))
 
 test()


### PR DESCRIPTION
The logger utility can be used for central logging and all verbosity.
The standard log level is INFO. If a critical message is sent, it will
be flushed and the execution will be aborted afterwards.

Using the logger is highly recommended and provides a unified format for
the verbosity. All normal print commands have hence been replaced by
logger.info

The icentral logger object can be obtained by importing the 'get'
function get_logger via
from machine_learning_hep.logger import get_logger

and then one can do

logger = get_logger()
logger.info("Some message")

On the command line, debug information can be enabled using the --debug
flag such that messages logged with logger.debug are printed as well.

The log can be additionaly written to a file by specifying the
--logfile <logfilepath>
Note that the logs are appended to the logfile if it already exists.