### PR TITLE
Finalising bitmap

### DIFF
--- a/machine_learning_hep/data/config_run_parameters.yml
+++ b/machine_learning_hep/data/config_run_parameters.yml
@@ -13,8 +13,8 @@ mlsubtype:
   default: "HFmeson"
 
 case:
-  choices: ["Bplus", "Dplus", "Ds", "Dsnew", "Dzero", "Dstar", "Lc", "LctopKpi", "LctopK0s", "PIDKaon", "PIDPion", "hypertritium", "lightquarkjet" ]
-  default: "Lc"
+  choices: ["Dplus", "Ds", "Dzero", "Dstar", "LctopKpi", "LctopK0s", "PIDKaon", "PIDPion", "hypertritium", "lightquarkjet" ]
+  default: "Dzero"
 
 binmin:
   default: 2

--- a/machine_learning_hep/data/database_ml_parameters.yml
+++ b/machine_learning_hep/data/database_ml_parameters.yml
@@ -25,10 +25,12 @@ Dzero:
   - [d_len_xy_ML, imp_par_xy_ML, max_norm_d0d0exp_ML, imp_par_xy_ML, cos_p_ML, d_len_xy_ML, imp_par_xy_ML, cos_p_ML, pt_cand_ML]
   var_others: [inv_mass_ML, pt_cand_ML]
   var_signal: signal_ML
-  bitselvariable : cand_type_ML
+  bitselvariable: cand_type_ML
+  bitselvariable_gen: cand_type_gen_ML
   var_target: signal_ML
   var_training: [d_len_ML, d_len_xy_ML, norm_dl_ML, norm_dl_xy_ML, cos_p_ML, cos_p_xy_ML, imp_par_xy_ML, dca_ML, cos_t_star_ML, imp_par_prod_ML, pt_prong0_ML, pt_prong1_ML, imp_par_prong0_ML, imp_par_prong1_ML, imp_par_err_prong0_ML, imp_par_err_prong1_ML, max_norm_d0d0exp_ML]
   sel_signal: "cand_type_ML>0"
+  sel_signal_gen: "cand_type_gen_ML>0"
   sel_bkg: inv_mass_ML<1.77 or inv_mass_ML>1.97
   var_binning: pt_cand_ML
   presel_reco: abs(eta_prong0_ML)<0.8 and abs(eta_prong1_ML)<0.8
@@ -36,22 +38,14 @@ Dzero:
   var_gen: [y_cand_gen_ML, pt_cand_gen_ML, cand_type_gen_ML, z_vtx_gen_ML]
   presel_gen: abs(y_cand_gen_ML) < 0.5 and abs(z_vtx_gen_ML) < 10 # pre-selections on generated candidates
   ptgen: pt_cand_gen_ML
-  sel_signal_gen: cand_type_gen_ML==[10, 11, 18, 19]
   bitmapsel:
     mcsignal_on_off: [[1],[5]]
     mcsignal_prompt_on_off: [[1,3],[5]]
     mcsignal_feed_on_off: [[1,4],[5]]
     mcbkg_on_off: [[2],[]]
     std_analysis_on_off : [[0],[]]
-    mcpreseltrack_pid_on_off : [[1,7,8],[5]]
-    datapreseltrack_pid_on_off: [[7,8],[]]
-    signalpreseltrack_pid_on_off : [[1,7,8],[5]]
-    bkgpreseltrack_pid_on_off: [[7,8],[]]
+    preseltrack_pid_on_off : [[7,8],[]]
   signif_opt:
-    sel_signal_reco_sopt: cand_type_ML==[10, 11, 18, 19] # define signal candidates
-    sel_signal_gen_sopt: cand_type_gen_ML==[10, 11, 18, 19]
-    sel_signal_reco_std: cand_type_ML==[11, 19] # define signal candidates + selected std
-    sel_signal_gen_std: cand_type_gen_ML==[11, 19]
     treename_event: fTreeEventChar # variables related to the event tree
     var_event: [is_ev_rej_ML]
     sel_event: is_ev_rej_ML==0
@@ -79,10 +73,12 @@ LctopK0s:
   - [imp_par_K0s_ML]
   var_others: [inv_mass_ML, pt_cand_ML]
   var_signal: signal_ML
+  bitselvariable: cand_type_ML
+  bitselvariable_gen: cand_type_gen_ML
   var_target: signal_ML
-  sel_signal: cand_type_ML==[10, 11, 18, 19]
-  bitselvariable : cand_type_ML
   var_training: [cos_t_star_ML, signd0_ML, dca_K0s_ML, imp_par_K0s_ML, d_len_K0s_ML, armenteros_K0s_ML, ctau_K0s_ML, cos_p_K0s_ML, pt_prong0_ML, pt_prong1_ML, pt_prong2_ML, imp_par_prong0_ML, imp_par_prong1_ML, imp_par_prong2_ML]
+  sel_signal: cand_type_ML>0
+  sel_signal_gen: cand_type_gen_ML>0
   sel_bkg: inv_mass_ML<2.1864 or inv_mass_ML>2.3864
   var_binning: pt_cand_ML
   presel_reco: abs(eta_prong0_ML)<0.8 and abs(eta_prong1_ML)<0.8 and abs(eta_prong2_ML)<0.8
@@ -96,10 +92,7 @@ LctopK0s:
     mcsignal_feed_on_off: [[1,4],[5]]
     mcbkg_on_off: [[2],[]]
     std_analysis_on_off : [[0],[]]
-    mcpreseltrack_pid_on_off : [[1,7,8],[5]]
-    datapreseltrack_pid_on_off: [[7,8],[]]
-    signalpreseltrack_pid_on_off : [[1,7,8],[5]]
-    bkgpreseltrack_pid_on_off: [[7,8],[]]
+    preseltrack_pid_on_off : [[7,8],[]]
   signif_opt:
     treename_event: fTreeEventChar # variables related to the event tree
     var_event: [is_ev_rej_ML]

--- a/machine_learning_hep/data/database_ml_parameters.yml
+++ b/machine_learning_hep/data/database_ml_parameters.yml
@@ -166,7 +166,7 @@ Ds:
   var_boundaries: [d_len_ML, max_norm_d0d0exp_ML]
   var_correlation:
   - [pt_cand_ML, d_len_xy_ML, sig_vert_ML, pt_cand_ML, pt_cand_ML, norm_dl_xy_ML, cos_PiDs_ML, cos_p_xy_ML, cos_p_xy_ML]
-  - [d_len_xy_ML, sig_vert_ML, mass_KK_ML, mass_KK_ML, sig_vert_ML, d_len_xy_ML, cos_PiKPhi_3_ML, sig_vert_ML, pt_cand_ML]
+  - [d_len_xy_ML, sig_vert_ML, delta_mass_KK_ML, delta_mass_KK_ML, sig_vert_ML, d_len_xy_ML, cos_PiKPhi_3_ML, sig_vert_ML, pt_cand_ML]
   var_others: [inv_mass_ML, pt_cand_ML]
   var_signal: signal_ML
   bitselvariable: cand_type_ML
@@ -188,7 +188,7 @@ Ds:
     mcsignal_feed_on_off: [[1,4],[5,11]]
     mcbkg_on_off: [[2],[11]]
     std_analysis_on_off : [[0],[]]
-    preseltrack_pid_on_off : [[7,8],[]]
+    preseltrack_pid_on_off : null #[[7,8],[]] #pid+track rejects everything for Ds (in data and MC), to check... For now turned off
   signif_opt:
     treename_event: fTreeEventChar # variables related to the event tree
     var_event: [is_ev_rej_ML]

--- a/machine_learning_hep/data/database_ml_parameters.yml
+++ b/machine_learning_hep/data/database_ml_parameters.yml
@@ -107,3 +107,195 @@ LctopK0s:
     bin_width: 0.008 # bin width of the invariant mass histogram
     bkg_data_fraction: 0.1 # fraction of real data used in the estimation
     num_steps: 101 # number of steps used in efficiency and signif. estimation
+Dplus:
+  sig_bkg_files: [data/inputroot/SmallSkimmed_Dplus_pp5TeV_MC_train341.root, data/inputroot/SmallSkimmed_Dplus_pp5TeV_train340.root]
+  data_mc_files: [data/inputroot/SmallSkimmed_Dplus_pp5TeV_train340.root, data/inputroot/SmallSkimmed_Dplus_pp5TeV_MC_train341.root]
+  mass_cut: [1.77, 1.97]
+  mass: 1.869
+  pdg_code: null
+  tree_name: fTreeDplusFlagged
+  var_all: [d_len_ML, d_len_xy_ML, norm_dl_xy_ML, cos_p_ML, cos_p_xy_ML, imp_par_xy_ML, dca_ML, sig_vert_ML, pt_prong0_ML, pt_prong1_ML, pt_prong2_ML, imp_par_prong0_ML, imp_par_prong1_ML, imp_par_prong2_ML, max_norm_d0d0exp_ML, inv_mass_ML, pt_cand_ML, signal_ML, cand_type_ML, y_cand_ML, cand_fileID_ML, cand_evtID_ML, eta_prong0_ML, eta_prong1_ML, eta_prong2_ML]
+  var_boundaries: [d_len_ML, max_norm_d0d0exp_ML]
+  var_correlation:
+  - [pt_cand_ML, d_len_xy_ML, sig_vert_ML, pt_cand_ML, pt_cand_ML, norm_dl_xy_ML, sig_vert_ML, cos_p_xy_ML, cos_p_xy_ML]
+  - [d_len_xy_ML, sig_vert_ML, max_norm_d0d0exp_ML, imp_par_xy_ML, sig_vert_ML, d_len_xy_ML, imp_par_xy_ML, sig_vert_ML, pt_cand_ML]
+  var_others: [inv_mass_ML, pt_cand_ML]
+  var_signal: signal_ML
+  bitselvariable: cand_type_ML
+  bitselvariable_gen: cand_type_gen_ML
+  var_target: signal_ML
+  var_training: [d_len_ML, d_len_xy_ML, norm_dl_xy_ML, cos_p_ML, cos_p_xy_ML, imp_par_xy_ML, dca_ML, sig_vert_ML, pt_prong0_ML, pt_prong1_ML, pt_prong2_ML, imp_par_prong0_ML, imp_par_prong1_ML, imp_par_prong2_ML, max_norm_d0d0exp_ML]
+  sel_signal: cand_type_ML>0
+  sel_signal_gen: cand_type_gen_ML>0
+  sel_bkg: inv_mass_ML<1.77 or inv_mass_ML>1.97
+  var_binning: pt_cand_ML
+  presel_reco: abs(eta_prong0_ML)<0.8 and abs(eta_prong1_ML)<0.8 and abs(eta_prong2_ML)<0.8
+  treename_gen: fTreeDplusGenFlagged # variables related to the tree of generated candidates
+  var_gen: [y_cand_gen_ML, pt_cand_gen_ML, cand_type_gen_ML, z_vtx_gen_ML]
+  presel_gen: abs(y_cand_gen_ML) < 0.5 and abs(z_vtx_gen_ML) < 10 # pre-selections on generated candidates
+  ptgen: pt_cand_gen_ML
+  bitmapsel:
+    mcsignal_on_off: [[1],[5]]
+    mcsignal_prompt_on_off: [[1,3],[5]]
+    mcsignal_feed_on_off: [[1,4],[5]]
+    mcbkg_on_off: [[2],[]]
+    std_analysis_on_off : [[0],[]]
+    preseltrack_pid_on_off : [[7,8],[]]
+  signif_opt:
+    treename_event: fTreeEventChar # variables related to the event tree
+    var_event: [is_ev_rej_ML]
+    sel_event: is_ev_rej_ML==0
+    filename_fonll: 'data/fonll/fo_pp_d0meson_5TeV_y0p5.csv' # file with FONLL predictions
+    fonll_pred: 'max' # edge of the FONLL prediction
+    FF: 0.2404 # fragmentation fraction (1509.01061)
+    sigma_MB: 50.87e-3 # Minimum Bias cross section (pp) [b]
+    BR: 8.98e-2 # branching ratio of the decay
+    f_prompt: 0.9 # estimated fraction of prompt candidates
+    mass_fit_lim: [1.6, 2.15] # region for the fit of the invariant mass distribution [GeV/c^2]
+    bin_width: 0.008 # bin width of the invariant mass histogram
+    bkg_data_fraction: 0.1 # fraction of real data used in the estimation
+    num_steps: 101 # number of steps used in efficiency and signif. estimation
+Ds:
+  sig_bkg_files: [data/inputroot/SmallSkimmed_Ds_pp5TeV_MC_train341.root, data/inputroot/SmallSkimmed_Ds_pp5TeV_train340.root]
+  data_mc_files: [data/inputroot/SmallSkimmed_Ds_pp5TeV_train340.root, data/inputroot/SmallSkimmed_Ds_pp5TeV_MC_train341.root]
+  mass_cut: [1.83, 2.012]
+  mass: 1.972
+  pdg_code: null
+  tree_name: fTreeDsFlagged
+  var_all: [d_len_ML, d_len_xy_ML, norm_dl_xy_ML, cos_p_ML, cos_p_xy_ML, imp_par_xy_ML, dca_ML, sig_vert_ML, delta_mass_KK_ML, cos_PiDs_ML, cos_PiKPhi_3_ML, pt_prong0_ML, pt_prong1_ML, pt_prong2_ML, imp_par_prong0_ML, imp_par_prong1_ML, imp_par_prong2_ML, max_norm_d0d0exp_ML, inv_mass_ML, pt_cand_ML, signal_ML, cand_type_ML, y_cand_ML, cand_fileID_ML, cand_evtID_ML, eta_prong0_ML, eta_prong1_ML, eta_prong2_ML]
+  var_boundaries: [d_len_ML, max_norm_d0d0exp_ML]
+  var_correlation:
+  - [pt_cand_ML, d_len_xy_ML, sig_vert_ML, pt_cand_ML, pt_cand_ML, norm_dl_xy_ML, cos_PiDs_ML, cos_p_xy_ML, cos_p_xy_ML]
+  - [d_len_xy_ML, sig_vert_ML, mass_KK_ML, mass_KK_ML, sig_vert_ML, d_len_xy_ML, cos_PiKPhi_3_ML, sig_vert_ML, pt_cand_ML]
+  var_others: [inv_mass_ML, pt_cand_ML]
+  var_signal: signal_ML
+  bitselvariable: cand_type_ML
+  bitselvariable_gen: cand_type_gen_ML
+  var_target: signal_ML
+  var_training: [d_len_ML, d_len_xy_ML, norm_dl_xy_ML, cos_p_ML, cos_p_xy_ML, imp_par_xy_ML, dca_ML, sig_vert_ML, delta_mass_KK_ML, cos_PiDs_ML, cos_PiKPhi_3_ML, pt_prong0_ML, pt_prong1_ML, pt_prong2_ML, imp_par_prong0_ML, imp_par_prong1_ML, imp_par_prong2_ML, max_norm_d0d0exp_ML]
+  sel_signal: cand_type_ML>0
+  sel_signal_gen: cand_type_gen_ML>0
+  sel_bkg: inv_mass_ML<1.83 or inv_mass_ML>2.012
+  var_binning: pt_cand_ML
+  presel_reco: abs(eta_prong0_ML)<0.8 and abs(eta_prong1_ML)<0.8 and abs(eta_prong2_ML)<0.8
+  treename_gen: fTreeDsGenFlagged # variables related to the tree of generated candidates
+  var_gen: [y_cand_gen_ML, pt_cand_gen_ML, cand_type_gen_ML, z_vtx_gen_ML]
+  presel_gen: abs(y_cand_gen_ML) < 0.5 and abs(z_vtx_gen_ML) < 10 # pre-selections on generated candidates
+  ptgen: pt_cand_gen_ML
+  bitmapsel:
+    mcsignal_on_off: [[1],[5,11]]
+    mcsignal_prompt_on_off: [[1,3],[5,11]]
+    mcsignal_feed_on_off: [[1,4],[5,11]]
+    mcbkg_on_off: [[2],[11]]
+    std_analysis_on_off : [[0],[]]
+    preseltrack_pid_on_off : [[7,8],[]]
+  signif_opt:
+    treename_event: fTreeEventChar # variables related to the event tree
+    var_event: [is_ev_rej_ML]
+    sel_event: is_ev_rej_ML==0
+    filename_fonll: 'data/fonll/fo_pp_d0meson_5TeV_y0p5.csv' # file with FONLL predictions
+    fonll_pred: 'max' # edge of the FONLL prediction
+    FF: 0.1281 # fragmentation fraction
+    sigma_MB: 50.87e-3 # Minimum Bias cross section (pp) [b]
+    BR: 2.27e-2 # branching ratio of the decay
+    f_prompt: 0.9 # estimated fraction of prompt candidates
+    mass_fit_lim: [1.75, 2.15] # region for the fit of the invariant mass distribution [GeV/c^2]
+    bin_width: 0.008 # bin width of the invariant mass histogram
+    bkg_data_fraction: 0.1 # fraction of real data used in the estimation
+    num_steps: 101 # number of steps used in efficiency and signif. estimation
+Dstar:
+  sig_bkg_files: [data/inputroot/SmallSkimmed_Dstar_pp5TeV_MC_train341.root, data/inputroot/SmallSkimmed_Dstar_pp5TeV_train340.root]
+  data_mc_files: [data/inputroot/SmallSkimmed_Dstar_pp5TeV_train340.root, data/inputroot/SmallSkimmed_Dstar_pp5TeV_MC_train341.root]
+  mass_cut: [0.14, 0.149]
+  mass: 0.1454 #mDstar - mD0
+  pdg_code: null
+  tree_name: fTreeDstarFlagged
+  var_all: [d_len_ML, d_len_xy_ML, norm_dl_xy_ML, cos_p_ML, cos_p_xy_ML, imp_par_xy_ML, dca_ML, cos_t_star_ML, angle_D0dkpPisoft_ML, imp_par_prod_ML, pt_prong0_ML, pt_prong1_ML, pt_prong2_ML, imp_par_prong0_ML, imp_par_prong1_ML, imp_par_prong2_ML, max_norm_d0d0exp_ML, inv_mass_ML, pt_cand_ML, inv_mass_D0_ML, pt_D0_ML, signal_ML, cand_type_ML, y_cand_ML, cand_fileID_ML, cand_evtID_ML, eta_prong0_ML, eta_prong1_ML, eta_prong2_ML]
+  var_boundaries: [d_len_xy_ML, max_norm_d0d0exp_ML]
+  var_correlation:
+  - [pt_cand_ML, d_len_xy_ML, pt_prong0_ML, pt_cand_ML, pt_cand_ML, norm_dl_xy_ML, cos_t_star_ML, cos_p_xy_ML, cos_p_xy_ML]
+  - [d_len_xy_ML, cos_t_star_ML, imp_par_prod_ML, imp_par_prod_ML, cos_t_star_ML, d_len_xy_ML, pt_prong0_ML, cos_t_star_ML, pt_cand_ML]
+  var_others: [inv_mass_ML, pt_cand_ML]
+  var_signal: signal_ML
+  bitselvariable: cand_type_ML
+  bitselvariable_gen: cand_type_gen_ML
+  var_target: signal_ML
+  var_training: [d_len_ML, d_len_xy_ML, norm_dl_xy_ML, cos_p_ML, cos_p_xy_ML, imp_par_xy_ML, dca_ML, cos_t_star_ML, angle_D0dkpPisoft_ML, imp_par_prod_ML, pt_prong0_ML, pt_prong1_ML, pt_prong2_ML, imp_par_prong0_ML, imp_par_prong1_ML, imp_par_prong2_ML, max_norm_d0d0exp_ML]
+  sel_signal: cand_type_ML>0
+  sel_signal_gen: cand_type_gen_ML>0
+  sel_bkg: inv_mass_ML<0.142 or inv_mass_ML>0.149
+  var_binning: pt_cand_ML
+  presel_reco: abs(eta_prong0_ML)<0.8 and abs(eta_prong1_ML)<0.8 and abs(eta_prong2_ML)<0.8
+  treename_gen: fTreeDstarGenFlagged # variables related to the tree of generated candidates
+  var_gen: [y_cand_gen_ML, pt_cand_gen_ML, cand_type_gen_ML, z_vtx_gen_ML]
+  presel_gen: abs(y_cand_gen_ML) < 0.5 and abs(z_vtx_gen_ML) < 10 # pre-selections on generated candidates
+  ptgen: pt_cand_gen_ML
+  bitmapsel:
+    mcsignal_on_off: [[1],[5]]
+    mcsignal_prompt_on_off: [[1,3],[5]]
+    mcsignal_feed_on_off: [[1,4],[5]]
+    mcbkg_on_off: [[2],[]]
+    std_analysis_on_off : [[0],[]]
+    preseltrack_pid_on_off : [[7,8],[]]
+  signif_opt:
+    treename_event: fTreeEventChar # variables related to the event tree
+    var_event: [is_ev_rej_ML]
+    sel_event: is_ev_rej_ML==0
+    filename_fonll: 'data/fonll/fo_pp_d0meson_5TeV_y0p5.csv' # file with FONLL predictions
+    fonll_pred: 'max' # edge of the FONLL prediction
+    FF: 0.2429 # fragmentation fraction (1509.01061)
+    sigma_MB: 50.87e-3 # Minimum Bias cross section (pp) [b]
+    BR: 2.63e-2 # branching ratio of the decay
+    f_prompt: 0.9 # estimated fraction of prompt candidates
+    mass_fit_lim: [0.140, 0.155] # region for the fit of the invariant mass distribution [GeV/c^2]
+    bin_width: 0.008 # bin width of the invariant mass histogram
+    bkg_data_fraction: 0.1 # fraction of real data used in the estimation
+    num_steps: 101 # number of steps used in efficiency and signif. estimation
+LctopKpi:
+  sig_bkg_files: [data/inputroot/SmallSkimmed_LctopKpi_pp5TeV_MC_train341.root, data/inputroot/SmallSkimmed_LctopKpi_pp5TeV_train340.root]
+  data_mc_files: [data/inputroot/SmallSkimmed_LctopKpi_pp5TeV_train340.root, data/inputroot/SmallSkimmed_LctopKpi_pp5TeV_MC_train341.root]
+  mass_cut: [2.2064, 2.3664]
+  mass: 2.2864
+  pdg_code: null
+  tree_name: fTreeLcFlagged
+  var_all: [d_len_ML, d_len_xy_ML, norm_dl_xy_ML, cos_p_ML, cos_p_xy_ML, imp_par_xy_ML, dca_ML, dist_12_ML, dist_23_ML, sig_vert_ML, pt_prong0_ML, pt_prong1_ML, pt_prong2_ML, imp_par_prong0_ML, imp_par_prong1_ML, imp_par_prong2_ML, max_norm_d0d0exp_ML, inv_mass_ML, pt_cand_ML, signal_ML, cand_type_ML, y_cand_ML, cand_fileID_ML, cand_evtID_ML, eta_prong0_ML, eta_prong1_ML, eta_prong2_ML]
+  var_boundaries: [d_len_xy_ML, max_norm_d0d0exp_ML]
+  var_correlation:
+  - [pt_cand_ML, d_len_xy_ML, sig_vert_ML, norm_dl_xy_ML, pt_cand_ML, norm_dl_xy_ML, pt_prong0_ML, pt_prong1_ML, cos_p_xy_ML]
+  - [d_len_xy_ML, sig_vert_ML, cos_p_xy_ML, cos_p_ML, sig_vert_ML, d_len_xy_ML, pt_prong2_ML, sig_vert_ML, pt_cand_ML]
+  var_others: [inv_mass_ML, pt_cand_ML]
+  var_signal: signal_ML
+  bitselvariable: cand_type_ML
+  bitselvariable_gen: cand_type_gen_ML
+  var_target: signal_ML
+  var_training: [d_len_ML, d_len_xy_ML, norm_dl_xy_ML, cos_p_ML, cos_p_xy_ML, imp_par_xy_ML, dca_ML, dist_12_ML, dist_23_ML, sig_vert_ML, pt_prong0_ML, pt_prong1_ML, pt_prong2_ML, imp_par_prong0_ML, imp_par_prong1_ML, imp_par_prong2_ML, max_norm_d0d0exp_ML]
+  sel_signal: cand_type_ML>0
+  sel_signal_gen: cand_type_gen_ML>0
+  sel_bkg: inv_mass_ML<2.1864 or inv_mass_ML>2.3864
+  var_binning: pt_cand_ML
+  presel_reco: abs(eta_prong0_ML)<0.8 and abs(eta_prong1_ML)<0.8 and abs(eta_prong2_ML)<0.8
+  treename_gen: fTreeLcGenFlagged # variables related to the tree of generated candidates
+  var_gen: [y_cand_gen_ML, pt_cand_gen_ML, cand_type_gen_ML, z_vtx_gen_ML]
+  presel_gen: abs(y_cand_gen_ML) < 0.5 and abs(z_vtx_gen_ML) < 10 # pre-selections on generated candidates
+  ptgen: pt_cand_gen_ML
+  bitmapsel:
+    mcsignal_on_off: [[1],[5]]
+    mcsignal_prompt_on_off: [[1,3],[5]]
+    mcsignal_feed_on_off: [[1,4],[5]]
+    mcbkg_on_off: [[2],[]]
+    std_analysis_on_off : [[0],[]]
+    preseltrack_pid_on_off : [[7,8],[]]
+  signif_opt:
+    treename_event: fTreeEventChar # variables related to the event tree
+    var_event: [is_ev_rej_ML]
+    sel_event: is_ev_rej_ML==0
+    filename_fonll: 'data/fonll/fo_pp_d0meson_5TeV_y0p5.csv' # file with FONLL predictions
+    fonll_pred: 'max' # edge of the FONLL prediction
+    FF: 0.1281 # fragmentation fraction
+    sigma_MB: 50.87e-3 # Minimum Bias cross section (pp) [b]
+    BR: 6.23e-2 # branching ratio of the decay
+    f_prompt: 0.9 # estimated fraction of prompt candidates
+    mass_fit_lim: [2.12, 2.45] # region for the fit of the invariant mass distribution [GeV/c^2]
+    bin_width: 0.008 # bin width of the invariant mass histogram
+    bkg_data_fraction: 0.1 # fraction of real data used in the estimation
+    num_steps: 101 # number of steps used in efficiency and signif. estimation

--- a/machine_learning_hep/doclassification_regression.py
+++ b/machine_learning_hep/doclassification_regression.py
@@ -254,7 +254,7 @@ def doclassification_regression(conf):  # pylint: disable=too-many-locals, too-m
     if dosignifopt == 1:
         logger.info("Doing significance optimization")
         if dotraining and dotesting and applytodatamc:
-            if (mlsubtype == "HFmeson"):
+            if mlsubtype == "HFmeson":
                 df_data_opt = df_data.query(sel_bkg)
                 df_data_opt = shuffle(df_data_opt, random_state=rnd_shuffle)
                 study_signif(case, names, [binmin, binmax], filemc, filedata, df_mc, df_ml_test,

--- a/machine_learning_hep/doclassification_regression.py
+++ b/machine_learning_hep/doclassification_regression.py
@@ -95,6 +95,7 @@ def doclassification_regression(conf):  # pylint: disable=too-many-locals, too-m
     var_boundaries = data[case]["var_boundaries"]
     var_binning = data[case]['var_binning']
     presel_reco = data[case]["presel_reco"]
+    mcsignal_on_off = data[case]["bitmapsel"]["mcsignal_on_off"]
     signalpreseltrack_pid_on_off = data[case]["bitmapsel"]["signalpreseltrack_pid_on_off"]
     bkgpreseltrack_pid_on_off = data[case]["bitmapsel"]["bkgpreseltrack_pid_on_off"]
     mcpreseltrack_pid_on_off = data[case]["bitmapsel"]["mcpreseltrack_pid_on_off"]
@@ -145,6 +146,9 @@ def doclassification_regression(conf):  # pylint: disable=too-many-locals, too-m
             df_sig = filter_bit_df(df_sig, bitselvariable, signalpreseltrack_pid_on_off)
         if bkgpreseltrack_pid_on_off:
             df_bkg = filter_bit_df(df_bkg, bitselvariable, bkgpreseltrack_pid_on_off)
+
+        if mcsignal_on_off and not signalpreseltrack_pid_on_off:
+            df_sig = filter_bit_df(df_sig, bitselvariable, mcsignal_on_off)
         _, df_ml_test, df_sig_train, df_bkg_train, _, _, \
         x_train, y_train, x_test, y_test = \
             create_mlsamples(df_sig, df_bkg, sel_signal, sel_bkg, rnd_shuffle,

--- a/machine_learning_hep/doclassification_regression.py
+++ b/machine_learning_hep/doclassification_regression.py
@@ -96,10 +96,7 @@ def doclassification_regression(conf):  # pylint: disable=too-many-locals, too-m
     var_binning = data[case]['var_binning']
     presel_reco = data[case]["presel_reco"]
     mcsignal_on_off = data[case]["bitmapsel"]["mcsignal_on_off"]
-    signalpreseltrack_pid_on_off = data[case]["bitmapsel"]["signalpreseltrack_pid_on_off"]
-    bkgpreseltrack_pid_on_off = data[case]["bitmapsel"]["bkgpreseltrack_pid_on_off"]
-    mcpreseltrack_pid_on_off = data[case]["bitmapsel"]["mcpreseltrack_pid_on_off"]
-    datapreseltrack_pid_on_off = data[case]["bitmapsel"]["datapreseltrack_pid_on_off"]
+    preseltrack_pid_on_off = data[case]["bitmapsel"]["preseltrack_pid_on_off"]
     bitselvariable = data[case]["bitselvariable"]
     summary_string = f"#sig events: {nevt_sig}\n#bkg events: {nevt_bkg}\nmltype: {mltype}\n" \
                      f"mlsubtype: {mlsubtype}\ncase: {case}"
@@ -141,14 +138,12 @@ def doclassification_regression(conf):  # pylint: disable=too-many-locals, too-m
         if presel_reco is not None:
             df_sig = df_sig.query(presel_reco)
             df_bkg = df_bkg.query(presel_reco)
-
-        if signalpreseltrack_pid_on_off:
-            df_sig = filter_bit_df(df_sig, bitselvariable, signalpreseltrack_pid_on_off)
-        if bkgpreseltrack_pid_on_off:
-            df_bkg = filter_bit_df(df_bkg, bitselvariable, bkgpreseltrack_pid_on_off)
-
-        if mcsignal_on_off and not signalpreseltrack_pid_on_off:
+        if preseltrack_pid_on_off:
+            df_sig = filter_bit_df(df_sig, bitselvariable, preseltrack_pid_on_off)
+            df_bkg = filter_bit_df(df_bkg, bitselvariable, preseltrack_pid_on_off)
+        if mcsignal_on_off:
             df_sig = filter_bit_df(df_sig, bitselvariable, mcsignal_on_off)
+
         _, df_ml_test, df_sig_train, df_bkg_train, _, _, \
         x_train, y_train, x_test, y_test = \
             create_mlsamples(df_sig, df_bkg, sel_signal, sel_bkg, rnd_shuffle,
@@ -198,10 +193,9 @@ def doclassification_regression(conf):  # pylint: disable=too-many-locals, too-m
         if presel_reco is not None:
             df_mc = df_mc.query(presel_reco)
             df_data = df_data.query(presel_reco)
-        if mcpreseltrack_pid_on_off:
-            df_mc = filter_bit_df(df_mc, bitselvariable, mcpreseltrack_pid_on_off)
-        if datapreseltrack_pid_on_off:
-            df_data = filter_bit_df(df_data, bitselvariable, datapreseltrack_pid_on_off)
+        if preseltrack_pid_on_off:
+            df_mc = filter_bit_df(df_mc, bitselvariable, preseltrack_pid_on_off)
+            df_data = filter_bit_df(df_data, bitselvariable, preseltrack_pid_on_off)
         # The model predictions are added to the dataframes of data and MC
         df_data = apply(mltype, names, trainedmodels, df_data, var_training)
         df_mc = apply(mltype, names, trainedmodels, df_mc, var_training)

--- a/machine_learning_hep/doclassification_regression.py
+++ b/machine_learning_hep/doclassification_regression.py
@@ -254,8 +254,7 @@ def doclassification_regression(conf):  # pylint: disable=too-many-locals, too-m
     if dosignifopt == 1:
         logger.info("Doing significance optimization")
         if dotraining and dotesting and applytodatamc:
-            if (mlsubtype == "HFmeson") and case in ("Dsnew", "LctopKpi", "LctopK0s", "Dzero", \
-                                                     "Dplus", "Dstar"):
+            if (mlsubtype == "HFmeson"):
                 df_data_opt = df_data.query(sel_bkg)
                 df_data_opt = shuffle(df_data_opt, random_state=rnd_shuffle)
                 study_signif(case, names, [binmin, binmax], filemc, filedata, df_mc, df_ml_test,

--- a/machine_learning_hep/optimization.py
+++ b/machine_learning_hep/optimization.py
@@ -198,7 +198,7 @@ def calc_sig_dmeson(filename, fonll_pred, frag_frac, branch_ratio, sigma_mb, f_p
 
     return signal_yield
 
-
+# pylint: disable=too-many-locals, too-many-statements, too-many-branches
 def study_signif(case, names, bin_lim, file_mc, file_data, df_mc_reco, df_ml_test,
                  df_data_dec, suffix, plotdir):
     """

--- a/machine_learning_hep/optimization.py
+++ b/machine_learning_hep/optimization.py
@@ -22,8 +22,9 @@ from ROOT import TH1F, TF1, gROOT  # pylint: disable=import-error,no-name-in-mod
 from machine_learning_hep.logger import get_logger
 from machine_learning_hep.general import getdataframe, filterdataframe_singlevar
 from machine_learning_hep.general import get_database_ml_parameters
+from machine_learning_hep.bitwise import filter_bit_df
 
-def calc_efficiency(df_to_sel, sel_signal, name, num_step, sel_signal_std=None):
+def calc_efficiency(df_to_sel, sel_signal, name, num_step, calc_for_std=None):
     """
     Calculate the ML selection efficiency as a function of the treshold on the
     ML model output.
@@ -34,7 +35,7 @@ def calc_efficiency(df_to_sel, sel_signal, name, num_step, sel_signal_std=None):
     eff_array = []
     eff_err_array = []
 
-    if sel_signal_std is None:
+    if calc_for_std is None:
         for thr in x_axis:
             num_sel_cand = len(df_to_sel[df_to_sel['y_test_prob' + name].values >= thr])
             eff = num_sel_cand / num_tot_cand
@@ -42,7 +43,7 @@ def calc_efficiency(df_to_sel, sel_signal, name, num_step, sel_signal_std=None):
             eff_array.append(eff)
             eff_err_array.append(eff_err)
     else:
-        num_sel_cand = len(df_to_sel.query(sel_signal_std))
+        num_sel_cand = len(df_to_sel)
         eff = num_sel_cand / num_tot_cand
         eff_err = np.sqrt(eff * (1 - eff) / num_tot_cand)
         eff_array = [eff] * num_step
@@ -212,6 +213,7 @@ def study_signif(case, names, bin_lim, file_mc, file_data, df_mc_reco, df_ml_tes
     mass = gen_dict["mass"]
 
     sopt_dict = gen_dict['signif_opt']
+    bitmap_dict = gen_dict['bitmapsel']
     mass_fit_lim = sopt_dict['mass_fit_lim']
     bin_width = sopt_dict['bin_width']
     bkg_fract = sopt_dict['bkg_data_fraction']
@@ -223,10 +225,18 @@ def study_signif(case, names, bin_lim, file_mc, file_data, df_mc_reco, df_ml_tes
     n_events = len(df_evt.query(sopt_dict['sel_event']))
     logger.debug("Number of events: %d", n_events)
 
+    if bitmap_dict["mcsignal_on_off"]:
+        df_mc_reco = filter_bit_df(df_mc_reco, gen_dict["bitselvariable"],
+                                   bitmap_dict["mcsignal_on_off"])
+        df_ml_test = filter_bit_df(df_ml_test, gen_dict["bitselvariable"],
+                                   bitmap_dict["mcsignal_on_off"])
+        df_mc_gen = filter_bit_df(df_mc_gen, gen_dict["bitselvariable_gen"],
+                                  bitmap_dict["mcsignal_on_off"])
+
     # The uncertainty on the pre-selection efficiency times acceptance is neglected as
     # that on the expected signal yield
-    eff_acc = calc_eff_acc(df_mc_gen, df_mc_reco, sopt_dict['sel_signal_reco_sopt'],
-                           sopt_dict['sel_signal_gen_sopt'])
+    eff_acc = calc_eff_acc(df_mc_gen, df_mc_reco, gen_dict['sel_signal'],
+                           gen_dict['sel_signal_gen'])
     exp_signal = calc_sig_dmeson(sopt_dict['filename_fonll'], sopt_dict['fonll_pred'],
                                  sopt_dict['FF'], sopt_dict['BR'], sopt_dict['sigma_MB'],
                                  sopt_dict['f_prompt'], bin_lim[0], bin_lim[1], eff_acc, n_events)
@@ -244,14 +254,14 @@ def study_signif(case, names, bin_lim, file_mc, file_data, df_mc_reco, df_ml_tes
     plt.title("Significance vs probability ", fontsize=20)
 
     df_data_dec = df_data_dec.tail(round(len(df_data_dec) * bkg_fract))
-    sigma = calc_peak_sigma(df_mc_reco, sopt_dict['sel_signal_reco_sopt'], mass,
+    sigma = calc_peak_sigma(df_mc_reco, gen_dict['sel_signal'], mass,
                             mass_fit_lim, bin_width)
     sig_region = [mass - 3 * sigma, mass + 3 * sigma]
 
     for name in names:
 
         eff_array, eff_err_array, x_axis = calc_efficiency(df_ml_test,
-                                                           sopt_dict['sel_signal_reco_sopt'],
+                                                           gen_dict['sel_signal'],
                                                            name, sopt_dict['num_steps'])
         plt.figure(fig_eff.number)
         plt.errorbar(x_axis, eff_array, yerr=eff_err_array, alpha=0.3, label=f'{name}',
@@ -269,11 +279,14 @@ def study_signif(case, names, bin_lim, file_mc, file_data, df_mc_reco, df_ml_tes
         plt.errorbar(x_axis, signif_array, yerr=signif_err_array, alpha=0.3, label=f'{name}',
                      elinewidth=2.5, linewidth=4.0)
 
+    if bitmap_dict["std_analysis_on_off"]:
+        df_ml_test = filter_bit_df(df_ml_test, gen_dict["bitselvariable"],
+                                   bitmap_dict["std_analysis_on_off"])
     eff_arr_std, eff_er_arr_std, x_axis_std = calc_efficiency(df_ml_test,
-                                                              sopt_dict['sel_signal_reco_sopt'],
+                                                              gen_dict['sel_signal'],
                                                               'ALICE Standard',
                                                               sopt_dict['num_steps'],
-                                                              sopt_dict['sel_signal_reco_std'])
+                                                              gen_dict['sel_signal'])
     plt.figure(fig_eff.number)
     plt.errorbar(x_axis_std, eff_arr_std, yerr=eff_er_arr_std, alpha=0.3, label=f'ALICE Standard',
                  elinewidth=2.5, linewidth=4.0)

--- a/machine_learning_hep/webapp/templates/display0.html
+++ b/machine_learning_hep/webapp/templates/display0.html
@@ -28,7 +28,7 @@
       var optionArray = ["lightquarkjet"];
     } 
     else if(s1.value == "HeavyFlavour"){
-      var optionArray = ["Lc","LctopKpi","LctopK0s","Dplus","Dzero","Dstar","Ds","Dsnew"];
+      var optionArray = ["LctopKpi","LctopK0s","Dplus","Dzero","Dstar","Ds"];
     }
     else if(s1.value == "Nuclei"){
       var optionArray = ["hypertritium"];


### PR DESCRIPTION
* Added bitmap selection also in significance optimisation (tested for D0, looks good. More tests might be needed)
* Adding other HF mesons (Ds, Dplus, Dstar, and Lc's) again.

NB: One should run ml-get-data again, as the files are updated
NB2: The SmallSkimmed MC files for Lc don't have enough signal for the moment. Will get updated in the dropbox folder.
NB3: Pre-PID&Track-selection turned on by default for all HF mesons except for Ds. Here there seems to be a bug with these bits set in AliPhysics, as all events get rejected