### PR TITLE
Temporary fix to avoid total merging of event df to avoid RAM error

### DIFF
--- a/machine_learning_hep/data/database_ml_parameters_D0pp_jets.yml
+++ b/machine_learning_hep/data/database_ml_parameters_D0pp_jets.yml
@@ -34,6 +34,7 @@ D0pp_jets:
   sel_skim_binmin: [4,6] #list of nbins
   sel_skim_binmax: [6,10] #list of nbins
   var_binning: pt_cand
+  dofullevtmerge: false
   
   bitmap_sel:
     use: True

--- a/machine_learning_hep/data/database_ml_parameters_D0pp_multiplicity.yml
+++ b/machine_learning_hep/data/database_ml_parameters_D0pp_multiplicity.yml
@@ -25,6 +25,7 @@ D0pp_multiplicity:
   sel_skim_binmin: [0,10,30] #list of nbins
   sel_skim_binmax: [10,30,50] #list of nbins
   var_binning: n_tracklets
+  dofullevtmerge: false
   
   bitmap_sel:
     use: True

--- a/machine_learning_hep/data/database_ml_parameters_Dspp_multiplicity.yml
+++ b/machine_learning_hep/data/database_ml_parameters_Dspp_multiplicity.yml
@@ -25,6 +25,7 @@ Dspp_multiplicity:
   sel_skim_binmin: [20] #list of nbins
   sel_skim_binmax: [50] #list of nbins
   var_binning: n_tracklets
+  dofullevtmerge: false
   
   bitmap_sel:
     use: True

--- a/machine_learning_hep/data/database_ml_parameters_DstoKKpiPbPbCen3050.yml
+++ b/machine_learning_hep/data/database_ml_parameters_DstoKKpiPbPbCen3050.yml
@@ -24,6 +24,7 @@ DstoKKpiPbPbCen3050:
   sel_skim_binmin: [2,3,16,24,36] #list of nbins min
   sel_skim_binmax: [3,4,24,36,50] #list of nbins max
   var_binning: pt_cand
+  dofullevtmerge: true
   
   bitmap_sel:
     use: True

--- a/machine_learning_hep/data/database_ml_parameters_LcpK0s_multiplicity.yml
+++ b/machine_learning_hep/data/database_ml_parameters_LcpK0s_multiplicity.yml
@@ -25,6 +25,7 @@ LcpK0s_multiplicity:
   sel_skim_binmin: [ 0,10,20,40,60,80] #list of nbins
   sel_skim_binmax: [10,20,40,60,80,100] #list of nbins
   var_binning: n_tracklets
+  dofullevtmerge: false
   
   bitmap_sel:
     use: True

--- a/machine_learning_hep/data/database_ml_parameters_LcpK0s_multiplicity_test.yml
+++ b/machine_learning_hep/data/database_ml_parameters_LcpK0s_multiplicity_test.yml
@@ -25,7 +25,8 @@ LcpK0s_multiplicity_test:
   sel_skim_binmin: [ 0,20] #list of nbins
   sel_skim_binmax: [20,100] #list of nbins
   var_binning: n_tracklets
-  
+  dofullevtmerge: false
+
   bitmap_sel:
     use: True
     var_name: cand_type

--- a/machine_learning_hep/data/database_ml_parameters_LcpK0s_pt.yml
+++ b/machine_learning_hep/data/database_ml_parameters_LcpK0s_pt.yml
@@ -25,6 +25,7 @@ LcpK0s_pt:
   sel_skim_binmin: [1,2,3,4,5,6,8,12] #list of nbins
   sel_skim_binmax: [2,3,4,5,6,8,12,24] #list of nbins
   var_binning: pt_cand
+  dofullevtmerge: false
   
   bitmap_sel:
     use: True

--- a/machine_learning_hep/data/database_ml_parameters_LcpKpi_multiplicity.yml
+++ b/machine_learning_hep/data/database_ml_parameters_LcpKpi_multiplicity.yml
@@ -25,6 +25,7 @@ LcpKpi_multiplicity:
   sel_skim_binmin: [20] #list of nbins
   sel_skim_binmax: [50] #list of nbins
   var_binning: n_tracklets
+  dofullevtmerge: false
   
   bitmap_sel:
     use: True

--- a/machine_learning_hep/multiprocesser.py
+++ b/machine_learning_hep/multiprocesser.py
@@ -36,6 +36,8 @@ class MultiProcesser: # pylint: disable=too-many-instance-attributes, too-many-s
         self.lpt_anbinmin = datap["sel_skim_binmin"]
         self.lpt_anbinmax = datap["sel_skim_binmax"]
         self.p_nptbins = len(datap["sel_skim_binmax"])
+        self.p_dofullevtmerge = datap["dofullevtmerge"]
+
         #directories
         self.dlper_root = datap["multi"][self.mcordata]["unmerged_tree_dir"]
         self.dlper_pkl = datap["multi"][self.mcordata]["pkl"]
@@ -103,8 +105,9 @@ class MultiProcesser: # pylint: disable=too-many-instance-attributes, too-many-s
     def multi_skim_allperiods(self):
         for indexp in range(self.prodnumber):
             self.process_listsample[indexp].process_skim_par()
-        merge_method(self.lper_evt, self.f_evt_mergedallp)
-        merge_method(self.lper_evtorig, self.f_evtorig_mergedallp)
+        if self.p_dofullevtmerge is True:
+            merge_method(self.lper_evt, self.f_evt_mergedallp)
+            merge_method(self.lper_evtorig, self.f_evtorig_mergedallp)
 
     def multi_mergeml_allperiods(self):
         for indexp in range(self.prodnumber):

--- a/machine_learning_hep/optimiser.py
+++ b/machine_learning_hep/optimiser.py
@@ -104,6 +104,7 @@ class Optimiser:
         self.rnd_splt = data_param["ml"]["rnd_splt"]
         self.test_frac = data_param["ml"]["test_frac"]
         self.p_plot_options = data_param["variables"].get("plot_options", {})
+        self.p_dofullevtmerge = data_param["dofullevtmerge"]
         #dataframes
         self.df_mc = None
         self.df_mcgen = None
@@ -336,9 +337,14 @@ class Optimiser:
     # pylint: disable=too-many-locals
     def do_significance(self):
         self.logger.info("Doing significance optimization")
-        self.df_evt_data = pickle.load(openfile(self.f_evt_data, 'rb'))
-        self.df_evttotsample_data = pickle.load(openfile(self.f_evttotsample_data, 'rb'))
         #first extract the number of data events in the ml sample
+        self.df_evt_data = pickle.load(openfile(self.f_evt_data, 'rb'))
+        if self.p_dofullevtmerge is True:
+            self.df_evttotsample_data = pickle.load(openfile(self.f_evttotsample_data, 'rb'))
+        else:
+            self.logger.info("The total merged event dataframe was not merged \
+                             for space limits")
+            self.df_evttotsample_data = pickle.load(openfile(self.f_evt_data, 'rb'))
         #and the total number of events
         self.p_nevttot = len(self.df_evttotsample_data)
         self.p_nevtml = len(self.df_evt_data)

--- a/machine_learning_hep/processer.py
+++ b/machine_learning_hep/processer.py
@@ -81,6 +81,7 @@ class Processer: # pylint: disable=too-many-instance-attributes
         self.p_sigmaarray = datap["analysis"]["sigmaarray"]
         self.p_fixedsigma = datap["analysis"]["FixedSigma"]
         self.p_casefit = datap["analysis"]["fitcase"]
+        self.p_dofullevtmerge = datap["dofullevtmerge"]
 
         #namefile root
         self.n_root = datap["files_names"]["namefile_unmerged_tree"]
@@ -318,8 +319,9 @@ class Processer: # pylint: disable=too-many-instance-attributes
         create_folder_struc(self.d_pklsk, self.l_path)
         arguments = [(i,) for i in range(len(self.l_reco))]
         self.parallelizer(self.skim, arguments, self.p_chunksizeskim)
-        merge_method(self.l_evt, self.f_totevt)
-        merge_method(self.l_evtorig, self.f_totevtorig)
+        if self.p_dofullevtmerge is True:
+            merge_method(self.l_evt, self.f_totevt)
+            merge_method(self.l_evtorig, self.f_totevtorig)
 
     def process_applymodel_par(self):
         print("doing apply model", self.mcordata, self.period)


### PR DESCRIPTION
For pp events, it is currently not possible to create a total merged evt sample because of the too large statistics (RAM memory error). For the moment a switch is introduced to turn off the merging when the flag is off. In the future I will introduce a parallelized loop to calculate the total number of events in the significance optimization tool so that producing a total merged event dataframes will not be needed. 