### PR TITLE
[WIP] Add plot facility

### DIFF
--- a/machine_learning_hep/plot.yaml
+++ b/machine_learning_hep/plot.yaml
@@ -1,0 +1,34 @@
+cuts:
+  pt_cand_low:
+    expression: "pt_cand > 1. and pt_cand < 4. and ismcprompt"
+  pt_cand_high:
+    expression: "pt_cand > 8. and pt_cand < 12. and ismcprompt"
+  pt_cand_medium:
+    expression: "pt_cand > 4. and pt_cand < 8. and ismcprompt"
+
+
+plots:
+  - observables:
+      - name: z_vtx_reco
+        range: [-20,20]
+        bins: 50
+        cuts:
+          - pt_cand_low
+      - name: n_tracklets
+        range: [0,140]
+        bins: [0, 10, 20, 40, 60, 80, 100, 140]
+        stacked: true
+        xlabel: n_tracklets
+        ylabel: "#entries"
+        cuts:
+          - pt_cand_low
+          - pt_cand_high
+          - pt_cand_medium
+
+  - observables:
+      - name: pt_cand
+        range: [0,10]
+        bins: 50
+        cuts:
+          - pt_cand_low
+          - null

--- a/machine_learning_hep/plot_from_file.py
+++ b/machine_learning_hep/plot_from_file.py
@@ -1,0 +1,41 @@
+#############################################################################
+##  © Copyright CERN 2018. All rights not expressly granted are reserved.  ##
+##                 Author: Gian.Michele.Innocenti@cern.ch                  ##
+## This program is free software: you can redistribute it and/or modify it ##
+##  under the terms of the GNU General Public License as published by the  ##
+## Free Software Foundation, either version 3 of the License, or (at your  ##
+## option) any later version. This program is distributed in the hope that ##
+##  it will be useful, but WITHOUT ANY WARRANTY; without even the implied  ##
+##     warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.    ##
+##           See the GNU General Public License for more details.          ##
+##    You should have received a copy of the GNU General Public License    ##
+##   along with this program. if not, see <https://www.gnu.org/licenses/>. ##
+#############################################################################
+
+import argparse
+from machine_learning_hep.logger import configure_logger, get_logger
+from machine_learning_hep.io import parse_yaml
+from machine_learning_hep.plotting import process_files, save_plots
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("top", help="directory where it should be looked for ROOT files")
+    parser.add_argument("--file-signature", dest="file_signature", help="regular expression matching filenames", default=r"AnalysisResultsReco.pkl")
+    parser.add_argument("--recursive", action="store_true", help="recursive search for files")
+    parser.add_argument("--debug", action="store_true", help="activate debug log level")
+    parser.add_argument("--n-files", dest="n_files", help="number of files to be processed", type=int, default=-1)
+    parser.add_argument("--plot-config", dest="plot_config", help="plots to be produced", required=True)
+    parser.add_argument("--output-dir", dest="output_dir", help="directory where plots are dumped", default="./plots_output/")
+
+    args = parser.parse_args()
+
+    configure_logger(args.debug)
+    plot_config = parse_yaml(args.plot_config)
+
+    logger = get_logger()
+
+    logger_string = f"Processing files with plotting configuration {args.plot_config}.\nPlots will be written to {args.output_dir}."
+    logger.info(logger_string)
+    names, axes, stats = process_files(args.top, args.file_signature, args.recursive, args.n_files, plot_config)
+    save_plots(names, axes, stats, args.output_dir)
+

--- a/machine_learning_hep/plot_from_file.py
+++ b/machine_learning_hep/plot_from_file.py
@@ -15,27 +15,52 @@
 import argparse
 from machine_learning_hep.logger import configure_logger, get_logger
 from machine_learning_hep.io import parse_yaml
-from machine_learning_hep.plotting import process_files, save_plots
+from machine_learning_hep.plotting import process_files, plot_from_yamls, save_plots
 
-def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("top", help="directory where it should be looked for ROOT files")
-    parser.add_argument("--file-signature", dest="file_signature", help="regular expression matching filenames", default=r"AnalysisResultsReco.pkl")
-    parser.add_argument("--recursive", action="store_true", help="recursive search for files")
-    parser.add_argument("--debug", action="store_true", help="activate debug log level")
-    parser.add_argument("--n-files", dest="n_files", help="number of files to be processed", type=int, default=-1)
-    parser.add_argument("--plot-config", dest="plot_config", help="plots to be produced", required=True)
-    parser.add_argument("--output-dir", dest="output_dir", help="directory where plots are dumped", default="./plots_output/")
-
-    args = parser.parse_args()
-
-    configure_logger(args.debug)
-    plot_config = parse_yaml(args.plot_config)
-
+def process_pickles(args):
     logger = get_logger()
+    plot_config = parse_yaml(args.plot_config)
 
     logger_string = f"Processing files with plotting configuration {args.plot_config}.\nPlots will be written to {args.output_dir}."
     logger.info(logger_string)
     names, axes, stats = process_files(args.top, args.file_signature, args.recursive, args.n_files, plot_config)
     save_plots(names, axes, stats, args.output_dir)
+
+def process_yamls(args):
+    logger = get_logger()
+
+    logger_string = f"Processing YAML files. Plots will be written to {args.output_dir}."
+    logger.info(logger_string)
+    names, axes, stats = plot_from_yamls(args.top)
+    save_plots(names, axes, stats, args.output_dir)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--debug", action="store_true", help="activate debug log level")
+    subparsers = parser.add_subparsers(help='sub-command help')
+
+    parser_pickles = subparsers.add_parser('plot-pickles', help='pickle plots help')
+
+    parser_pickles.add_argument("top", help="directory where it should be looked for ROOT files")
+    parser_pickles.add_argument("--file-signature", dest="file_signature", help="regular expression matching filenames", default=r"AnalysisResultsGen.pkl")
+    parser_pickles.add_argument("--recursive", action="store_true", help="recursive search for files")
+    parser_pickles.add_argument("--n-files", dest="n_files", help="number of files to be processed", type=int, default=-1)
+    parser_pickles.add_argument("--plot-config", dest="plot_config", help="plots to be produced", required=True)
+    parser_pickles.add_argument("--output-dir", dest="output_dir", help="directory where plots are dumped", default="./plots_output/")
+    parser_pickles.set_defaults(func=process_pickles)
+
+    parser_yamls = subparsers.add_parser('plot-yamls', help='YAML plots help')
+    parser_yamls.add_argument("top", help="directory where it should be looked for ROOT files", nargs="+")
+    parser_yamls.add_argument("--output-dir", dest="output_dir", help="directory where plots are dumped", default="./plots_output/")
+    parser_yamls.set_defaults(func=process_yamls)
+
+    args = parser.parse_args()
+
+    configure_logger(args.debug)
+
+    args.func(args)
+
+
+    #logger = get_logger()
 

--- a/machine_learning_hep/plotting.py
+++ b/machine_learning_hep/plotting.py
@@ -162,7 +162,11 @@ def process_files(top_dir, file_signature, recursive, n_files, plot_config):
         # Brute force for now
         for plot in plots:
             for o in plot["observables"]:
-                for cut in o["cuts"]:
+                legend_labels = o.get("legend_labels", o["cuts"])
+                if len(legend_labels) != len(o["cuts"]):
+                    logger_string = f"Different number of legend labels and cuts found for observable {o['name']}"
+                    logger.fatal(logger_string)
+                for cut, label in zip(o["cuts"], legend_labels):
                     if cut is None:
                         values = pickle.load(openfile(f, "rb"))[o["name"]]
                         if values.size == 0:
@@ -173,7 +177,7 @@ def process_files(top_dir, file_signature, recursive, n_files, plot_config):
                         if o["name"] not in histograms:
                             histograms[o["name"]] = {}
                         if histo_name not in histograms[o["name"]]:
-                                histograms[o["name"]][histo_name] = Histo1D(histo_name, o["bins"], o["range"], "no_cut", o.get("xlabel", "xlabel"), o.get("ylabel", "ylabel"))
+                                histograms[o["name"]][histo_name] = Histo1D(histo_name, o["bins"], o["range"], str(label), o.get("xlabel", "xlabel"), o.get("ylabel", "ylabel"))
                         histograms[o["name"]][histo_name].add_values(values)
                     else:
                         values = pickle.load(openfile(f, "rb")).query(available_cuts[cut]["expression"])[o["name"]]
@@ -185,7 +189,7 @@ def process_files(top_dir, file_signature, recursive, n_files, plot_config):
                         if o["name"] not in histograms:
                             histograms[o["name"]] = {}
                         if histo_name not in histograms[o["name"]]:
-                            histograms[o["name"]][histo_name] = Histo1D(histo_name, o["bins"], o["range"], available_cuts[cut]["expression"], o.get("xlabel", "xlabel"), o.get("ylabel", "ylabel"))
+                            histograms[o["name"]][histo_name] = Histo1D(histo_name, o["bins"], o["range"], str(label), o.get("xlabel", "xlabel"), o.get("ylabel", "ylabel"))
                         histograms[o["name"]][histo_name].add_values(values)
 
     return make_plots_stats(histograms)

--- a/machine_learning_hep/plotting.py
+++ b/machine_learning_hep/plotting.py
@@ -1,0 +1,276 @@
+#############################################################################
+##  © Copyright CERN 2018. All rights not expressly granted are reserved.  ##
+##                 Author: Gian.Michele.Innocenti@cern.ch                  ##
+## This program is free software: you can redistribute it and/or modify it ##
+##  under the terms of the GNU General Public License as published by the  ##
+## Free Software Foundation, either version 3 of the License, or (at your  ##
+## option) any later version. This program is distributed in the hope that ##
+##  it will be useful, but WITHOUT ANY WARRANTY; without even the implied  ##
+##     warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.    ##
+##           See the GNU General Public License for more details.          ##
+##    You should have received a copy of the GNU General Public License    ##
+##   along with this program. if not, see <https://www.gnu.org/licenses/>. ##
+#############################################################################
+
+import os
+import glob
+import pickle
+import pandas as pd
+from machine_learning_hep.utilities import openfile
+from machine_learning_hep.logger import configure_logger, get_logger
+from machine_learning_hep.io import parse_yaml, dump_yaml_from_dict
+import matplotlib.pyplot as plt
+import numpy as np
+
+class Histo1D:
+    def __init__(self, name, bins, axis_range, label, xlabel, ylabel):
+        self.name = name
+        self.bins = bins
+        self.axis_range = axis_range
+        self.xlabel = xlabel
+        self.ylabel = ylabel
+        self.label = label
+        self.hist, self.edges = np.histogram([], bins, axis_range)
+
+    def add_values(self, values, weights=None):
+        self.hist += np.histogram(values, self.bins, self.axis_range, None, weights)[0]
+
+    def get_statistics(self):
+        return [ ("bin_" + str(i + 1), self.edges[i], self.edges[i+1], self.hist[i]) for i in range(len(self.hist)) ]
+
+
+def plot1D(histograms, plot_name, ax=None):
+
+    logger = get_logger()
+    try:
+        it = iter(histograms)
+    except TypeError as te:
+        histograms = [histograms]
+
+    fig = plt.figure(figsize=(60,25))
+    if ax is None:
+        ax = plt.gca()
+    # Derive bin centers from edges of first histogram
+    common_edges = histograms[0].edges
+    common_xlabel = histograms[0].xlabel
+    common_ylabel = histograms[0].ylabel
+    bin_widths = [ 0.9 * (common_edges[i+1] - common_edges[i] ) for i in range(len(common_edges) - 1) ]
+    bin_centers = [ (common_edges[i+1] + common_edges[i]) / 2 for i in range(len(common_edges) - 1) ]
+    new_bottom = np.zeros(len(histograms[0].hist))
+    for h in histograms:
+        if not np.array_equal(h.edges,common_edges):
+            logger_string = f"Incompatible edges found in histogram {h.name}"
+            logger.fatal(logger_string)
+        ax.bar(bin_centers, h.hist, width=bin_widths, alpha=0.5, label=h.label, bottom=new_bottom)
+    ax.legend(fontsize=30)
+    ax.set_xlabel(common_xlabel, fontsize=30)
+    ax.set_ylabel(common_ylabel, fontsize=30)
+    ax.tick_params(labelsize=30)
+    return ax
+
+def get_statistics(histograms):
+
+    logger = get_logger()
+    try:
+        it = iter(histograms)
+    except TypeError as te:
+        histograms = [histograms]
+
+    stats_list = []
+    for h in histograms:
+        stats_dict = {}
+        stats = h.get_statistics()
+        stats_dict["name"] = h.name
+        stats_dict["edges"] = []
+        stats_dict["total_count"] = 0
+        total_stats = 0
+        for s in stats:
+            stats_dict["edges"].append([str(s[0]), float(s[1]), float(s[2]), float(s[3])])
+            stats_dict["total_count"] += float(s[3])
+        stats_list.append(stats_dict)
+
+    return stats_list
+
+
+def make_plots_stats(histograms, in_one_figure=False):
+
+    figures = []
+    stats = []
+    names = []
+
+    logger = get_logger()
+
+    if in_one_figure:
+        fig = plt.figure(figsize=(60, 25))
+        gs = GridSpec(3, int(len(histograms)/3+1))
+        axes = [fig.add_subplot(gs[i]) for i in range(len(histograms))]
+
+        i = 0
+        for h_name, histos in histograms.items():
+            histo_list = [ v for v in histos.values() ] 
+            names.append(h_name)
+            plot1D(histo_list, h_name, ax=axes[i])
+            stats.append(get_statistics(histo_list))
+            i += 1
+        return [fig], names, stats
+
+    else:
+        for h_name, histos in histograms.items():
+            fig = plt.figure(figsize=(60, 25))
+            ax = fig.subplots()
+            histo_list = [ v for v in histos.values() ] 
+            names.append(h_name)
+            plot1D(histo_list, h_name, ax=ax)
+            stats.append(get_statistics(histo_list))
+            figures.append(fig)
+
+    return figures, names, stats
+
+
+
+def process_files(top_dir, file_signature, recursive, n_files, plot_config):
+    top_dir = os.path.expanduser(top_dir)
+    logger = get_logger()
+    if not os.path.isdir(top_dir):
+        logger_string = f"Directory {top_dir} does not exist."
+        logger.fatal(logger_string)
+    
+    file_signature = os.path.join(top_dir, "**/", file_signature)
+    logger_string = f"Globbing files with matching {file_signature}"
+    logger.info(logger_string)
+
+    root_files = glob.glob(file_signature, recursive=recursive)
+    if not root_files:
+        logger.fatal("No ROOT files selected")
+
+    if len(root_files) < n_files:
+        logger_string = f"Although {n_files} were requested, could only glob {len(root_files)}"
+        logger.warning(logger_string)
+    elif len(root_files) > n_files and n_files > 0:
+        # Skim list of ROOT files to requested number
+        root_files = root_files[:n_files]
+
+    available_cuts = plot_config["cuts"]
+    available_cuts[None] = None
+    plots = plot_config["plots"]
+
+    histograms = {}
+    # Now, go though all files
+    for i_file, f in enumerate(root_files):
+        logger_string = f"Process {i_file}. file at {f}"
+        logger.debug(logger_string)
+        # Brute force for now
+        for plot in plots:
+            for o in plot["observables"]:
+                for cut in o["cuts"]:
+                    if cut is None:
+                        values = pickle.load(openfile(f, "rb"))[o["name"]]
+                        if values.size == 0:
+                            logger_string = f"Tree dataframe in file {f} seems to be empty"
+                            logger.warning(logger_string)
+                            continue
+                        histo_name = o["name"] + "_no_cut"
+                        if o["name"] not in histograms:
+                            histograms[o["name"]] = {}
+                        if histo_name not in histograms[o["name"]]:
+                                histograms[o["name"]][histo_name] = Histo1D(histo_name, o["bins"], o["range"], "no_cut", o.get("xlabel", "xlabel"), o.get("ylabel", "ylabel"))
+                        histograms[o["name"]][histo_name].add_values(values)
+                    else:
+                        values = pickle.load(openfile(f, "rb")).query(available_cuts[cut]["expression"])[o["name"]]
+                        if values.size == 0:
+                            logger_string = f"After cut nothing left in dataframe in file {f}"
+                            logger.warning(logger_string)
+                            continue
+                        histo_name = o["name"] + "_" + cut
+                        if o["name"] not in histograms:
+                            histograms[o["name"]] = {}
+                        if histo_name not in histograms[o["name"]]:
+                            histograms[o["name"]][histo_name] = Histo1D(histo_name, o["bins"], o["range"], available_cuts[cut]["expression"], o.get("xlabel", "xlabel"), o.get("ylabel", "ylabel"))
+                        histograms[o["name"]][histo_name].add_values(values)
+
+    return make_plots_stats(histograms)
+
+def process_dataframe(dfs, plot_config, output_dir):
+
+    logger = get_logger()
+    try:
+        it = iter(dfs)
+    except TypeError as te:
+        dfs = [dfs]
+
+    plots = plot_config["plots"]
+    available_cuts = plot_config.get("cuts", {})
+    available_cuts[None] = None
+
+    for i_df, df in enumerate(dfs):
+        logger_string = f"Process {i_file}. dataframe"
+        logger.debug(logger_string)
+        # Brute force for now
+        for plot in plots:
+            for o in plot["observables"]:
+                for cut in o["cuts"]:
+                    if cut is None:
+                        values = df[o["name"]]
+                        if values.size == 0:
+                            logger_string = f"Dataframe seems to be empty"
+                            logger.warning(logger_string)
+                            continue
+                        histo_name = o["name"] + "_no_cut"
+                        if o["name"] not in histograms:
+                            histograms[o["name"]] = {}
+                        if histo_name not in histograms[o["name"]]:
+                                histograms[o["name"]][histo_name] = Histo1D(histo_name, o["bins"], o["range"], "no_cut", o.get("xlabel", "xlabel"), o.get("ylabel", "ylabel"))
+                        histograms[o["name"]][histo_name].add_values(values)
+                    else:
+                        values = df.query(available_cuts[cut]["expression"])[o["name"]]
+                        if values.size == 0:
+                            logger_string = f"After cut nothing left in dataframe"
+                            logger.warning(logger_string)
+                            continue
+                        histo_name = o["name"] + "_" + cut
+                        if o["name"] not in histograms:
+                            histograms[o["name"]] = {}
+                        if histo_name not in histograms[o["name"]]:
+                            histograms[o["name"]][histo_name] = Histo1D(histo_name, o["bins"], o["range"], available_cuts[cut]["expression"], o.get("xlabel", "xlabel"), o.get("ylabel", "ylabel"))
+                        histograms[o["name"]][histo_name].add_values(values)
+
+    return make_plots_stats(histograms)
+
+
+def save_plots(figures, names, stats, output_dir="./", close_figures=True):
+    
+    logger = get_logger()
+    if not os.path.isdir(output_dir):
+        if os.path.exists(output_dir):
+            logger_string = f"{output_dir} exists but is not a directory"
+            logger.fatal(logger_string)
+        os.makedirs(output_dir)
+
+    if len(figures) == 1 and len(names) > 1:
+        # Apparently many histograms were put in one figure
+        prefix = "_".join(names)
+        output_path = os.path.join(output_dir, prefix + ".png")
+        
+        logger_string = f"Save plot {output_path}"
+        logger.info(logger_string)
+        fig[0].savefig(output_path)
+        if close_figures:
+            plt.close(fig[0])
+    
+    elif len(figures) != len(names):
+        # Don't know how to handle this
+        logger_string = f"{len(figures)} figures and {len(names)} given. Don't know how to handle that"
+        logger.fatal(logger_string)
+
+    else:
+        for fig, name, stat in zip(figures, names, stats):
+            output_path = os.path.join(output_dir, name + ".png")
+            logger_string = f"Save plot {output_path}"
+            logger.info(logger_string)
+            fig.savefig(output_path)
+            for s in stat:
+                output_path = os.path.join(output_dir, s["name"] + ".yaml")
+                dump_yaml_from_dict(s, output_path)
+            if close_figures:
+                plt.close(fig)
+

--- a/setup.py
+++ b/setup.py
@@ -111,6 +111,7 @@ setup(
       "console_scripts": [ "ml-get-data = machine_learning_hep.ml_get_data:main",
                            "ml-doclassification-regression = " \
                            "machine_learning_hep.doclassification_regression:main",
-                           "ml-webapp = machine_learning_hep.webapp:main" ]
+                           "ml-webapp = machine_learning_hep.webapp:main",
+                           "ml-plot = machine_learning_hep.plot_from_file:main" ]
   }
 )


### PR DESCRIPTION
What can it do?
* plot basically anything what is available in the pickled pandas datatframes
* easy to configure (see `plot.yaml`)
* planned to serve as the plotting facility for all plots created during the ML workflow were possible

TODO (this PR)
* Add README
* run pylint
* check a few more plotting scenarios

TODO (next PRs)
* further optimisation wrt speed/multi-processing can/shall be done in the near future
* add further options for plotting style (e.g. histogram, scatter, ...)
* more fancy plots (e.g. histogram + fit or function) should be possible
* if needed, add 2D plots

Why?
* enables a user to quickly produce plots
* only in very special cases 
* given the configuration via a `yaml´ file, it ensures reproducibility

Usage
1. first run the installation again `pip install -e .` from within your virtual env
2. the you can type `ml-plot [--help]` to see what is possible
3. Maybe you can even try


@ginnocen What do you think?