### PR TITLE
Add plot of model predictions on train and test set

### DIFF
--- a/machine_learning_hep/data/database_ml_parameters_DsPbPb3050.yml
+++ b/machine_learning_hep/data/database_ml_parameters_DsPbPb3050.yml
@@ -253,5 +253,5 @@ DsPbPb3050:
       dir: ['',''] #list of periods
       dirmerged: ''
     mc:
-      dir: ['','','',''] #list of periods
+      dir: ['',''] #list of periods
       dirmerged: ''

--- a/machine_learning_hep/default_apply.yml
+++ b/machine_learning_hep/default_apply.yml
@@ -34,6 +34,7 @@ ml_study:
   dolearningcurve: false
   doroc: false
   doroctraintest: false
+  doplotdistr: false
   doimportance: false
   dogridsearch: false
   doboundary: false

--- a/machine_learning_hep/default_complete.yaml
+++ b/machine_learning_hep/default_complete.yaml
@@ -34,6 +34,7 @@ ml_study:
   dolearningcurve: false
   doroc: false
   doroctraintest: false
+  doplotdistr: false
   doimportance: false
   dogridsearch: false
   doboundary: false

--- a/machine_learning_hep/default_pre.yml
+++ b/machine_learning_hep/default_pre.yml
@@ -34,6 +34,7 @@ ml_study:
   dolearningcurve: false
   doroc: false
   doroctraintest: false
+  doplotdistr: false
   doimportance: false
   dogridsearch: false
   doboundary: false

--- a/machine_learning_hep/default_train.yml
+++ b/machine_learning_hep/default_train.yml
@@ -34,6 +34,7 @@ ml_study:
   dolearningcurve: true
   doroc: true
   doroctraintest: false
+  doplotdistr: false
   doimportance: true
   dogridsearch: false
   doboundary: false

--- a/machine_learning_hep/mlperformance.py
+++ b/machine_learning_hep/mlperformance.py
@@ -274,54 +274,37 @@ def plot_learning_curves(names_, classifiers_, suffix_, folder, x_data, y_data, 
     img_learn.seek(0)
     return img_learn
 
-def plot_overtraining(names_, classifiers_, suffix_, folder, \
-        x_train, y_train, x_val, y_val, bins=30):
-    img_overtrain_array = []
-    for name, clf in zip(names_, classifiers_):
-        plt.figure()
-
+def plot_overtraining(names, classifiers, suffix, folder, x_train, y_train, x_val, y_val,
+                      bins=50):
+    for name, clf in zip(names, classifiers):
+        fig = plt.figure(figsize=(10, 8))
         decisions = []
         for x, y in ((x_train, y_train), (x_val, y_val)):
             d1 = clf.predict_proba(x[y > 0.5])[:, 1]
             d2 = clf.predict_proba(x[y < 0.5])[:, 1]
             decisions += [d1, d2]
 
-        plt.hist(decisions[0],
-                 color='r', alpha=0.5, range=[0, 1], bins=bins,
-                 histtype='stepfilled', density=True,
-                 label='S (train)')
-        plt.hist(decisions[1],
-                 color='b', alpha=0.5, range=[0, 1], bins=bins,
-                 histtype='stepfilled', density=True,
-                 label='B (train)')
-
-        hist, bins = np.histogram(decisions[2],
-                                  bins=bins, range=[0, 1], density=True)
+        plt.hist(decisions[0], color='r', alpha=0.5, range=[0, 1], bins=bins,
+                 histtype='stepfilled', density=True, label='S, train')
+        plt.hist(decisions[1], color='b', alpha=0.5, range=[0, 1], bins=bins,
+                 histtype='stepfilled', density=True, label='B, train')
+        hist, bins = np.histogram(decisions[2], bins=bins, range=[0, 1], density=True)
         scale = len(decisions[2]) / sum(hist)
         err = np.sqrt(hist * scale) / scale
-
         center = (bins[:-1] + bins[1:]) / 2
-        plt.errorbar(center, hist, yerr=err, fmt='o', c='r', label='S (test)')
-
-        hist, bins = np.histogram(decisions[3],
-                                  bins=bins, range=[0, 1], density=True)
+        plt.errorbar(center, hist, yerr=err, fmt='o', c='r', label='S, test')
+        hist, bins = np.histogram(decisions[3], bins=bins, range=[0, 1], density=True)
         scale = len(decisions[3]) / sum(hist)
         err = np.sqrt(hist * scale) / scale
+        plt.errorbar(center, hist, yerr=err, fmt='o', c='b', label='B, test')
+        plt.xlabel("Model output", fontsize=15)
+        plt.ylabel("Arbitrary units", fontsize=15)
+        plt.legend(loc="best", frameon=False, fontsize=15)
+        plt.yscale("log")
 
-        plt.errorbar(center, hist, yerr=err, fmt='o', c='b', label='B (test)')
-
-        plt.xlabel("output response")
-        plt.ylabel("Arbitrary units")
-        plt.legend(loc='best')
-
-        plotname = folder+'/overtraining_%s%s.png' % (name, suffix_)
-        plt.savefig(plotname)
-        img_overtrain = BytesIO()
-        plt.savefig(img_overtrain, format='png')
-        img_overtrain.seek(0)
-        img_overtrain_array += img_overtrain
-        plt.clf()
-    return img_overtrain_array
+        plot_name = f'{folder}/ModelOutDistr_{name}_{suffix}.png'
+        fig.savefig(plot_name)
+        plot_name = plot_name.replace('png', 'pickle')
 
 def roc_train_test(names, classifiers, x_train, y_train, x_test, y_test, suffix, folder):
     fig = plt.figure(figsize=(20, 15))

--- a/machine_learning_hep/optimiser.py
+++ b/machine_learning_hep/optimiser.py
@@ -317,7 +317,7 @@ class Optimiser:
     def do_roc_train_test(self):
         roc_train_test(self.p_classname, self.p_class, self.df_xtrain, self.df_ytrain,
                        self.df_xtest, self.df_ytest, self.s_suffix, self.dirmlplot)
-                       
+
     def do_plot_model_pred(self):
         plot_overtraining(self.p_classname, self.p_class, self.s_suffix, self.dirmlplot,
                           self.df_xtrain, self.df_ytrain, self.df_xtest, self.df_ytest)

--- a/machine_learning_hep/optimiser.py
+++ b/machine_learning_hep/optimiser.py
@@ -33,7 +33,7 @@ from machine_learning_hep.models import fit, savemodels, test, apply, decisionbo
 from machine_learning_hep.root import write_tree
 from machine_learning_hep.mlperformance import cross_validation_mse, plot_cross_validation_mse
 from machine_learning_hep.mlperformance import plot_learning_curves, precision_recall
-from machine_learning_hep.mlperformance import roc_train_test
+from machine_learning_hep.mlperformance import roc_train_test, plot_overtraining
 from machine_learning_hep.grid_search import do_gridsearch, read_grid_dict, perform_plot_gridsearch
 from machine_learning_hep.models import importanceplotall
 from machine_learning_hep.logger import get_logger
@@ -317,6 +317,10 @@ class Optimiser:
     def do_roc_train_test(self):
         roc_train_test(self.p_classname, self.p_class, self.df_xtrain, self.df_ytrain,
                        self.df_xtest, self.df_ytest, self.s_suffix, self.dirmlplot)
+                       
+    def do_plot_model_pred(self):
+        plot_overtraining(self.p_classname, self.p_class, self.s_suffix, self.dirmlplot,
+                          self.df_xtrain, self.df_ytrain, self.df_xtest, self.df_ytest)
 
     def do_importance(self):
         importanceplotall(self.v_train, self.p_classname, self.p_class,

--- a/machine_learning_hep/steer_analysis.py
+++ b/machine_learning_hep/steer_analysis.py
@@ -92,6 +92,7 @@ def do_entire_analysis(data_config: dict, data_param: dict, data_model: dict, gr
     dogridsearch = data_config["ml_study"]['dogridsearch']
     dosignifopt = data_config["ml_study"]['dosignifopt']
     doscancuts = data_config["ml_study"]["doscancuts"]
+    doplotdistr = data_config["ml_study"]["doplotdistr"]
     doapplydata = data_config["mlapplication"]["data"]["doapply"]
     doapplymc = data_config["mlapplication"]["mc"]["doapply"]
     domergeapplydata = data_config["mlapplication"]["data"]["domergeapply"]
@@ -346,6 +347,8 @@ def do_entire_analysis(data_config: dict, data_param: dict, data_model: dict, gr
                 myopt.do_roc()
             if doroctraintest is True:
                 myopt.do_roc_train_test()
+            if doplotdistr is True:
+                myopt.do_plot_model_pred()
             if doimportance is True:
                 myopt.do_importance()
             if dogridsearch is True:


### PR DESCRIPTION
Add the possibility to compare the model prediction for signal and bkg on the training and test set, useful to check for over-training. This PR slightly modify and makes callable again the function implemented by @jaimenorman in #78 