### PR TITLE
Possibility to skip already applied files

### DIFF
--- a/machine_learning_hep/default_ana.yml
+++ b/machine_learning_hep/default_ana.yml
@@ -44,11 +44,11 @@ mlapplication:
   data:
     doapply: false
     domergeapply: false
-    domergeapplyperiods: false
+    docontinueafterstop: false
   mc:
     doapply: false
     domergeapply: false
-    domergeapplyperiods: false
+    docontinueafterstop: false
 
 analysis:
   type: MBvspt_ntrkl

--- a/machine_learning_hep/default_apply.yml
+++ b/machine_learning_hep/default_apply.yml
@@ -44,11 +44,11 @@ mlapplication:
   data:
     doapply: true
     domergeapply: true
-    domergeapplyperiods: true
+    docontinueafterstop: false
   mc:
     doapply: true
     domergeapply: true
-    domergeapplyperiods: true
+    docontinueafterstop: false
 
 analysis:
   type: SPDvspt

--- a/machine_learning_hep/default_complete.yaml
+++ b/machine_learning_hep/default_complete.yaml
@@ -44,11 +44,11 @@ mlapplication:
   data:
     doapply: false
     domergeapply: false
-    domergeapplyperiods: false
+    docontinueafterstop: false
   mc:
     doapply: false
     domergeapply: false
-    domergeapplyperiods: false
+    docontinueafterstop: false
 
 analysis:
   type: MBvspt_ntrkl

--- a/machine_learning_hep/default_complete_MBvspt_ntrkl.yaml
+++ b/machine_learning_hep/default_complete_MBvspt_ntrkl.yaml
@@ -44,11 +44,11 @@ mlapplication:
   data:
     doapply: false
     domergeapply: false
-    domergeapplyperiods: false
+    docontinueafterstop: false
   mc:
     doapply: false
     domergeapply: false
-    domergeapplyperiods: false
+    docontinueafterstop: false
 
 analysis:
   type: MBvspt_ntrkl #MBvspt_ntrk, MBvspt_v0ml, SPDvspt, V0mvspt

--- a/machine_learning_hep/default_complete_MBvspt_v0ml.yaml
+++ b/machine_learning_hep/default_complete_MBvspt_v0ml.yaml
@@ -44,11 +44,11 @@ mlapplication:
   data:
     doapply: false
     domergeapply: false
-    domergeapplyperiods: false
+    docontinueafterstop: false
   mc:
     doapply: false
     domergeapply: false
-    domergeapplyperiods: false
+    docontinueafterstop: false
 
 analysis:
   type: MBvspt_v0m #MBvspt_ntrk, MBvspt_v0ml, SPDvspt, V0mvspt

--- a/machine_learning_hep/default_complete_SPDvspt.yaml
+++ b/machine_learning_hep/default_complete_SPDvspt.yaml
@@ -44,11 +44,11 @@ mlapplication:
   data:
     doapply: false
     domergeapply: false
-    domergeapplyperiods: false
+    docontinueafterstop: false
   mc:
     doapply: false
     domergeapply: false
-    domergeapplyperiods: false
+    docontinueafterstop: false
 
 analysis:
   type: SPDvspt #MBvspt_ntrk, MBvspt_v0ml, SPDvspt, V0mvspt

--- a/machine_learning_hep/default_complete_V0mvspt.yaml
+++ b/machine_learning_hep/default_complete_V0mvspt.yaml
@@ -44,11 +44,11 @@ mlapplication:
   data:
     doapply: false
     domergeapply: false
-    domergeapplyperiods: false
+    docontinueafterstop: false
   mc:
     doapply: false
     domergeapply: false
-    domergeapplyperiods: false
+    docontinueafterstop: false
 
 analysis:
   type: V0mvspt #MBvspt_ntrk, MBvspt_v0ml, SPDvspt, V0mvspt

--- a/machine_learning_hep/default_pre.yml
+++ b/machine_learning_hep/default_pre.yml
@@ -44,11 +44,11 @@ mlapplication:
   data:
     doapply: false
     domergeapply: false
-    domergeapplyperiods: false
+    docontinueafterstop: false
   mc:
     doapply: false
     domergeapply: false
-    domergeapplyperiods: false
+    docontinueafterstop: false
 
 analysis:
   type: SPDvspt

--- a/machine_learning_hep/default_train.yml
+++ b/machine_learning_hep/default_train.yml
@@ -44,11 +44,11 @@ mlapplication:
   data:
     doapply: false
     domergeapply: false
-    domergeapplyperiods: false
+    docontinueafterstop: false
   mc:
     doapply: false
     domergeapply: false
-    domergeapplyperiods: false
+    docontinueafterstop: false
 
 analysis:
   type: SPDvspt

--- a/machine_learning_hep/processer.py
+++ b/machine_learning_hep/processer.py
@@ -297,6 +297,9 @@ class Processer: # pylint: disable=too-many-instance-attributes
 
     def applymodel(self, file_index):
         for ipt in range(self.p_nptbins):
+            if os.path.exists(self.mptfiles_recoskmldec[ipt][file_index]):
+                if os.stat(self.mptfiles_recoskmldec[ipt][file_index]).st_size != 0:
+                    continue
             dfrecosk = pickle.load(openfile(self.mptfiles_recosk[ipt][file_index], "rb"))
             if os.path.isfile(self.lpt_model[ipt]) is False:
                 print("Model file not present in bin %d" % ipt)
@@ -307,6 +310,7 @@ class Processer: # pylint: disable=too-many-instance-attributes
             dfrecoskml = dfrecoskml.loc[dfrecoskml[probvar] > self.lpt_probcutpre[ipt]]
             pickle.dump(dfrecoskml, openfile(self.mptfiles_recoskmldec[ipt][file_index], "wb"),
                         protocol=4)
+
     def parallelizer(self, function, argument_list, maxperchunk):
         chunks = [argument_list[x:x+maxperchunk] \
                   for x in range(0, len(argument_list), maxperchunk)]

--- a/machine_learning_hep/steer_analysis.py
+++ b/machine_learning_hep/steer_analysis.py
@@ -94,6 +94,8 @@ def do_entire_analysis(data_config: dict, data_param: dict, data_model: dict, gr
     doapplymc = data_config["mlapplication"]["mc"]["doapply"]
     domergeapplydata = data_config["mlapplication"]["data"]["domergeapply"]
     domergeapplymc = data_config["mlapplication"]["mc"]["domergeapply"]
+    docontinueapplydata = data_config["mlapplication"]["data"]["docontinueafterstop"]
+    docontinueapplymc = data_config["mlapplication"]["mc"]["docontinueafterstop"]
     dohistomassmc = data_config["analysis"]["mc"]["histomass"]
     dohistomassdata = data_config["analysis"]["data"]["histomass"]
     doefficiency = data_config["analysis"]["mc"]["efficiency"]
@@ -187,17 +189,19 @@ def do_entire_analysis(data_config: dict, data_param: dict, data_model: dict, gr
         counter = counter + checkdir(mlout)
         counter = counter + checkdir(mlplot)
 
-    if doapplymc is True:
-        counter = counter + checkdirlist(dirpklskdecmc)
+    if docontinueapplymc is False:
+        if doapplymc is True:
+            counter = counter + checkdirlist(dirpklskdecmc)
 
-    if doapplydata is True:
-        counter = counter + checkdirlist(dirpklskdecdata)
+        if domergeapplymc is True:
+            counter = counter + checkdirlist(dirpklskdec_mergedmc)
 
-    if domergeapplymc is True:
-        counter = counter + checkdirlist(dirpklskdec_mergedmc)
+    if docontinueapplydata is False:
+        if doapplydata is True:
+            counter = counter + checkdirlist(dirpklskdecdata)
 
-    if domergeapplydata is True:
-        counter = counter + checkdirlist(dirpklskdec_mergeddata)
+        if domergeapplydata is True:
+            counter = counter + checkdirlist(dirpklskdec_mergeddata)
 
     if dohistomassmc is True:
         counter = counter + checkdirlist(dirresultsmc)
@@ -249,17 +253,19 @@ def do_entire_analysis(data_config: dict, data_param: dict, data_model: dict, gr
         checkmakedir(mlout)
         checkmakedir(mlplot)
 
-    if doapplymc is True:
-        checkmakedirlist(dirpklskdecmc)
+    if docontinueapplymc is False:
+        if doapplymc is True:
+            checkmakedirlist(dirpklskdecmc)
 
-    if doapplydata is True:
-        checkmakedirlist(dirpklskdecdata)
+        if domergeapplymc is True:
+            checkmakedirlist(dirpklskdec_mergedmc)
 
-    if domergeapplymc is True:
-        checkmakedirlist(dirpklskdec_mergedmc)
+    if docontinueapplydata is False:
+        if doapplydata is True:
+            checkmakedirlist(dirpklskdecdata)
 
-    if domergeapplydata is True:
-        checkmakedirlist(dirpklskdec_mergeddata)
+        if domergeapplydata is True:
+            checkmakedirlist(dirpklskdec_mergeddata)
 
     if dohistomassmc is True:
         checkmakedirlist(dirresultsmc)


### PR DESCRIPTION
Possibility to "pause" the heavy application operation by stopping the python job. Uses a flag in the default_complete to skip the already processed files when process is restarted.

Used a lot when applying for the Lc in PbPb analysis, files don't get corrupted