### PR TITLE
Use fPrompt from MB for HM + Update downloader

### DIFF
--- a/cplusutilities/Download.sh
+++ b/cplusutilities/Download.sh
@@ -230,15 +230,15 @@ elif [ "$dataset" == "MCpp13TeV_MB_all" ]; then
               /alice/sim/2018/LHC18f4a/257630/PWGHF/HF_TreeCreator
               /alice/sim/2018/LHC18l4a/272123/PWGHF/HF_TreeCreator
               /alice/sim/2018/LHC18l4b/288908/PWGHF/HF_TreeCreator
-              /alice/sim/2019/LHC19h4c1/257630/PWGHF/HF_TreeCreator
+              /alice/sim/2019/LHC19h4c1/253529/PWGHF/HF_TreeCreator
               /alice/sim/2019/LHC19h4b1/272123/PWGHF/HF_TreeCreator
-              /alice/sim/2019/LHC19h4a1/293386/PWGHF/HF_TreeCreator
-              /alice/sim/2019/LHC19h4c2/257630/PWGHF/HF_TreeCreator
+              /alice/sim/2019/LHC19h4a1/288908/PWGHF/HF_TreeCreator
+              /alice/sim/2019/LHC19h4c2/253529/PWGHF/HF_TreeCreator
               /alice/sim/2019/LHC19h4b2/272123/PWGHF/HF_TreeCreator
-              /alice/sim/2019/LHC19h4a2/293386/PWGHF/HF_TreeCreator
-              /alice/sim/2019/LHC19h4c3/257630/PWGHF/HF_TreeCreator
+              /alice/sim/2019/LHC19h4a2/288908/PWGHF/HF_TreeCreator
+              /alice/sim/2019/LHC19h4c3/253529/PWGHF/HF_TreeCreator
               /alice/sim/2019/LHC19h4b3/272123/PWGHF/HF_TreeCreator
-              /alice/sim/2019/LHC19h4a3/293386/PWGHF/HF_TreeCreator)
+              /alice/sim/2019/LHC19h4a3/288908/PWGHF/HF_TreeCreator)
   datasetwithchilds=1
   splitchildsdifferentpaths=1
   dataset_short_arr=("pp_2016_mc_prodD2H"

--- a/machine_learning_hep/HFPtSpectrum.C
+++ b/machine_learning_hep/HFPtSpectrum.C
@@ -50,47 +50,47 @@ enum rapidity{ kdefault, k08to04, k07to04, k04to01, k01to01, k01to04, k04to07, k
 enum particularity{ kTopological, kLowPt, kPP7TeVPass4, kBDT };
 
 void HFPtSpectrum ( Int_t decayChan=kDplusKpipi,
-		    const char *mcfilename="FeedDownCorrectionMC.root",
-		    const char *efffilename="Efficiencies.root",
-        const char *nameeffprompt= "eff",
-        const char *nameefffeed = "effB",
-		    const char *recofilename="Reconstructed.root",
-		    const char *recohistoname="hRawSpectrumD0",
-		    const char *outfilename="HFPtSpectrum.root",
-		    Double_t nevents=1.0, // overriden by nevhistoname
-		    Double_t sigma=1.0, // sigma[pb]
-		    Int_t fdMethod=kfc,
-		    Int_t cc=kpp7,
-		    Int_t year=k2010,
-		    Int_t Energy=k276,
-		    Int_t isRaavsEP=kPhiIntegrated,
-		    const char *epResolfile="",
-		    Bool_t PbPbEloss=false,
-		    Int_t rapiditySlice=kdefault,
-		    Bool_t isParticlePlusAntiParticleYield=true,
-		    Int_t analysisSpeciality=kTopological,
-		    Int_t ccestimator = kV0M,
-		    Bool_t setUsePtDependentEffUncertainty=true,
-		    const char *nevhistoname="hNEvents"){
-
-
+                   const char *mcfilename="FeedDownCorrectionMC.root",
+                   const char *efffilename="Efficiencies.root",
+                   const char *nameeffprompt= "eff",
+                   const char *nameefffeed = "effB",
+                   const char *recofilename="Reconstructed.root",
+                   const char *recohistoname="hRawSpectrumD0",
+                   const char *outfilename="HFPtSpectrum.root",
+                   Double_t nevents=1.0, // overriden by nevhistoname
+                   Double_t sigma=1.0, // sigma[pb]
+                   Int_t fdMethod=kfc,
+                   Int_t cc=kpp7,
+                   Int_t year=k2010,
+                   Int_t Energy=k276,
+                   Int_t isRaavsEP=kPhiIntegrated,
+                   const char *epResolfile="",
+                   Bool_t PbPbEloss=false,
+                   Int_t rapiditySlice=kdefault,
+                   Bool_t isParticlePlusAntiParticleYield=true,
+                   Int_t analysisSpeciality=kTopological,
+                   Int_t ccestimator = kV0M,
+                   Bool_t setUsePtDependentEffUncertainty=true,
+                   const char *nevhistoname="hNEvents"){
+  
+  
   //  gROOT->Macro("$ALICE_PHYSICS/PWGHF/vertexingHF/macros/LoadLibraries.C");
-
+  
   //  Set if calculation considers asymmetric uncertainties or not
   Bool_t asym = true;
-
+  
   Int_t option=3;
   if (fdMethod==kfc) option=1;
   else if (fdMethod==kNb) option=2;
   else if (fdMethod==knone) { option=0; asym=false; PbPbEloss=false; }
   else option=3;
-
+  
   if (option>2) {
     cout<< "Bad calculation option, should be <=2"<<endl;
     return;
   }
-
-
+  
+  
   //
   // Defining the Tab values for the given centrality class
   // https://twiki.cern.ch/twiki/bin/viewauth/ALICE/CentStudies
@@ -140,7 +140,7 @@ void HFPtSpectrum ( Int_t decayChan=kDplusKpipi,
       tab = 0.4173; tabUnc = 0.014;
     }
   }
-
+  
   // pPb Glauber (A. Toia)
   // https://twiki.cern.ch/twiki/bin/viewauth/ALICE/PACentStudies#Glauber_Calculations_with_sigma
   if( cc == kpPb0100 ){
@@ -182,12 +182,12 @@ void HFPtSpectrum ( Int_t decayChan=kDplusKpipi,
       tab = 0.0369; tabUnc = 0.0085;
     }
   }
-
+  
   tab *= 1e-9; // to pass from mb^{-1} to pb^{-1}
   tabUnc *= 1e-9;
-
-
-
+  
+  
+  
   //
   // Get the histograms from the files
   //
@@ -201,7 +201,7 @@ void HFPtSpectrum ( Int_t decayChan=kDplusKpipi,
   TH1D *hDirectEffpt=0;          // c-->D Acceptance and efficiency correction
   TH1D *hFeedDownEffpt=0;        // b-->D Acceptance and efficiency correction
   TH1D *hRECpt=0;                // all reconstructed D
-
+  
   //
   // Define/Get the input histograms
   //
@@ -312,7 +312,7 @@ void HFPtSpectrum ( Int_t decayChan=kDplusKpipi,
     hFeedDownMCptMax->Scale(scaleFONLL);
     hFeedDownMCptMin->Scale(scaleFONLL);
   }
-
+  
   //
   //
   if(gSystem->Exec(Form("ls -l %s > /dev/null 2>&1",recofilename)) !=0){
@@ -368,7 +368,7 @@ void HFPtSpectrum ( Int_t decayChan=kDplusKpipi,
       hRECpt->SetBinError(i,error);
     }
   }
-
+  
   //
   // Define the output histograms
   //
@@ -399,21 +399,21 @@ void HFPtSpectrum ( Int_t decayChan=kDplusKpipi,
   TGraphAsymmErrors * gSigmaCorrConservative = 0;
   //
   TNtuple * nSigma = 0;
-
-
+  
+  
   //
   // Main functionalities for the calculation
   //
-
+  
   // Define and set the basic option flags
   AliHFPtSpectrum * spectra = new AliHFPtSpectrum("AliHFPtSpectrum","AliHFPtSpectrum",option);
   spectra->SetFeedDownCalculationOption(option);
   spectra->SetComputeAsymmetricUncertainties(asym);
   // Set flag on whether to additional PbPb Eloss hypothesis have to be computed
   spectra->SetComputeElossHypothesis(PbPbEloss);
-
+  
   spectra->SetUsePtDependentEffUncertainty(setUsePtDependentEffUncertainty);
-
+  
   // Feed the input histograms
   //  reconstructed spectra
   cout << " Setting the reconstructed spectrum,";
@@ -432,7 +432,7 @@ void HFPtSpectrum ( Int_t decayChan=kDplusKpipi,
     spectra->SetFeedDownMCptSpectra(hFeedDownMCpt);
     if(asym) spectra->SetFeedDownMCptDistributionsBounds(hFeedDownMCptMax,hFeedDownMCptMin);
   }
-
+  
   cout << " and the normalization" <<endl;
   // Set normalization factors (uncertainties set to 0. as example)
   spectra->SetNormalization(nevents,sigma);
@@ -442,16 +442,16 @@ void HFPtSpectrum ( Int_t decayChan=kDplusKpipi,
   Double_t effTrig = 1.0;
   spectra->SetTriggerEfficiency(effTrig,0.);
   if(isRaavsEP>0.) spectra->SetIsEventPlaneAnalysis(kTRUE);
-
+  
   // Set the global uncertainties on the efficiencies (in percent)
   Double_t globalEffUnc = 0.05;
   Double_t globalBCEffRatioUnc = 0.05;
   if(analysisSpeciality==kLowPt) globalBCEffRatioUnc = 0.;
   spectra->SetAccEffPercentageUncertainty(globalEffUnc,globalBCEffRatioUnc);
-
+  
   // Set if the yield is for particle+anti-particle or only one type
   spectra->SetIsParticlePlusAntiParticleYield(isParticlePlusAntiParticleYield);
-
+  
   // Set the Tab parameter and uncertainties
   if ( (cc != kpp7) && (cc != kpp8) && (cc != kpp276) && (cc != kpp5) ) {
     spectra->SetTabParameter(tab,tabUnc);
@@ -461,9 +461,9 @@ void HFPtSpectrum ( Int_t decayChan=kDplusKpipi,
   } else if ( !( cc==kpp7 || cc==kpp8 || cc==kpp276 || cc==kpp5 ) ) {
     spectra->SetCollisionType(1);
   }
-
+  
   // Set the systematics externally
-
+  
   Bool_t combineFeedDown = true;
   AliHFSystErr *systematics = new AliHFSystErr();
   if(year==k2010) systematics->SetRunNumber(10);
@@ -487,20 +487,20 @@ void HFPtSpectrum ( Int_t decayChan=kDplusKpipi,
   }
   else if ( cc == kpPb0100 || cc == kpPb010 || cc == kpPb020 || cc == kpPb1020 || cc == kpPb2040 || cc == kpPb4060 || cc == kpPb60100 ) {
     systematics->SetCollisionType(2);
-
+    
     // Rapidity slices
     if(rapiditySlice!=kdefault){
       systematics->SetIspPb2011RapidityScan(true);
       TString rapidity="";
       switch(rapiditySlice) {
-          case k08to04: rapidity="0804"; break;
-          case k07to04: rapidity="0804"; break;
-          case k04to01: rapidity="0401"; break;
-          case k01to01: rapidity="0101"; break;
-          case k01to04: rapidity="0104"; break;
-          case k04to07: rapidity="0408"; break;
-          case k04to08: rapidity="0408"; break;
-          case k01to05: rapidity="0401"; break;
+        case k08to04: rapidity="0804"; break;
+        case k07to04: rapidity="0804"; break;
+        case k04to01: rapidity="0401"; break;
+        case k01to01: rapidity="0101"; break;
+        case k01to04: rapidity="0104"; break;
+        case k04to07: rapidity="0408"; break;
+        case k04to08: rapidity="0408"; break;
+        case k01to05: rapidity="0401"; break;
       }
       systematics->SetRapidity(rapidity);
     }
@@ -524,8 +524,8 @@ void HFPtSpectrum ( Int_t decayChan=kDplusKpipi,
       else if(cc == kpPb60100) systematics->SetCentrality("60100CL1");
     } else {
       if(!(cc == kpPb0100)) {
-	cout <<" Error on the pPb options"<<endl;
-	return;
+        cout <<" Error on the pPb options"<<endl;
+        return;
       }
     }
   }
@@ -533,22 +533,22 @@ void HFPtSpectrum ( Int_t decayChan=kDplusKpipi,
   else if( cc!=kpp7 )  {
     systematics->SetCollisionType(1);
     if(Energy==k276){
-        if ( cc == k07half ) systematics->SetCentrality("07half");
-        else if ( cc == k010 )  systematics->SetCentrality("010");
-				else if ( cc == k1020 )  systematics->SetCentrality("1020");
-        else if ( cc == k020 )  systematics->SetCentrality("020");
-        else if ( cc == k2040 || cc == k2030 || cc == k3040 ) {
-            systematics->SetCentrality("2040");
-            systematics->SetIsPbPb2010EnergyScan(true);
-        }
-        else if ( cc == k3050 ) {
-            if (isRaavsEP == kPhiIntegrated) systematics->SetCentrality("4080");
-            else if (isRaavsEP == kInPlane) systematics->SetCentrality("3050InPlane");
-            else if (isRaavsEP == kOutOfPlane) systematics->SetCentrality("3050OutOfPlane");
-        }
-        else if ( cc == k4060 || cc == k4050 || cc == k5060 )  systematics->SetCentrality("4060");
-        else if ( cc == k6080 )  systematics->SetCentrality("6080");
-        else if ( cc == k4080 ) systematics->SetCentrality("4080");
+      if ( cc == k07half ) systematics->SetCentrality("07half");
+      else if ( cc == k010 )  systematics->SetCentrality("010");
+      else if ( cc == k1020 )  systematics->SetCentrality("1020");
+      else if ( cc == k020 )  systematics->SetCentrality("020");
+      else if ( cc == k2040 || cc == k2030 || cc == k3040 ) {
+        systematics->SetCentrality("2040");
+        systematics->SetIsPbPb2010EnergyScan(true);
+      }
+      else if ( cc == k3050 ) {
+        if (isRaavsEP == kPhiIntegrated) systematics->SetCentrality("4080");
+        else if (isRaavsEP == kInPlane) systematics->SetCentrality("3050InPlane");
+        else if (isRaavsEP == kOutOfPlane) systematics->SetCentrality("3050OutOfPlane");
+      }
+      else if ( cc == k4060 || cc == k4050 || cc == k5060 )  systematics->SetCentrality("4060");
+      else if ( cc == k6080 )  systematics->SetCentrality("6080");
+      else if ( cc == k4080 ) systematics->SetCentrality("4080");
     } else if (Energy==k5dot023){
       if ( cc == k010 ){
         systematics->SetCentrality("010");
@@ -577,7 +577,7 @@ void HFPtSpectrum ( Int_t decayChan=kDplusKpipi,
   //
   systematics->Init(decay);
   spectra->SetSystematicUncertainty(systematics);
-
+  
   // Do the calculations
   cout << " Doing the calculation... "<< endl;
   Double_t deltaY = 1.0;
@@ -586,9 +586,9 @@ void HFPtSpectrum ( Int_t decayChan=kDplusKpipi,
   spectra->ComputeHFPtSpectrum(deltaY,branchingRatioC,branchingRatioBintoFinalDecay);
   spectra->ComputeSystUncertainties(combineFeedDown);
   cout << "   ended the calculation, getting the histograms back " << endl;
-
-
-
+  
+  
+  
   //
   // Get the output histograms
   //
@@ -617,7 +617,7 @@ void HFPtSpectrum ( Int_t decayChan=kDplusKpipi,
     histoYieldCorrRcb->SetName("histoYieldCorrRcb");
     histoSigmaCorrRcb->SetName("histoSigmaCorrRcb");
   }
-
+  
   // Get & Rename the TGraphs
   gSigmaCorr = spectra->GetCrossSectionFromYieldSpectrum();
   gYieldCorr = spectra->GetFeedDownCorrectedSpectrum();
@@ -627,7 +627,7 @@ void HFPtSpectrum ( Int_t decayChan=kDplusKpipi,
     gSigmaCorrConservative = spectra->GetCrossSectionFromYieldSpectrumConservative();
     gYieldCorrConservative = spectra->GetFeedDownCorrectedSpectrumConservative();
   }
-
+  
   // Get & Rename the TGraphs
   if (option==0){
     gYieldCorr->SetNameTitle("gYieldCorr","gYieldCorr (uncorr)");
@@ -664,22 +664,22 @@ void HFPtSpectrum ( Int_t decayChan=kDplusKpipi,
     gFcConservative = spectra->GetFeedDownCorrectionFcConservative();
     gFcConservative->SetNameTitle("gFcConservative","gFcConservative");
   }
-
+  
   if(PbPbEloss){
     nSigma = spectra->GetNtupleCrossSectionVsEloss();
   }
-
+  
   //
   // Now, plot the results ! :)
   //
-
+  
   gROOT->SetStyle("Plain");
-
+  
   cout << " Drawing the results ! " << endl;
-
+  
   // control plots
   if (option==1) {
-
+    
     TCanvas *ceff = new TCanvas("ceff","efficiency drawing");
     ceff->Divide(1,2);
     ceff->cd(1);
@@ -687,7 +687,7 @@ void HFPtSpectrum ( Int_t decayChan=kDplusKpipi,
     ceff->cd(2);
     hFeedDownEffpt->Draw();
     ceff->Update();
-
+    
     TCanvas *cTheoryRebin = new TCanvas("cTheoryRebin","control the theoretical spectra rebin");
     cTheoryRebin->Divide(1,2);
     cTheoryRebin->cd(1);
@@ -701,7 +701,7 @@ void HFPtSpectrum ( Int_t decayChan=kDplusKpipi,
     hFeedDownRebin->SetLineColor(2);
     hFeedDownRebin->Draw("same");
     cTheoryRebin->Update();
-
+    
     TCanvas *cTheoryRebinLimits = new TCanvas("cTheoryRebinLimits","control the theoretical spectra limits rebin");
     cTheoryRebinLimits->Divide(1,2);
     cTheoryRebinLimits->cd(1);
@@ -724,15 +724,15 @@ void HFPtSpectrum ( Int_t decayChan=kDplusKpipi,
     hFeedDownMinRebin->Draw("same");
     cTheoryRebinLimits->Update();
   }
-
+  
   if (option==1) {
-
+    
     TCanvas * cfc = new TCanvas("cfc","Fc");
     histofcMax->Draw("c");
     histofc->Draw("csame");
     histofcMin->Draw("csame");
     cfc->Update();
-
+    
     if (asym) {
       TH2F *histofcDraw= new TH2F("histofcDraw","histofc (for drawing)",100,0,33.25,100,0.01,1.25);
       histofcDraw->SetStats(0);
@@ -741,43 +741,43 @@ void HFPtSpectrum ( Int_t decayChan=kDplusKpipi,
       histofcDraw->GetXaxis()->SetTitleOffset(0.95);
       histofcDraw->GetYaxis()->SetTitle(" fc ");
       histofcDraw->GetYaxis()->SetTitleSize(0.05);
-
+      
       if (gFcExtreme){
-
-// 	for(Int_t item=0; item<gSigmaCorr->GetN(); item++){
-// 	  Double_t center=0., value=0.;
-// 	  gFcExtreme->GetPoint(item,center,value);
-// 	  Double_t highunc = gFcExtreme->GetErrorYhigh(item) / value ;
-// 	  Double_t lowunc = gFcExtreme->GetErrorYlow(item) / value ;
-// 	  cout << "Fc extreme: i=" << item << ", center=" << center <<", value=" << value << " high unc=" << highunc*100 << "%, low unc=" << lowunc*100 << "%"<<endl;
-// 	}
-// 	for(Int_t item=0; item<gSigmaCorr->GetN(); item++){
-// 	  Double_t center=0., value=0.;
-// 	  gFcConservative->GetPoint(item,center,value);
-// 	  Double_t highunc = gFcConservative->GetErrorYhigh(item) / value ;
-// 	  Double_t lowunc = gFcConservative->GetErrorYlow(item) / value ;
-// 	  cout << "Fc conservative: i=" << item << ", center=" << center <<", value=" << value << " high unc=" << highunc*100 << "%, low unc=" << lowunc*100 << "%"<<endl;
-// 	}
-	TCanvas *cfcExtreme = new TCanvas("cfcExtreme","Extreme Asymmetric fc (TGraphAsymmErr)");
-	gFcExtreme->SetFillStyle(3006);
-	gFcExtreme->SetLineWidth(3);
-	gFcExtreme->SetMarkerStyle(20);
-	gFcExtreme->SetFillColor(2);
-	histofcDraw->Draw();
-	gFcExtreme->Draw("3same");
-
-	if(gFcConservative){
-	  gFcConservative->SetFillStyle(3007);
-	  gFcConservative->SetFillColor(4);
-	  gFcConservative->Draw("3same");
-	}
-
-	cfcExtreme->Update();
+        
+        // 	for(Int_t item=0; item<gSigmaCorr->GetN(); item++){
+        // 	  Double_t center=0., value=0.;
+        // 	  gFcExtreme->GetPoint(item,center,value);
+        // 	  Double_t highunc = gFcExtreme->GetErrorYhigh(item) / value ;
+        // 	  Double_t lowunc = gFcExtreme->GetErrorYlow(item) / value ;
+        // 	  cout << "Fc extreme: i=" << item << ", center=" << center <<", value=" << value << " high unc=" << highunc*100 << "%, low unc=" << lowunc*100 << "%"<<endl;
+        // 	}
+        // 	for(Int_t item=0; item<gSigmaCorr->GetN(); item++){
+        // 	  Double_t center=0., value=0.;
+        // 	  gFcConservative->GetPoint(item,center,value);
+        // 	  Double_t highunc = gFcConservative->GetErrorYhigh(item) / value ;
+        // 	  Double_t lowunc = gFcConservative->GetErrorYlow(item) / value ;
+        // 	  cout << "Fc conservative: i=" << item << ", center=" << center <<", value=" << value << " high unc=" << highunc*100 << "%, low unc=" << lowunc*100 << "%"<<endl;
+        // 	}
+        TCanvas *cfcExtreme = new TCanvas("cfcExtreme","Extreme Asymmetric fc (TGraphAsymmErr)");
+        gFcExtreme->SetFillStyle(3006);
+        gFcExtreme->SetLineWidth(3);
+        gFcExtreme->SetMarkerStyle(20);
+        gFcExtreme->SetFillColor(2);
+        histofcDraw->Draw();
+        gFcExtreme->Draw("3same");
+        
+        if(gFcConservative){
+          gFcConservative->SetFillStyle(3007);
+          gFcConservative->SetFillColor(4);
+          gFcConservative->Draw("3same");
+        }
+        
+        cfcExtreme->Update();
       }
     }
-
+    
   }
-
+  
   //
   // Drawing the results (the raw-reconstructed, the expected, and the corrected spectra)
   //
@@ -796,7 +796,7 @@ void HFPtSpectrum ( Int_t decayChan=kDplusKpipi,
   hRECpt->Draw("psame");
   cresult->SetLogy();
   cresult->Update();
-
+  
   TCanvas * cresult2 = new TCanvas("cresult2","corrected yield & sigma");
   histoSigmaCorr->SetMarkerStyle(21);
   histoSigmaCorr->SetMarkerColor(2);
@@ -809,10 +809,10 @@ void HFPtSpectrum ( Int_t decayChan=kDplusKpipi,
   hRECpt->Draw("psame");
   cresult2->SetLogy();
   cresult2->Update();
-
-
+  
+  
   if (asym) {
-
+    
     TH2F *histoDraw = new TH2F("histoDraw","histo (for drawing)",100,0,33.25,100,50.,1e7);
     float max = 1.1*gYieldCorr->GetMaximum();
     histoDraw->SetAxisRange(0.1,max,"Y");
@@ -832,7 +832,7 @@ void HFPtSpectrum ( Int_t decayChan=kDplusKpipi,
     gYieldCorr->Draw("Xsame");
     cyieldAsym->SetLogy();
     cyieldAsym->Update();
-
+    
     TCanvas * cyieldExtreme = new TCanvas("cyieldExtreme","Extreme Asymmetric corrected yield (TGraphAsymmErr)");
     histoYieldCorr->Draw();
     gYieldCorrExtreme->SetFillStyle(3002);
@@ -844,7 +844,7 @@ void HFPtSpectrum ( Int_t decayChan=kDplusKpipi,
     gYieldCorrExtreme->Draw("3same");
     cyieldExtreme->SetLogy();
     cyieldExtreme->Update();
-
+    
     TH2F *histo2Draw = new TH2F("histo2Draw","histo2 (for drawing)",100,0,33.25,100,50.,1e9);
     max = 1.1*gSigmaCorr->GetMaximum();
     histo2Draw->SetAxisRange(0.1,max,"Y");
@@ -864,16 +864,16 @@ void HFPtSpectrum ( Int_t decayChan=kDplusKpipi,
     gSigmaCorr->Draw("Xsame");
     csigmaAsym->SetLogy();
     csigmaAsym->Update();
-
-//     cout << endl <<" Sytematics (stat approach) " <<endl;
-//     for(Int_t item=0; item<gSigmaCorr->GetN(); item++){
-//       Double_t center=0., value=0.;
-//       gSigmaCorr->GetPoint(item,center,value);
-//       Double_t highunc = gSigmaCorr->GetErrorYhigh(item) / value ;
-//       Double_t lowunc = gSigmaCorr->GetErrorYlow(item) / value ;
-//       cout << "Sigma syst (stat), i=" << item << ", center=" << center <<", value=" << value << " high unc=" << highunc*100 << "%, low unc=" << lowunc*100 << "%"<<endl;
-//     }
-
+    
+    //     cout << endl <<" Sytematics (stat approach) " <<endl;
+    //     for(Int_t item=0; item<gSigmaCorr->GetN(); item++){
+    //       Double_t center=0., value=0.;
+    //       gSigmaCorr->GetPoint(item,center,value);
+    //       Double_t highunc = gSigmaCorr->GetErrorYhigh(item) / value ;
+    //       Double_t lowunc = gSigmaCorr->GetErrorYlow(item) / value ;
+    //       cout << "Sigma syst (stat), i=" << item << ", center=" << center <<", value=" << value << " high unc=" << highunc*100 << "%, low unc=" << lowunc*100 << "%"<<endl;
+    //     }
+    
     TCanvas * csigmaExtreme = new TCanvas("csigmaExtreme","Asymmetric extreme corrected sigma (TGraphAsymmErr)");
     histoSigmaCorr->Draw();
     gSigmaCorr->Draw("3Psame");
@@ -884,27 +884,27 @@ void HFPtSpectrum ( Int_t decayChan=kDplusKpipi,
     gSigmaCorrExtreme->Draw("3Psame");
     csigmaExtreme->SetLogy();
     csigmaExtreme->Update();
-
-//     cout << endl << " Sytematics (Extreme approach)" <<endl;
-//     for(Int_t item=0; item<gSigmaCorrExtreme->GetN(); item++){
-//       Double_t center=0., value=0.;
-//       gSigmaCorrExtreme->GetPoint(item,center,value);
-//       Double_t highunc = gSigmaCorrExtreme->GetErrorYhigh(item) / value ;
-//       Double_t lowunc = gSigmaCorrExtreme->GetErrorYlow(item) / value ;
-//       cout << "Sigma syst (extreme) i=" << item << ", center=" << center <<", value=" << value << " high unc=" << highunc*100 << "%, low unc=" << lowunc*100 << "%"<<endl;
-//     }
-
-//     cout << endl << " Sytematics (Conservative approach)" <<endl;
-//     for(Int_t item=0; item<gSigmaCorrConservative->GetN(); item++){
-//       Double_t center=0., value=0.;
-//       gSigmaCorrConservative->GetPoint(item,center,value);
-//       Double_t highunc = gSigmaCorrConservative->GetErrorYhigh(item) / value ;
-//       Double_t lowunc = gSigmaCorrConservative->GetErrorYlow(item) / value ;
-//       cout << "Sigma syst (conservative) i=" << item << ", center=" << center <<", value=" << value << " high unc=" << highunc*100 << "%, low unc=" << lowunc*100 << "%"<<endl;
-//     }
-
- }
-
+    
+    //     cout << endl << " Sytematics (Extreme approach)" <<endl;
+    //     for(Int_t item=0; item<gSigmaCorrExtreme->GetN(); item++){
+    //       Double_t center=0., value=0.;
+    //       gSigmaCorrExtreme->GetPoint(item,center,value);
+    //       Double_t highunc = gSigmaCorrExtreme->GetErrorYhigh(item) / value ;
+    //       Double_t lowunc = gSigmaCorrExtreme->GetErrorYlow(item) / value ;
+    //       cout << "Sigma syst (extreme) i=" << item << ", center=" << center <<", value=" << value << " high unc=" << highunc*100 << "%, low unc=" << lowunc*100 << "%"<<endl;
+    //     }
+    
+    //     cout << endl << " Sytematics (Conservative approach)" <<endl;
+    //     for(Int_t item=0; item<gSigmaCorrConservative->GetN(); item++){
+    //       Double_t center=0., value=0.;
+    //       gSigmaCorrConservative->GetPoint(item,center,value);
+    //       Double_t highunc = gSigmaCorrConservative->GetErrorYhigh(item) / value ;
+    //       Double_t lowunc = gSigmaCorrConservative->GetErrorYlow(item) / value ;
+    //       cout << "Sigma syst (conservative) i=" << item << ", center=" << center <<", value=" << value << " high unc=" << highunc*100 << "%, low unc=" << lowunc*100 << "%"<<endl;
+    //     }
+    
+  }
+  
   // Draw the PbPb Eloss hypothesis histograms
   if(PbPbEloss){
     AliHFPtSpectrum *CalcBins=NULL;
@@ -1031,13 +1031,13 @@ void HFPtSpectrum ( Int_t decayChan=kDplusKpipi,
     legrcb->Draw();
     canvasSRcb1->Update();
   }
-
-
+  
+  
   //
   // Write the histograms to the output file
   //
   cout << " Saving the results ! " << endl<< endl;
-
+  
   out->cd();
   //
   hDirectMCpt->Write();        hFeedDownMCpt->Write();
@@ -1050,14 +1050,14 @@ void HFPtSpectrum ( Int_t decayChan=kDplusKpipi,
   histoYieldCorrMax->Write();     histoYieldCorrMin->Write();
   histoSigmaCorr->Write();
   histoSigmaCorrMax->Write();     histoSigmaCorrMin->Write();
-
+  
   if(PbPbEloss){
     histofcRcb->Write();    histofcRcb_px->Write();
     histoYieldCorrRcb->Write();
     histoSigmaCorrRcb->Write();
     nSigma->Write();
   }
-
+  
   gYieldCorr->Write();
   gSigmaCorr->Write();
   if(asym){
@@ -1067,14 +1067,14 @@ void HFPtSpectrum ( Int_t decayChan=kDplusKpipi,
     if(gSigmaCorrConservative) gSigmaCorrConservative->Write();
     if(asym && gFcConservative) gFcConservative->Write();
   }
-
+  
   if(option==1){
     histofc->Write();
     histofcMax->Write();     histofcMin->Write();
     if(asym && gFcExtreme) gFcExtreme->Write();
   }
-
-
+  
+  
   TH1D * hStatUncEffcSigma = spectra->GetDirectStatEffUncOnSigma();
   TH1D * hStatUncEffbSigma = spectra->GetFeedDownStatEffUncOnSigma();
   hStatUncEffcSigma->Write();
@@ -1086,12 +1086,12 @@ void HFPtSpectrum ( Int_t decayChan=kDplusKpipi,
     hStatUncEffbFD->Write();
   }
   systematics->Write();
-
+  
   // Draw the cross-section
   //  spectra->DrawSpectrum(gPrediction);
-
-    out->Close();
-    recofile->Close();
-    efffile->Close();
-    mcfile->Close();
+  
+  out->Close();
+  recofile->Close();
+  efffile->Close();
+  mcfile->Close();
 }

--- a/machine_learning_hep/HFPtSpectrum2.C
+++ b/machine_learning_hep/HFPtSpectrum2.C
@@ -1,0 +1,288 @@
+#if !defined(__CINT__) || defined(__MAKECINT__)
+#include <Riostream.h>
+#include "TH1D.h"
+#include "TH1.h"
+#include "TH2F.h"
+#include "TNtuple.h"
+#include "TFile.h"
+#include "TSystem.h"
+#include "TGraphAsymmErrors.h"
+#include "TCanvas.h"
+#include "TROOT.h"
+#include "TStyle.h"
+#include "TLegend.h"
+#include "AliHFSystErr.h"
+#endif
+
+//
+// Macro to use mimic AliHFPtSpectrum class using HFPtSpectrum file as input
+// used for high multiplicity analyses where fPrompt calculation with Nb 
+// method fails due to multiplicity-independent FONLL prediction.
+//
+// Besides using the fPrompt fraction from the input file, also the syst.
+// errors (AliHFSystErr class) is copied.
+//
+// NB: So far only works for pp, using Nb method.
+//
+
+void HFPtSpectrum2 (const char *inputCrossSection, 
+                    const char *efffilename="Efficiencies.root",
+                    const char *nameeffprompt= "eff",
+                    const char *nameefffeed = "effB",
+                    const char *recofilename="Reconstructed.root",
+                    const char *recohistoname="hRawSpectrumD0",
+                    const char *outfilename="HFPtSpectrum.root",
+                    Double_t nevents=1.0, // overriden by nevhistoname
+                    Double_t sigma=1.0, // sigma[pb]
+                    Bool_t isParticlePlusAntiParticleYield=true,
+                    Bool_t setUsePtDependentEffUncertainty=true,
+                    const char *nevhistoname="hNEvents"){
+
+  //
+  // Get the histograms from the files
+  //
+  TH1D *hDirectMCpt=0;           // Input MC c-->D spectra
+  TH1D *hFeedDownMCpt=0;         // Input MC b-->D spectra
+  TH1D *hDirectMCptMax=0;        // Input MC maximum c-->D spectra
+  TH1D *hDirectMCptMin=0;        // Input MC minimum c-->D spectra
+  TH1D *hFeedDownMCptMax=0;      // Input MC maximum b-->D spectra
+  TH1D *hFeedDownMCptMin=0;      // Input MC minimum b-->D spectra
+  TGraphAsymmErrors * gFcConservative = 0; // Input fPrompt fraction
+  AliHFSystErr * systematics = 0;
+
+  TH1D *hDirectEffpt=0;          // c-->D Acceptance and efficiency correction
+  TH1D *hFeedDownEffpt=0;        // b-->D Acceptance and efficiency correction
+  TH1D *hRECpt=0;                // all reconstructed D
+
+  //
+  // Get theory predictions from cross section file for f_prompt
+  //
+  if(gSystem->Exec(Form("ls -l %s > /dev/null 2>&1",inputCrossSection)) !=0){
+    printf("File %s with input fPrompt does not exist -> exiting\n",inputCrossSection);
+    return;
+  }
+  TFile* inputcrossfile = new TFile(inputCrossSection,"read");
+  if(!inputcrossfile){
+    printf("File %s with input fPrompt not opened -> exiting\n",inputCrossSection);
+    return;
+  }
+
+  hDirectMCpt = (TH1D*)inputcrossfile->Get("hDirectMCpt");
+  hFeedDownMCpt = (TH1D*)inputcrossfile->Get("hFeedDownMCpt");
+  hDirectMCptMax = (TH1D*)inputcrossfile->Get("hDirectMCptMax");
+  hDirectMCptMin = (TH1D*)inputcrossfile->Get("hDirectMCptMin");
+  hFeedDownMCptMax = (TH1D*)inputcrossfile->Get("hFeedDownMCptMax");
+  hFeedDownMCptMin = (TH1D*)inputcrossfile->Get("hFeedDownMCptMin");
+  gFcConservative = (TGraphAsymmErrors*)inputcrossfile->Get("gFcConservative");
+  systematics = (AliHFSystErr*)inputcrossfile->Get("AliHFSystErr");
+
+  //
+  // Get efficiencies for cross section calculation
+  //
+  if(gSystem->Exec(Form("ls -l %s > /dev/null 2>&1",efffilename)) !=0){
+    printf("File %s with efficiencies does not exist -> exiting\n",efffilename);
+    return;
+  }
+  TFile * efffile = new TFile(efffilename,"read");
+  if(!efffile){
+    printf("File %s with efficiencies not opened -> exiting\n",efffilename);
+    return;
+  }
+  hDirectEffpt = (TH1D*)efffile->Get(nameeffprompt);
+  hDirectEffpt->SetNameTitle("hDirectEffpt","direct acc x eff");
+  hFeedDownEffpt = (TH1D*)efffile->Get(nameefffeed);
+  hFeedDownEffpt->SetNameTitle("hFeedDownEffpt","feed-down acc x eff");
+
+  //
+  // Get raw yield for cross section calculation
+  //
+  if(gSystem->Exec(Form("ls -l %s > /dev/null 2>&1",recofilename)) !=0){
+    printf("File %s with raw yield does not exist -> exiting\n",recofilename);
+    return;
+  }
+  TFile * recofile = new TFile(recofilename,"read");
+  if(!recofile){
+    printf("File %s with raw yields not opened -> exiting\n",recofilename);
+    return;
+  }
+  hRECpt = (TH1D*)recofile->Get(recohistoname);
+  hRECpt->SetNameTitle("hRECpt","Reconstructed spectra");
+
+  //
+  // Get (corrected) number of analysd events for cross section calculation
+  //
+  TH1F* hNorm=(TH1F*)recofile->Get(nevhistoname);
+  if(hNorm){
+    nevents=hNorm->GetBinContent(1);
+  }else{
+    printf("Histogram with number of events for norm not found in raw yiled file\n");
+    printf("  nevents = %.0f will be used\n",nevents);
+  }
+
+  Int_t fnPtBins = hRECpt->GetNbinsX();
+  Double_t *fPtBinLimits = new Double_t[fnPtBins+1];
+  Double_t *fPtBinWidths = new Double_t[fnPtBins];
+  Double_t xlow=0., binwidth=0.;
+  for(Int_t i=1; i<fnPtBins; i++){
+    binwidth = hRECpt->GetBinWidth(i);
+    xlow = hRECpt->GetBinLowEdge(i);
+    fPtBinLimits[i-1] = xlow;
+    fPtBinWidths[i-1] = binwidth;
+  }
+  fPtBinLimits[fnPtBins] = xlow + binwidth;
+
+  //
+  // Define the remaining output histograms to be calculated here
+  //
+  TH1D *histoYieldCorr = new TH1D("histoYieldCorr","corrected yield",fnPtBins,fPtBinLimits);
+  TH1D *histoYieldCorrMax = new TH1D("histoYieldCorrMax","max corrected yield (no feed-down corr)",fnPtBins,fPtBinLimits);
+  TH1D *histoYieldCorrMin = new TH1D("histoYieldCorrMin","min corrected yield",fnPtBins,fPtBinLimits);
+  TGraphAsymmErrors * gYieldCorr = new TGraphAsymmErrors(fnPtBins+1);
+  TGraphAsymmErrors * gYieldCorrExtreme = new TGraphAsymmErrors(fnPtBins+1);
+  TGraphAsymmErrors * gYieldCorrConservative = new TGraphAsymmErrors(fnPtBins+1);
+  gYieldCorr->SetNameTitle("gYieldCorr","gYieldCorr (by Nb)");
+  gYieldCorrExtreme->SetNameTitle("gYieldCorrExtreme","Extreme gYieldCorr (by Nb)");
+  gYieldCorrConservative->SetNameTitle("gYieldCorrConservative","Conservative gYieldCorr (by Nb)");
+
+  TH1D *histoSigmaCorr = new TH1D("histoSigmaCorr","corrected invariant cross-section",fnPtBins,fPtBinLimits);
+  TH1D *histoSigmaCorrMax = new TH1D("histoSigmaCorrMax","max corrected invariant cross-section",fnPtBins,fPtBinLimits);
+  TH1D *histoSigmaCorrMin = new TH1D("histoSigmaCorrMin","min corrected invariant cross-section",fnPtBins,fPtBinLimits);
+  TGraphAsymmErrors * gSigmaCorr = new TGraphAsymmErrors(fnPtBins+1);
+  TGraphAsymmErrors * gSigmaCorrExtreme = new TGraphAsymmErrors(fnPtBins+1);
+  TGraphAsymmErrors * gSigmaCorrConservative = new TGraphAsymmErrors(fnPtBins+1);
+  gSigmaCorr->SetNameTitle("gSigmaCorr","gSigmaCorr (by Nb)");
+  gSigmaCorrExtreme->SetNameTitle("gSigmaCorrExtreme","Extreme gSigmaCorr (by Nb)");
+  gSigmaCorrConservative->SetNameTitle("gSigmaCorrConservative","Conservative gSigmaCorr (by Nb)");
+
+  // NB: Don't care for the moment about fhStatUncEffc/bSigma fhStatUncEffc/bFD
+  TH1D *hStatUncEffcSigma = new TH1D("fhStatUncEffcSigma","direct charm stat unc on the cross section",fnPtBins,fPtBinLimits);
+  TH1D *hStatUncEffbSigma = new TH1D("fhStatUncEffbSigma","secondary charm stat unc on the cross section",fnPtBins,fPtBinLimits);
+  TH1D *hStatUncEffcFD = new TH1D("fhStatUncEffcFD","direct charm stat unc on the feed-down correction",fnPtBins,fPtBinLimits);
+  TH1D *hStatUncEffbFD = new TH1D("fhStatUncEffbFD","secondary charm stat unc on the feed-down correction",fnPtBins,fPtBinLimits);
+
+  //
+  // Do the corrected yield calculation.
+  // NB: Don't care for the moment about histoYieldCorrMin/Max gYieldCorrExtreme/Conservative
+  // 
+  Double_t value = 0., errvalue = 0., errvalueMax = 0., errvalueMin = 0.;
+  for (Int_t ibin=1; ibin<=fnPtBins; ibin++) {
+    // Calculate the value
+    //    physics =  [ reco  - (lumi * delta_y * BR_b * eff_trig * eff_b * Nb_th) ] / bin-width
+    //            =    reco * fprompt_NB
+    Double_t frac = 1.0, errfrac =0.;
+
+    // Variables initialization
+    value = 0.; errvalue = 0.; errvalueMax = 0.; errvalueMin = 0.;
+
+    // Get fPrompt from input value
+    Double_t x = 0., correction = 0;
+    gFcConservative->GetPoint(ibin,x,correction);
+
+    // Calculate corrected yield (= raw yield * fprompt)
+    if( hRECpt->GetBinContent(ibin)>0. && hRECpt->GetBinContent(ibin)!=0. && hFeedDownMCpt->GetBinContent(ibin)>0. && hFeedDownEffpt->GetBinContent(ibin)>0. ) value = hRECpt->GetBinContent(ibin) * correction;
+    value /= hRECpt->GetBinWidth(ibin);
+    if (value<0.) value =0.;
+
+    //  Statistical uncertainty:   delta_physics = sqrt ( (delta_reco)^2 )  / bin-width
+    if (value!=0. && hRECpt->GetBinError(ibin) && hRECpt->GetBinError(ibin)!=0.) errvalue = hRECpt->GetBinError(ibin);
+    errvalue /= hRECpt->GetBinWidth(ibin);
+
+    histoYieldCorr->SetBinContent(ibin,value);
+    histoYieldCorr->SetBinError(ibin,errvalue);
+    gYieldCorr->SetPoint(ibin,x,value);
+    gYieldCorr->SetPointError(ibin,(fPtBinWidths[ibin-1]/2.),(fPtBinWidths[ibin-1]/2.),errvalueMin,errvalueMax);
+
+  }
+
+  //
+  // Do the corrected sigma calculation.
+  // NB: Don't care for the moment about histoSigmaCorrMin/Max and gSigmaCorrExtreme/Conservative
+  // 
+  Double_t fLuminosity[2] = {nevents / sigma, 0.04 * nevents / sigma};
+  Double_t fTrigEfficiency[2] = {1.0, 0};
+  Double_t fGlobalEfficiencyUncertainties[2] = {0.05, 0.05};
+  Double_t deltaY = 1.0;
+  Double_t branchingRatioC = 1.0;
+  Double_t branchingRatioBintoFinalDecay = 1.0;
+  Bool_t fGlobalEfficiencyPtDependent = setUsePtDependentEffUncertainty;
+  Int_t fParticleAntiParticle = 1;
+  if( isParticlePlusAntiParticleYield ) fParticleAntiParticle = 2;
+  printf("\n\n     Correcting the spectra with : \n   luminosity = %2.2e +- %2.2e, trigger efficiency = %2.2e +- %2.2e, \n    delta_y = %2.2f, BR_c = %2.2e, BR_b_decay = %2.2e \n    %2.2f percent uncertainty on the efficiencies, and %2.2f percent uncertainty on the b/c efficiencies ratio \n    usage of pt-dependent efficiency uncertainty for Nb uncertainy calculation? %1.0d \n\n",fLuminosity[0],fLuminosity[1],fTrigEfficiency[0],fTrigEfficiency[1],deltaY,branchingRatioC,branchingRatioBintoFinalDecay,fGlobalEfficiencyUncertainties[0],fGlobalEfficiencyUncertainties[1],fGlobalEfficiencyPtDependent);
+
+  // protect against null denominator
+  if (deltaY==0. || fLuminosity[0]==0. || fTrigEfficiency[0]==0. || branchingRatioC==0.) {
+    printf(" Hey you ! Why luminosity or trigger-efficiency or the c-BR or delta_y are set to zero ?! ");
+    return;
+  }
+
+  for (Int_t ibin=1; ibin<=fnPtBins; ibin++) {
+
+    // Variables initialization
+    value=0.; errvalue=0.;
+
+    Double_t x = histoYieldCorr->GetBinCenter(ibin);
+
+    // Sigma calculation
+    //   Sigma = ( 1. / (lumi * delta_y * BR_c * ParticleAntiPartFactor * eff_trig * eff_c ) ) * spectra (corrected for feed-down)
+    if (hDirectEffpt->GetBinContent(ibin) && hDirectEffpt->GetBinContent(ibin)!=0. && hRECpt->GetBinContent(ibin)>0.) { 
+      value = histoYieldCorr->GetBinContent(ibin) / ( deltaY * branchingRatioC * fParticleAntiParticle * fLuminosity[0] * fTrigEfficiency[0] * hDirectEffpt->GetBinContent(ibin) );
+    }
+
+    // Sigma statistical uncertainty:
+    //   delta_sigma = sigma * sqrt ( (delta_spectra/spectra)^2 )
+    if (value!=0.) {
+      errvalue = value * (histoYieldCorr->GetBinError(ibin)/histoYieldCorr->GetBinContent(ibin));
+    }
+
+    histoSigmaCorr->SetBinContent(ibin,value);
+    histoSigmaCorr->SetBinError(ibin,errvalue);
+    gSigmaCorr->SetPoint(ibin,x,value); // i,x,y
+    gSigmaCorr->SetPointError(ibin,(fPtBinWidths[ibin-1]/2.),(fPtBinWidths[ibin-1]/2.),errvalueMin,errvalueMax); // i,xl,xh,yl,yh
+  }
+  
+  //
+  // Define output file, in same style as original HFPtSpectrum macro
+  //
+  TFile *out = new TFile(outfilename,"recreate");
+  out->cd();
+
+  hDirectMCpt->Write();
+  hFeedDownMCpt->Write();
+  hDirectMCptMax->Write();
+  hDirectMCptMin->Write();
+  hFeedDownMCptMax->Write();
+  hFeedDownMCptMin->Write();
+
+  hDirectEffpt->Write();
+  hFeedDownEffpt->Write();
+  hRECpt->Write();
+
+  histoYieldCorr->Write();
+  histoYieldCorrMax->Write();
+  histoYieldCorrMin->Write();
+
+  histoSigmaCorr->Write();
+  histoSigmaCorrMax->Write();
+  histoSigmaCorrMin->Write();
+
+  gYieldCorr->Write();
+  gSigmaCorr->Write();
+  gYieldCorrExtreme->Write();
+  gSigmaCorrExtreme->Write();
+  gYieldCorrConservative->Write();
+  gSigmaCorrConservative->Write();
+
+  gFcConservative->Write();
+
+  hStatUncEffcSigma->Write();
+  hStatUncEffbSigma->Write();
+  hStatUncEffcFD->Write();
+  hStatUncEffbFD->Write();
+
+  systematics->Write();
+
+  out->Close();
+  recofile->Close();
+  efffile->Close();
+  inputcrossfile->Close();
+}

--- a/machine_learning_hep/HFPtSpectrum2.C
+++ b/machine_learning_hep/HFPtSpectrum2.C
@@ -123,7 +123,7 @@ void HFPtSpectrum2 (const char *inputCrossSection,
   Double_t *fPtBinLimits = new Double_t[fnPtBins+1];
   Double_t *fPtBinWidths = new Double_t[fnPtBins];
   Double_t xlow=0., binwidth=0.;
-  for(Int_t i=1; i<fnPtBins; i++){
+  for(Int_t i=1; i<=fnPtBins; i++){
     binwidth = hRECpt->GetBinWidth(i);
     xlow = hRECpt->GetBinLowEdge(i);
     fPtBinLimits[i-1] = xlow;

--- a/machine_learning_hep/ana.sh
+++ b/machine_learning_hep/ana.sh
@@ -18,27 +18,33 @@ export MLPBACKEND=pdf
 srun python do_entire_analysis.py -r default_ana.yml -d data/database_ml_parameters_D0pp.yml -a MBvspt_ntrkl &
 srun python do_entire_analysis.py -r default_ana.yml -d data/database_ml_parameters_D0pp.yml -a MBvspt_v0m &
 srun python do_entire_analysis.py -r default_ana.yml -d data/database_ml_parameters_D0pp.yml -a MBvspt_perc &
-srun python do_entire_analysis.py -r default_ana.yml -d data/database_ml_parameters_D0pp.yml -a SPDvspt &
-srun python do_entire_analysis.py -r default_ana.yml -d data/database_ml_parameters_D0pp.yml -a V0mvspt &
-srun python do_entire_analysis.py -r default_ana.yml -d data/database_ml_parameters_D0pp.yml -a V0mvspt_perc_v0m &
 
 srun python do_entire_analysis.py -r default_ana.yml -d data/database_ml_parameters_LcpK0spp.yml -a MBvspt_ntrkl &
 srun python do_entire_analysis.py -r default_ana.yml -d data/database_ml_parameters_LcpK0spp.yml -a MBvspt_v0m &
 srun python do_entire_analysis.py -r default_ana.yml -d data/database_ml_parameters_LcpK0spp.yml -a MBvspt_perc &
-srun python do_entire_analysis.py -r default_ana.yml -d data/database_ml_parameters_LcpK0spp.yml -a SPDvspt &
-srun python do_entire_analysis.py -r default_ana.yml -d data/database_ml_parameters_LcpK0spp.yml -a V0mvspt &
-srun python do_entire_analysis.py -r default_ana.yml -d data/database_ml_parameters_LcpK0spp.yml -a V0mvspt_perc_v0m &
 
 srun python do_entire_analysis.py -r default_ana.yml -d data/database_ml_parameters_Dspp.yml -a MBvspt_ntrkl &
 srun python do_entire_analysis.py -r default_ana.yml -d data/database_ml_parameters_Dspp.yml -a MBvspt_v0m &
 srun python do_entire_analysis.py -r default_ana.yml -d data/database_ml_parameters_Dspp.yml -a MBvspt_perc &
-srun python do_entire_analysis.py -r default_ana.yml -d data/database_ml_parameters_Dspp.yml -a SPDvspt &
-srun python do_entire_analysis.py -r default_ana.yml -d data/database_ml_parameters_Dspp.yml -a V0mvspt &
-srun python do_entire_analysis.py -r default_ana.yml -d data/database_ml_parameters_Dspp.yml -a V0mvspt_perc_v0m &
 
 srun python do_entire_analysis.py -r default_ana.yml -d data/database_ml_parameters_LcpKpipp.yml -a MBvspt_ntrkl &
 srun python do_entire_analysis.py -r default_ana.yml -d data/database_ml_parameters_LcpKpipp.yml -a MBvspt_v0m &
 srun python do_entire_analysis.py -r default_ana.yml -d data/database_ml_parameters_LcpKpipp.yml -a MBvspt_perc &
+
+wait
+
+srun python do_entire_analysis.py -r default_ana.yml -d data/database_ml_parameters_D0pp.yml -a SPDvspt &
+srun python do_entire_analysis.py -r default_ana.yml -d data/database_ml_parameters_D0pp.yml -a V0mvspt &
+srun python do_entire_analysis.py -r default_ana.yml -d data/database_ml_parameters_D0pp.yml -a V0mvspt_perc_v0m &
+
+srun python do_entire_analysis.py -r default_ana.yml -d data/database_ml_parameters_LcpK0spp.yml -a SPDvspt &
+srun python do_entire_analysis.py -r default_ana.yml -d data/database_ml_parameters_LcpK0spp.yml -a V0mvspt &
+srun python do_entire_analysis.py -r default_ana.yml -d data/database_ml_parameters_LcpK0spp.yml -a V0mvspt_perc_v0m &
+
+srun python do_entire_analysis.py -r default_ana.yml -d data/database_ml_parameters_Dspp.yml -a SPDvspt &
+srun python do_entire_analysis.py -r default_ana.yml -d data/database_ml_parameters_Dspp.yml -a V0mvspt &
+srun python do_entire_analysis.py -r default_ana.yml -d data/database_ml_parameters_Dspp.yml -a V0mvspt_perc_v0m &
+
 srun python do_entire_analysis.py -r default_ana.yml -d data/database_ml_parameters_LcpKpipp.yml -a SPDvspt &
 srun python do_entire_analysis.py -r default_ana.yml -d data/database_ml_parameters_LcpKpipp.yml -a V0mvspt &
 srun python do_entire_analysis.py -r default_ana.yml -d data/database_ml_parameters_LcpKpipp.yml -a V0mvspt_perc_v0m &

--- a/machine_learning_hep/analyzer.py
+++ b/machine_learning_hep/analyzer.py
@@ -1510,7 +1510,8 @@ class Analyzer:
         yield_filename = self.make_file_path(self.d_resultsallpdata, self.yields_filename, "root",
                                              None, [self.case, self.typean])
         gROOT.LoadMacro("HFPtSpectrum.C")
-        from ROOT import HFPtSpectrum
+        gROOT.LoadMacro("HFPtSpectrum2.C")
+        from ROOT import HFPtSpectrum, HFPtSpectrum2
         for imult in range(self.p_nbin2):
             bineff = -1
             if self.p_bineff is None:
@@ -1536,10 +1537,16 @@ class Analyzer:
                   self.lvar2_binmin[imult], self.lvar2_binmax[imult])
             print("N. events selected=", normold, "N. events counter =", norm)
 
-            HFPtSpectrum(self.p_indexhpt, \
-                "inputsCross/D0DplusDstarPredictions_13TeV_y05_all_300416_BDShapeCorrected.root", \
-                fileouteff, namehistoeffprompt, namehistoefffeed, yield_filename, nameyield, \
-                fileoutcrossmult, norm, self.p_sigmav0 * 1e12, self.p_fd_method, self.p_cctype)
+            if self.p_fprompt_from_mb is None or imult == 0 or self.p_fd_method != 2:
+                HFPtSpectrum(self.p_indexhpt, \
+                    "inputsCross/D0DplusDstarPredictions_13TeV_y05_all_300416_BDShapeCorrected.root", \
+                    fileouteff, namehistoeffprompt, namehistoefffeed, yield_filename, nameyield, \
+                    fileoutcrossmult, norm, self.p_sigmav0 * 1e12, self.p_fd_method, self.p_cctype)
+            else:
+                self.logger.info("Calculating spectra using fPrompt from MB (Nb). Assuming MB is bin 0!")
+                filecrossmb = "%s/finalcross%s%smult0.root" % (self.d_resultsallpdata, self.case, self.typean)
+                HFPtSpectrum2(filecrossmb, fileouteff, namehistoeffprompt, namehistoefffeed, yield_filename, \
+                              nameyield, fileoutcrossmult, norm, self.p_sigmav0 * 1e12)
         fileoutcrosstot = TFile.Open("%s/finalcross%s%smulttot.root" % \
             (self.d_resultsallpdata, self.case, self.typean), "recreate")
 

--- a/machine_learning_hep/analyzer.py
+++ b/machine_learning_hep/analyzer.py
@@ -129,6 +129,7 @@ class Analyzer:
 
         self.p_nevents = datap["analysis"][self.typean]["nevents"]
         self.p_bineff = datap["analysis"][self.typean]["usesinglebineff"]
+        self.p_fprompt_from_mb = datap["analysis"][self.typean]["fprompt_from_mb"]
         self.p_sigmamb = datap["ml"]["opt"]["sigma_MB"]
         self.p_br = datap["ml"]["opt"]["BR"]
 
@@ -1539,14 +1540,17 @@ class Analyzer:
 
             if self.p_fprompt_from_mb is None or imult == 0 or self.p_fd_method != 2:
                 HFPtSpectrum(self.p_indexhpt, \
-                    "inputsCross/D0DplusDstarPredictions_13TeV_y05_all_300416_BDShapeCorrected.root", \
-                    fileouteff, namehistoeffprompt, namehistoefffeed, yield_filename, nameyield, \
-                    fileoutcrossmult, norm, self.p_sigmav0 * 1e12, self.p_fd_method, self.p_cctype)
+                 "inputsCross/D0DplusDstarPredictions_13TeV_y05_all_300416_BDShapeCorrected.root", \
+                 fileouteff, namehistoeffprompt, namehistoefffeed, yield_filename, nameyield, \
+                 fileoutcrossmult, norm, self.p_sigmav0 * 1e12, self.p_fd_method, self.p_cctype)
             else:
-                self.logger.info("Calculating spectra using fPrompt from MB (Nb). Assuming MB is bin 0!")
-                filecrossmb = "%s/finalcross%s%smult0.root" % (self.d_resultsallpdata, self.case, self.typean)
-                HFPtSpectrum2(filecrossmb, fileouteff, namehistoeffprompt, namehistoefffeed, yield_filename, \
-                              nameyield, fileoutcrossmult, norm, self.p_sigmav0 * 1e12)
+                self.logger.info("Calculating spectra using fPrompt from MB (Nb). "\
+                                 "Assuming MB is bin 0!")
+                filecrossmb = "%s/finalcross%s%smult0.root" % \
+                               (self.d_resultsallpdata, self.case, self.typean)
+                HFPtSpectrum2(filecrossmb, fileouteff, namehistoeffprompt, namehistoefffeed, \
+                              yield_filename, nameyield, fileoutcrossmult, norm, \
+                              self.p_sigmav0 * 1e12)
         fileoutcrosstot = TFile.Open("%s/finalcross%s%smulttot.root" % \
             (self.d_resultsallpdata, self.case, self.typean), "recreate")
 

--- a/machine_learning_hep/data/database_ml_parameters_D0pp.yml
+++ b/machine_learning_hep/data/database_ml_parameters_D0pp.yml
@@ -245,6 +245,7 @@ D0pp:
       normalizecross: false
       plotbin: [1,1,1,0]
       usesinglebineff: null
+      fprompt_from_mb: true
       sel_binmin2:  [0,1,20,60] #list of var2 splittng nbins
       sel_binmax2: [9999,20,60,100] #list of var2 splitting nbins
       var_binning2: n_tracklets_corr
@@ -324,6 +325,7 @@ D0pp:
       normalizecross: false
       plotbin: [1,1,1,0]
       usesinglebineff: null
+      fprompt_from_mb: true
       sel_binmin2:  [0,1,200,600] #list of var2 splittng nbins
       sel_binmax2: [9999,200,600,1000] #list of var2 splitting nbins
       var_binning2: v0m_corr
@@ -394,6 +396,7 @@ D0pp:
       normalizecross: false
       plotbin: [1,1,1,0]
       usesinglebineff: null
+      fprompt_from_mb: true
       sel_binmin2:  [0,30,0.1,0.] #list of var2 splittng nbins
       sel_binmax2: [100,100,30,0.1] #list of var2 splitting nbins
       var_binning2: perc_v0m
@@ -466,6 +469,7 @@ D0pp:
       normalizecross: true
       plotbin: [1]
       usesinglebineff: null
+      fprompt_from_mb: true
       sel_binmin2: [5] #list of nbins
       sel_binmax2: [15] #list of nbins
       var_binning2: pt_jet
@@ -535,6 +539,7 @@ D0pp:
       normalizecross: false
       plotbin: [0,0,0,1]
       usesinglebineff: 2
+      fprompt_from_mb: true
       sel_binmin2:  [0,1,20,60] #list of var2 splittng nbins
       sel_binmax2: [9999,20,60,100] #list of var2 splitting nbins
       var_binning2: n_tracklets_corr
@@ -605,6 +610,7 @@ D0pp:
       normalizecross: false
       plotbin: [0,0,0,1]
       usesinglebineff: 2
+      fprompt_from_mb: true
       sel_binmin2:  [0,1,200,600] #list of var2 splittng nbins
       sel_binmax2: [9999,200,600,1000] #list of var2 splitting nbins
       var_binning2: v0m_corr
@@ -674,6 +680,7 @@ D0pp:
       normalizecross: false
       plotbin: [0,0,0,1]
       usesinglebineff: 2
+      fprompt_from_mb: true
       sel_binmin2:  [0,30,0.1,0.] #list of var2 splittng nbins
       sel_binmax2: [100,100,30,0.1] #list of var2 splitting nbins
       var_binning2: perc_v0m

--- a/machine_learning_hep/data/database_ml_parameters_D0pp.yml
+++ b/machine_learning_hep/data/database_ml_parameters_D0pp.yml
@@ -246,6 +246,7 @@ D0pp:
       plotbin: [1,1,1,0]
       usesinglebineff: null
       fprompt_from_mb: true
+      corresp_mb_typean: null
       sel_binmin2:  [0,1,20,60] #list of var2 splittng nbins
       sel_binmax2: [9999,20,60,100] #list of var2 splitting nbins
       var_binning2: n_tracklets_corr
@@ -326,6 +327,7 @@ D0pp:
       plotbin: [1,1,1,0]
       usesinglebineff: null
       fprompt_from_mb: true
+      corresp_mb_typean: null
       sel_binmin2:  [0,1,200,600] #list of var2 splittng nbins
       sel_binmax2: [9999,200,600,1000] #list of var2 splitting nbins
       var_binning2: v0m_corr
@@ -397,6 +399,7 @@ D0pp:
       plotbin: [1,1,1,0]
       usesinglebineff: null
       fprompt_from_mb: true
+      corresp_mb_typean: null
       sel_binmin2:  [0,30,0.1,0.] #list of var2 splittng nbins
       sel_binmax2: [100,100,30,0.1] #list of var2 splitting nbins
       var_binning2: perc_v0m
@@ -470,6 +473,7 @@ D0pp:
       plotbin: [1]
       usesinglebineff: null
       fprompt_from_mb: true
+      corresp_mb_typean: null
       sel_binmin2: [5] #list of nbins
       sel_binmax2: [15] #list of nbins
       var_binning2: pt_jet
@@ -540,6 +544,7 @@ D0pp:
       plotbin: [0,0,0,1]
       usesinglebineff: 2
       fprompt_from_mb: true
+      corresp_mb_typean: MBvspt_ntrkl
       sel_binmin2:  [0,1,20,60] #list of var2 splittng nbins
       sel_binmax2: [9999,20,60,100] #list of var2 splitting nbins
       var_binning2: n_tracklets_corr
@@ -611,6 +616,7 @@ D0pp:
       plotbin: [0,0,0,1]
       usesinglebineff: 2
       fprompt_from_mb: true
+      corresp_mb_typean: MBvspt_v0m
       sel_binmin2:  [0,1,200,600] #list of var2 splittng nbins
       sel_binmax2: [9999,200,600,1000] #list of var2 splitting nbins
       var_binning2: v0m_corr
@@ -681,6 +687,7 @@ D0pp:
       plotbin: [0,0,0,1]
       usesinglebineff: 2
       fprompt_from_mb: true
+      corresp_mb_typean: MBvspt_perc
       sel_binmin2:  [0,30,0.1,0.] #list of var2 splittng nbins
       sel_binmax2: [100,100,30,0.1] #list of var2 splitting nbins
       var_binning2: perc_v0m

--- a/machine_learning_hep/data/database_ml_parameters_Dspp.yml
+++ b/machine_learning_hep/data/database_ml_parameters_Dspp.yml
@@ -251,6 +251,7 @@ Dspp:
       plotbin: [1,1,1,0]
       usesinglebineff: null
       fprompt_from_mb: true
+      corresp_mb_typean: null
       sel_binmin2:  [0,1,20,60] #list of var2 splittng nbins
       sel_binmax2: [9999,20,60,100] #list of var2 splitting nbins
       var_binning2: n_tracklets_corr
@@ -333,6 +334,7 @@ Dspp:
       plotbin: [1,1,1,0]
       usesinglebineff: null
       fprompt_from_mb: true
+      corresp_mb_typean: null
       sel_binmin2:  [0,1,200,600] #list of var2 splittng nbins
       sel_binmax2: [9999,200,600,1000] #list of var2 splitting nbins
       var_binning2: v0m_corr
@@ -405,6 +407,7 @@ Dspp:
       plotbin: [1,1,1,0]
       usesinglebineff: null
       fprompt_from_mb: true
+      corresp_mb_typean: null
       sel_binmin2:  [0,30,0.1,0.] #list of var2 splittng nbins
       sel_binmax2: [100,100,30,0.1] #list of var2 splitting nbins
       var_binning2: perc_v0m
@@ -477,6 +480,7 @@ Dspp:
       plotbin: [1]
       usesinglebineff: null
       fprompt_from_mb: true
+      corresp_mb_typean: null
       sel_binmin2: [5] #list of nbins
       sel_binmax2: [15] #list of nbins
       var_binning2: pt_jet
@@ -549,6 +553,7 @@ Dspp:
       plotbin: [0,0,0,1]
       usesinglebineff: 2
       fprompt_from_mb: true
+      corresp_mb_typean: MBvspt_ntrkl
       sel_binmin2:  [0,1,20,60] #list of var2 splittng nbins
       sel_binmax2: [9999,20,60,100] #list of var2 splitting nbins
       var_binning2: n_tracklets_corr
@@ -621,6 +626,7 @@ Dspp:
       plotbin: [0,0,0,1]
       usesinglebineff: 2
       fprompt_from_mb: true
+      corresp_mb_typean: MBvspt_v0m
       sel_binmin2:  [0,1,200,600] #list of var2 splittng nbins
       sel_binmax2: [9999,200,600,1000] #list of var2 splitting nbins
       var_binning2: v0m_corr
@@ -693,6 +699,7 @@ Dspp:
       plotbin: [0,0,0,1]
       usesinglebineff: 2
       fprompt_from_mb: true
+      corresp_mb_typean: MBvspt_perc
       sel_binmin2:  [0,30,0.1,0.] #list of var2 splittng nbins
       sel_binmax2: [100,100,30,0.1] #list of var2 splitting nbins
       var_binning2: perc_v0m

--- a/machine_learning_hep/data/database_ml_parameters_Dspp.yml
+++ b/machine_learning_hep/data/database_ml_parameters_Dspp.yml
@@ -250,6 +250,7 @@ Dspp:
       normalizecross: false  
       plotbin: [1,1,1,0]
       usesinglebineff: null
+      fprompt_from_mb: true
       sel_binmin2:  [0,1,20,60] #list of var2 splittng nbins
       sel_binmax2: [9999,20,60,100] #list of var2 splitting nbins
       var_binning2: n_tracklets_corr
@@ -331,6 +332,7 @@ Dspp:
       normalizecross: false
       plotbin: [1,1,1,0]
       usesinglebineff: null
+      fprompt_from_mb: true
       sel_binmin2:  [0,1,200,600] #list of var2 splittng nbins
       sel_binmax2: [9999,200,600,1000] #list of var2 splitting nbins
       var_binning2: v0m_corr
@@ -402,6 +404,7 @@ Dspp:
       normalizecross: false
       plotbin: [1,1,1,0]
       usesinglebineff: null
+      fprompt_from_mb: true
       sel_binmin2:  [0,30,0.1,0.] #list of var2 splittng nbins
       sel_binmax2: [100,100,30,0.1] #list of var2 splitting nbins
       var_binning2: perc_v0m
@@ -473,6 +476,7 @@ Dspp:
       normalizecross: true
       plotbin: [1]
       usesinglebineff: null
+      fprompt_from_mb: true
       sel_binmin2: [5] #list of nbins
       sel_binmax2: [15] #list of nbins
       var_binning2: pt_jet
@@ -544,6 +548,7 @@ Dspp:
       normalizecross: false
       plotbin: [0,0,0,1]
       usesinglebineff: 2
+      fprompt_from_mb: true
       sel_binmin2:  [0,1,20,60] #list of var2 splittng nbins
       sel_binmax2: [9999,20,60,100] #list of var2 splitting nbins
       var_binning2: n_tracklets_corr
@@ -615,6 +620,7 @@ Dspp:
       normalizecross: false
       plotbin: [0,0,0,1]
       usesinglebineff: 2
+      fprompt_from_mb: true
       sel_binmin2:  [0,1,200,600] #list of var2 splittng nbins
       sel_binmax2: [9999,200,600,1000] #list of var2 splitting nbins
       var_binning2: v0m_corr
@@ -686,6 +692,7 @@ Dspp:
       normalizecross: false
       plotbin: [0,0,0,1]
       usesinglebineff: 2
+      fprompt_from_mb: true
       sel_binmin2:  [0,30,0.1,0.] #list of var2 splittng nbins
       sel_binmax2: [100,100,30,0.1] #list of var2 splitting nbins
       var_binning2: perc_v0m

--- a/machine_learning_hep/data/database_ml_parameters_LcpK0spp.yml
+++ b/machine_learning_hep/data/database_ml_parameters_LcpK0spp.yml
@@ -326,6 +326,7 @@ LcpK0spp:
       plotbin: [1,1,1,0]
       usesinglebineff: null
       fprompt_from_mb: true
+      corresp_mb_typean: null
       sel_binmin2:  [0,1,20,60] #list of var2 splittng nbins
       sel_binmax2: [9999,20,60,100] #list of var2 splitting nbins
       var_binning2: n_tracklets_corr
@@ -403,6 +404,7 @@ LcpK0spp:
       plotbin: [1,1,1,0]
       usesinglebineff: null
       fprompt_from_mb: true
+      corresp_mb_typean: null
       sel_binmin2:  [0,1,200,600] #list of var2 splittng nbins
       sel_binmax2: [9999,200,600,1000] #list of var2 splitting nbins
       var_binning2: v0m_corr
@@ -471,6 +473,7 @@ LcpK0spp:
       plotbin: [1,1,1,0]
       usesinglebineff: null
       fprompt_from_mb: true
+      corresp_mb_typean: null
       sel_binmin2:  [0,30,0.1,0.] #list of var2 splittng nbins
       sel_binmax2: [100,100,30,0.1] #list of var2 splitting nbins
       var_binning2: perc_v0m
@@ -539,6 +542,7 @@ LcpK0spp:
       plotbin: [1]
       usesinglebineff: null
       fprompt_from_mb: true
+      corresp_mb_typean: null
       sel_binmin2: [5] #list of nbins
       sel_binmax2: [15] #list of nbins
       var_binning2: pt_jet
@@ -607,6 +611,7 @@ LcpK0spp:
       plotbin: [0,0,0,1]
       usesinglebineff: 2
       fprompt_from_mb: true
+      corresp_mb_typean: MBvspt_ntrkl
       sel_binmin2:  [0,1,20,60] #list of var2 splittng nbins
       sel_binmax2: [9999,20,60,100] #list of var2 splitting nbins
       var_binning2: n_tracklets_corr
@@ -675,6 +680,7 @@ LcpK0spp:
       plotbin: [0,0,0,1]
       usesinglebineff: 2
       fprompt_from_mb: true
+      corresp_mb_typean: MBvspt_v0m
       sel_binmin2:  [0,1,200,600] #list of var2 splittng nbins
       sel_binmax2: [9999,200,600,1000] #list of var2 splitting nbins
       var_binning2: v0m_corr
@@ -743,6 +749,7 @@ LcpK0spp:
       plotbin: [0,0,0,1]
       usesinglebineff: 2
       fprompt_from_mb: true
+      corresp_mb_typean: MBvspt_perc
       sel_binmin2:  [0,30,0.1,0.] #list of var2 splittng nbins
       sel_binmax2: [100,100,30,0.1] #list of var2 splitting nbins
       var_binning2: perc_v0m

--- a/machine_learning_hep/data/database_ml_parameters_LcpK0spp.yml
+++ b/machine_learning_hep/data/database_ml_parameters_LcpK0spp.yml
@@ -325,6 +325,7 @@ LcpK0spp:
       normalizecross: false
       plotbin: [1,1,1,0]
       usesinglebineff: null
+      fprompt_from_mb: true
       sel_binmin2:  [0,1,20,60] #list of var2 splittng nbins
       sel_binmax2: [9999,20,60,100] #list of var2 splitting nbins
       var_binning2: n_tracklets_corr
@@ -401,6 +402,7 @@ LcpK0spp:
       normalizecross: false
       plotbin: [1,1,1,0]
       usesinglebineff: null
+      fprompt_from_mb: true
       sel_binmin2:  [0,1,200,600] #list of var2 splittng nbins
       sel_binmax2: [9999,200,600,1000] #list of var2 splitting nbins
       var_binning2: v0m_corr
@@ -468,6 +470,7 @@ LcpK0spp:
       normalizecross: false
       plotbin: [1,1,1,0]
       usesinglebineff: null
+      fprompt_from_mb: true
       sel_binmin2:  [0,30,0.1,0.] #list of var2 splittng nbins
       sel_binmax2: [100,100,30,0.1] #list of var2 splitting nbins
       var_binning2: perc_v0m
@@ -535,6 +538,7 @@ LcpK0spp:
       normalizecross: true
       plotbin: [1]
       usesinglebineff: null
+      fprompt_from_mb: true
       sel_binmin2: [5] #list of nbins
       sel_binmax2: [15] #list of nbins
       var_binning2: pt_jet
@@ -602,6 +606,7 @@ LcpK0spp:
       normalizecross: false
       plotbin: [0,0,0,1]
       usesinglebineff: 2
+      fprompt_from_mb: true
       sel_binmin2:  [0,1,20,60] #list of var2 splittng nbins
       sel_binmax2: [9999,20,60,100] #list of var2 splitting nbins
       var_binning2: n_tracklets_corr
@@ -669,6 +674,7 @@ LcpK0spp:
       normalizecross: false
       plotbin: [0,0,0,1]
       usesinglebineff: 2
+      fprompt_from_mb: true
       sel_binmin2:  [0,1,200,600] #list of var2 splittng nbins
       sel_binmax2: [9999,200,600,1000] #list of var2 splitting nbins
       var_binning2: v0m_corr
@@ -736,6 +742,7 @@ LcpK0spp:
       normalizecross: false
       plotbin: [0,0,0,1]
       usesinglebineff: 2
+      fprompt_from_mb: true
       sel_binmin2:  [0,30,0.1,0.] #list of var2 splittng nbins
       sel_binmax2: [100,100,30,0.1] #list of var2 splitting nbins
       var_binning2: perc_v0m

--- a/machine_learning_hep/data/database_ml_parameters_LcpKpipp.yml
+++ b/machine_learning_hep/data/database_ml_parameters_LcpKpipp.yml
@@ -253,6 +253,7 @@ LcpKpipp:
       normalizecross: false
       plotbin: [1,1,1,0]
       usesinglebineff: null
+      fprompt_from_mb: true
       sel_binmin2:  [0,1,20,60] #list of var2 splittng nbins
       sel_binmax2: [9999,20,60,100] #list of var2 splitting nbins
       var_binning2: n_tracklets_corr
@@ -330,6 +331,7 @@ LcpKpipp:
       normalizecross: false
       plotbin: [1,1,1,0]
       usesinglebineff: null
+      fprompt_from_mb: true
       sel_binmin2:  [0,1,200,600] #list of var2 splittng nbins
       sel_binmax2: [9999,200,600,1000] #list of var2 splitting nbins
       var_binning2: v0m_corr
@@ -398,6 +400,7 @@ LcpKpipp:
       normalizecross: false
       plotbin: [1,1,1,0]
       usesinglebineff: null
+      fprompt_from_mb: true
       sel_binmin2: [0,30,0.1,0.] #list of var2 splittng nbins
       sel_binmax2: [100,100,30,0.1] #list of var2 splitting nbins
       var_binning2: perc_v0m
@@ -466,6 +469,7 @@ LcpKpipp:
       normalizecross: true
       plotbin: [1]
       usesinglebineff: null
+      fprompt_from_mb: true
       sel_binmin2: [5] #list of nbins
       sel_binmax2: [15] #list of nbins
       var_binning2: pt_jet
@@ -534,6 +538,7 @@ LcpKpipp:
       normalizecross: false
       plotbin: [0,0,0,1]
       usesinglebineff: 2
+      fprompt_from_mb: true
       sel_binmin2:  [0,1,20,60] #list of var2 splittng nbins
       sel_binmax2: [9999,20,60,100] #list of var2 splitting nbins
       var_binning2: n_tracklets_corr
@@ -598,6 +603,7 @@ LcpKpipp:
       normalizecross: false
       plotbin: [0,0,0,1]
       usesinglebineff: 2
+      fprompt_from_mb: true
       sel_binmin2:  [0,1,200,600] #list of var2 splittng nbins
       sel_binmax2: [9999,200,600,1000] #list of var2 splitting nbins
       var_binning2: v0m_corr
@@ -665,6 +671,7 @@ LcpKpipp:
       normalizecross: false
       plotbin: [0,0,0,1]
       usesinglebineff: 2
+      fprompt_from_mb: true
       sel_binmin2: [0,30,0.1,0.] #list of var2 splittng nbins
       sel_binmax2: [100,100,30,0.1] #list of var2 splitting nbins
       var_binning2: perc_v0m

--- a/machine_learning_hep/data/database_ml_parameters_LcpKpipp.yml
+++ b/machine_learning_hep/data/database_ml_parameters_LcpKpipp.yml
@@ -254,6 +254,7 @@ LcpKpipp:
       plotbin: [1,1,1,0]
       usesinglebineff: null
       fprompt_from_mb: true
+      corresp_mb_typean: null
       sel_binmin2:  [0,1,20,60] #list of var2 splittng nbins
       sel_binmax2: [9999,20,60,100] #list of var2 splitting nbins
       var_binning2: n_tracklets_corr
@@ -332,6 +333,7 @@ LcpKpipp:
       plotbin: [1,1,1,0]
       usesinglebineff: null
       fprompt_from_mb: true
+      corresp_mb_typean: null
       sel_binmin2:  [0,1,200,600] #list of var2 splittng nbins
       sel_binmax2: [9999,200,600,1000] #list of var2 splitting nbins
       var_binning2: v0m_corr
@@ -401,6 +403,7 @@ LcpKpipp:
       plotbin: [1,1,1,0]
       usesinglebineff: null
       fprompt_from_mb: true
+      corresp_mb_typean: null
       sel_binmin2: [0,30,0.1,0.] #list of var2 splittng nbins
       sel_binmax2: [100,100,30,0.1] #list of var2 splitting nbins
       var_binning2: perc_v0m
@@ -470,6 +473,7 @@ LcpKpipp:
       plotbin: [1]
       usesinglebineff: null
       fprompt_from_mb: true
+      corresp_mb_typean: null
       sel_binmin2: [5] #list of nbins
       sel_binmax2: [15] #list of nbins
       var_binning2: pt_jet
@@ -539,6 +543,7 @@ LcpKpipp:
       plotbin: [0,0,0,1]
       usesinglebineff: 2
       fprompt_from_mb: true
+      corresp_mb_typean: MBvspt_ntrkl
       sel_binmin2:  [0,1,20,60] #list of var2 splittng nbins
       sel_binmax2: [9999,20,60,100] #list of var2 splitting nbins
       var_binning2: n_tracklets_corr
@@ -604,6 +609,7 @@ LcpKpipp:
       plotbin: [0,0,0,1]
       usesinglebineff: 2
       fprompt_from_mb: true
+      corresp_mb_typean: MBvspt_v0m
       sel_binmin2:  [0,1,200,600] #list of var2 splittng nbins
       sel_binmax2: [9999,200,600,1000] #list of var2 splitting nbins
       var_binning2: v0m_corr
@@ -672,6 +678,7 @@ LcpKpipp:
       plotbin: [0,0,0,1]
       usesinglebineff: 2
       fprompt_from_mb: true
+      corresp_mb_typean: MBvspt_perc
       sel_binmin2: [0,30,0.1,0.] #list of var2 splittng nbins
       sel_binmax2: [100,100,30,0.1] #list of var2 splitting nbins
       var_binning2: perc_v0m


### PR DESCRIPTION
* Full MC ready, so new paths
* Added 2nd HFPtSpectrum script that uses the fPrompt fraction from a HFPtSprectrum.root as input file, to calculate the corrected yield/cross section. Tested at AliPhysics level, not yet in the MLHEP package. Therefore WIP

TODO: Use MB input file for HM triggered analysis mode. Now it is taking mult-int in HM triggered data. Should also work when MB file is not run yet, as things are going in parallel