### PR TITLE
Bump pylint to same version as Travis

### DIFF
--- a/machine_learning_hep/systematics.py
+++ b/machine_learning_hep/systematics.py
@@ -460,6 +460,7 @@ class Systematics:
             h_gen_fd[i].Write()
             h_sel_fd[i].Write()
 
+    # pylint: disable=import-outside-toplevel
     # pylint: disable=too-many-branches, too-many-locals, too-many-nested-blocks
     def cutvariation_fitter(self, min_cv_cut, max_cv_cut):
 
@@ -648,6 +649,7 @@ class Systematics:
 
             fileout.Close()
 
+    # pylint: disable=import-outside-toplevel
     def cutvariation_makenormyields(self):
         #self.test_aliphysics()
 

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
   # requirements files see:
   # https://packaging.python.org/en/latest/requirements.html
   install_requires=[ "numpy", "pandas", "scipy", "matplotlib", "seaborn", "uproot", "scikit-learn",
-                     "xgboost==0.90", "keras", "tensorflow", "PyYaml", "pylint", "twisted", "klein",
+                     "xgboost==0.90", "keras", "tensorflow", "PyYaml", "pylint==2.4.3", "twisted", "klein",
                     "Jinja2>=2.10.1", "numba", "pyarrow", "lz4>=2.1.10", "pyyaml"],
 
   python_requires='>=3.6, <3.7',


### PR DESCRIPTION
There was a mismatch between pylint from package (2.3.1) and the one Travis used (2.4.3) with different end result on "disable=import-outside-toplevel". Forced package to take same version as Travis