### PR TITLE
Refactory of fitting

### DIFF
--- a/machine_learning_hep/analyzer.py
+++ b/machine_learning_hep/analyzer.py
@@ -19,7 +19,6 @@ main script for doing final stage analysis
 import os
 # pylint: disable=unused-wildcard-import, wildcard-import
 from array import *
-from subprocess import Popen
 import numpy as np
 # pylint: disable=import-error, no-name-in-module, unused-import
 from root_numpy import hist2array, array2hist
@@ -30,7 +29,7 @@ from ROOT import TStyle, kBlue, kGreen, kBlack, kRed, kOrange
 from ROOT import TLatex
 from ROOT import gInterpreter, gPad
 # HF specific imports
-from machine_learning_hep.globalfitter import Fitter
+from machine_learning_hep.fitting.helpers import MLFitter
 from machine_learning_hep.logger import get_logger
 from machine_learning_hep.io import dump_yaml_from_dict
 from machine_learning_hep.utilities import folding, get_bins, make_latex_table, parallelizer
@@ -48,6 +47,7 @@ class Analyzer:
         #namefiles pkl
         self.case = case
         self.typean = typean
+        self.datap = datap
         self.v_var_binning = datap["var_binning"]
         self.lpt_finbinmin = datap["analysis"][self.typean]["sel_an_binmin"]
         self.lpt_finbinmax = datap["analysis"][self.typean]["sel_an_binmax"]
@@ -76,6 +76,7 @@ class Analyzer:
 
         # Output directories and filenames
         self.yields_filename = "yields"
+        self.fits_dirname = "fits"
         self.yields_syst_filename = "yields_syst"
         self.efficiency_filename = "efficiencies"
         self.sideband_subtracted_filename = "sideband_subtracted"
@@ -182,6 +183,9 @@ class Analyzer:
                                                                         None)
         self.path_for_crossmb = datap["analysis"][self.typean].get("path_for_crossmb", None)
 
+        # Fitting
+        self.fitter = None
+
     @staticmethod
     def loadstyle():
         gStyle.SetOptStat(0)
@@ -214,805 +218,44 @@ class Analyzer:
         extension = extension.replace(".", "")
         return os.path.join(directory, filename + "." + extension)
 
-    def test_aliphysics(self):
-        test_macro = "/tmp/aliphysics_test.C"
-        with open(test_macro, "w") as m:
-            m.write("void aliphysics_test()\n{\n")
-            m.write("TH1F* h = new TH1F(\"name\", \"\", 2, 1., 2.);\n \
-                    auto fitter = new AliHFInvMassFitter(h, 1., 2., 1, 1);\n \
-                    if(fitter) { std::cerr << \" Success \"; \n \
-                    delete fitter; }\n \
-                    else { std::cerr << \"Fail\"; }\n \
-                    std::cerr << std::endl; }")
-        proc = Popen(["root", "-l", "-b", "-q", test_macro])
-        success = proc.wait()
-        if success != 0:
-            self.logger.fatal("You are not in the AliPhysics env")
-
-
-    # pylint: disable=too-many-branches, too-many-locals, too-many-nested-blocks
     # pylint: disable=import-outside-toplevel
-    def fitter(self):
-        # Test if we are in AliPhysics env
-        #self.test_aliphysics()
+    def fit(self):
+        # Enable ROOT batch mode and reset in the end
         tmp_is_root_batch = gROOT.IsBatch()
         gROOT.SetBatch(True)
-        from ROOT import AliHFInvMassFitter, AliVertexingHFUtils
-        # Enable ROOT batch mode and reset in the end
 
-        self.loadstyle()
-
-        # Immediately fail if something weird was chosen for fit init
-        if self.init_fits_from[0] not in  ["mc", "data"]:
-            self.logger.fatal("Fit can only be initialized from \"data\" or \"mc\"")
-
-        lfile = TFile.Open(self.n_filemass, "READ")
-        lfile_mc = TFile.Open(self.n_filemass_mc, "READ")
-
+        self.fitter = MLFitter(self.datap, self.typean, self.n_filemass, self.n_filemass_mc)
+        self.fitter.perform_pre_fits()
+        self.fitter.perform_central_fits()
         fileout_name = self.make_file_path(self.d_resultsallpdata, self.yields_filename, "root",
                                            None, [self.case, self.typean])
         fileout = TFile(fileout_name, "RECREATE")
-        # Summarize in mult histograms in pT bins
-        yieldshistos = [TH1F("hyields%d" % (imult), "", \
-                self.p_nptbins, array("d", self.ptranges)) for imult in range(self.p_nbin2)]
-        means_histos = [TH1F("hmeanss%d" % (imult), "", \
-                self.p_nptbins, array("d", self.ptranges)) for imult in range(self.p_nbin2)]
-        sigmas_histos = [TH1F("hsigmas%d" % (imult), "", \
-                self.p_nptbins, array("d", self.ptranges)) for imult in range(self.p_nbin2)]
-        have_summary_pt_bins = []
-        means_init_mc_histos = TH1F("hmeans_init_mc", "",
-                                    self.p_nptbins, array("d", self.ptranges))
-        sigmas_init_mc_histos = TH1F("hsigmas_init_mc", "",
-                                     self.p_nptbins, array("d", self.ptranges))
-        means_init_data_histos = TH1F("hmeans_init_data", "",
-                                      self.p_nptbins, array("d", self.ptranges))
-        sigmas_init_data_histos = TH1F("hsigmas_init_data", "",
-                                       self.p_nptbins, array("d", self.ptranges))
-
-        if self.p_nptbins < 9:
-            nx = 4
-            ny = 2
-            canvy = 533
-        elif self.p_nptbins < 13:
-            nx = 4
-            ny = 3
-            canvy = 800
-        else:
-            nx = 5
-            ny = 4
-            canvy = 1200
-        canvas_init_mc = TCanvas("canvas_init_mc", "MC", 1000, canvy)
-        canvas_init_data = TCanvas("canvas_init_data", "Data", 1000, canvy)
-        canvas_data = [TCanvas("canvas_data%d" % (imult), "Data", 1000, canvy) \
-                       for imult in range(self.p_nbin2)]
-        canvas_init_mc.Divide(nx, ny)
-        canvas_init_data.Divide(nx, ny)
-        for imult in range(self.p_nbin2):
-            canvas_data[imult].Divide(nx, ny)
-
-        # Fit mult integrated MC and data in integrated multiplicity bin for all pT bins
-        # Hence, extract respective bin of second variable
-        bin_mult_int = self.p_bineff if self.p_bineff is not None else 0
-        mult_int_min = self.lvar2_binmin[bin_mult_int]
-        mult_int_max = self.lvar2_binmax[bin_mult_int]
-
-        fit_status = {}
-        mean_min = 9999.
-        mean_max = 0.
-        sigma_min = 9999.
-        sigma_max = 0.
-        minperc = 1 - self.p_max_perc_sigma_diff
-        maxperc = 1 + self.p_max_perc_sigma_diff
-        mass_fitter = []
-        ifit = -1
-
-        # Start fitting...
-        for imult in range(self.p_nbin2):
-            if imult not in fit_status:
-                fit_status[imult] = {}
-            mass_fitter_mc_init = []
-            mass_fitter_data_init = []
-            # Collect additional objects to be drawn outside of pT loop
-            add_draw_objects = []
-            for ipt in range(self.p_nptbins):
-                if ipt not in fit_status[imult]:
-                    fit_status[imult][ipt] = {}
-                bin_id = self.bin_matching[ipt]
-
-                # Initialize mean and sigma with user seeds. This is also the fallback if initial
-                # MC and data fits fail
-                mean_for_data = self.p_masspeak
-                sigma_for_data = self.p_sigmaarray[ipt]
-                means_sigmas_init = [(3, mean_for_data, sigma_for_data)]
-
-                # Store mean, sigma asked to be used by user
-                mean_case_user = None
-                sigma_case_user = None
-
-                ########################
-                # START initialize fit #
-                ########################
-                # Get integrated histograms
-                fit_status[imult][ipt]["init_MC"] = {}
-                suffix = "%s%d_%d_%.2f%s_%.2f_%.2f" % \
-                         (self.v_var_binning, self.lpt_finbinmin[ipt],
-                          self.lpt_finbinmax[ipt], self.lpt_probcutfin[bin_id],
-                          self.v_var2_binning, mult_int_min, mult_int_max)
-
-                suffix_write = "%s%d_%d_%s_%.2f_%.2f" % \
-                               (self.v_var_binning, self.lpt_finbinmin[ipt],
-                                self.lpt_finbinmax[ipt],
-                                self.v_var2_binning, mult_int_min, mult_int_max)
-                h_invmass_mc_init = lfile_mc.Get("hmass_sig" + suffix)
-
-                h_mc_init_rebin_ = AliVertexingHFUtils.RebinHisto(h_invmass_mc_init,
-                                                                  self.rebins[bin_mult_int][ipt],
-                                                                  -1)
-                h_mc_init_rebin = TH1F()
-                h_mc_init_rebin_.Copy(h_mc_init_rebin)
-                h_mc_init_rebin.SetTitle("%.1f < #it{p}_{T} < %.1f (prob > %.2f)" \
-                                         % (self.lpt_finbinmin[ipt], self.lpt_finbinmax[ipt], \
-                                            self.lpt_probcutfin[bin_id]))
-                h_mc_init_rebin.GetXaxis().SetTitle("#it{M}_{inv} (GeV/#it{c}^{2})")
-                h_mc_init_rebin.GetYaxis().SetTitle("Entries/(%.0f MeV/#it{c}^{2})" \
-                                                    % (h_mc_init_rebin.GetBinWidth(1) * 1000))
-                h_mc_init_rebin.GetYaxis().SetTitleOffset(1.1)
-
-                #mass_fitter_mc_init.append(AliHFInvMassFitter(h_mc_init_rebin, self.p_massmin[ipt],
-                #                                              self.p_massmax[ipt],
-                #                                              self.bkg_fmap[self.p_bkgfunc[ipt]],
-                #                                              self.sig_fmap[self.p_sgnfunc[ipt]]))
-
-                # Force to go on with final fit although there is no estimated signal
-                #mass_fitter_mc_init[ipt].SetCheckSignalCountsAfterFirstFit(False)
-                #if self.p_dolike:
-                #    mass_fitter_mc_init[ipt].SetUseLikelihoodFit()
-                #mass_fitter_mc_init[ipt].SetInitialGaussianMean(mean_for_data)
-                #mass_fitter_mc_init[ipt].SetInitialGaussianSigma(sigma_for_data)
-                #mass_fitter_mc_init[ipt].SetNSigma4SideBands(self.p_exclude_nsigma_sideband)
-                #success = mass_fitter_mc_init[ipt].MassFitter(False)
-                success = False
-                user_init_success = False
-                for r in [2., 3., 4., 5., 6., 7.]:
-                    guess_mean = h_mc_init_rebin.GetMean()
-                    guess_sigma = h_mc_init_rebin.GetRMS()
-                    guess_low_range = guess_mean - r * guess_sigma
-                    guess_up_range = guess_mean + r * guess_sigma
-                    guess_int = h_mc_init_rebin.Integral(h_mc_init_rebin.FindBin(guess_low_range),
-                                                         h_mc_init_rebin.FindBin(guess_up_range),
-                                                         "width")
-                    gaus_func = TF1("mc_init_gaus", "gaus", guess_low_range, guess_up_range)
-                    gaus_func.SetParameter(0, guess_int)
-                    gaus_func.SetParameter(1, guess_mean)
-                    gaus_func.SetParameter(2, guess_sigma)
-                    h_mc_init_rebin.Fit(gaus_func, "BEL0+", "", guess_low_range, guess_up_range)
-                    int_tmp = gaus_func.GetParameter(0)
-                    mean_tmp = gaus_func.GetParameter(1)
-                    mean_err_tmp = gaus_func.GetParError(1)
-                    sigma_tmp = gaus_func.GetParameter(2)
-                    sigma_err_tmp = gaus_func.GetParError(2)
-                    ndf = gaus_func.GetNDF()
-                    chi2 = gaus_func.GetChisquare()
-                    chi2ndf = chi2 / ndf if ndf > 0 else 0
-                    print("########################")
-                    print(f"Fit n RMS {r}")
-                    print(f"Guessed sigma: {guess_sigma}")
-                    print(f"fit range: {guess_low_range} - {guess_up_range}")
-                    print(f"fitted sigma {sigma_tmp}")
-                    print(f"chi2 / NDF {chi2ndf}")
-
-                    if int_tmp * sigma_tmp > 0 and \
-                            guess_mean - guess_sigma < mean_tmp < guess_mean + guess_sigma and \
-                            sigma_tmp < 1.1 * guess_sigma and chi2ndf > 0:
-                        success = True
-                        mass_fitter_mc_init.append(gaus_func)
-                        break
-
-
-                fit_status[imult][ipt]["init_MC"]["sigma"] = -1.
-                fit_status[imult][ipt]["init_MC"]["success"] = success
-                if not success:
-                    self.logger.error("Could not do initial fit on MC")
-
-                else:
-                    mean_for_data = mass_fitter_mc_init[-1].GetParameter(1)
-                    sigma_for_data = mass_fitter_mc_init[-1].GetParameter(2)
-                    mean_err_tmp = mass_fitter_mc_init[-1].GetParError(1)
-                    sigma_err_tmp = mass_fitter_mc_init[-1].GetParError(2)
-                    means_sigmas_init.insert(0, (2, mean_for_data, sigma_for_data))
-                    fit_status[imult][ipt]["init_MC"]["sigma"] = sigma_for_data
-                    if ipt not in have_summary_pt_bins:
-                        means_init_mc_histos.SetBinContent(ipt + 1, mean_for_data)
-                        means_init_mc_histos.SetBinError(ipt + 1, mean_err_tmp)
-                        sigmas_init_mc_histos.SetBinContent(ipt + 1, sigma_for_data)
-                        sigmas_init_mc_histos.SetBinError(ipt + 1, sigma_err_tmp)
-
-                    if self.init_fits_from[ipt] == "mc":
-                        user_init_success = True
-                        mean_case_user = mean_for_data
-                        sigma_case_user = sigma_for_data
-                canvas = TCanvas("fit_canvas_mc_init", suffix_write, 700, 700)
-                canvas.cd()
-                h_mc_init_rebin.Draw()
-                mass_fitter_mc_init[-1].SetLineColor(kBlue)
-                mass_fitter_mc_init[-1].Draw("same")
-
-                #mass_fitter_mc_init[ipt].DrawHere(canvas, self.p_nsigma_signal)
-                canvas.SaveAs(self.make_file_path(self.d_resultsallpdata,
-                                                  "fittedplot_integrated_mc", "eps",
-                                                  None, suffix_write))
-                canvas.Close()
-                canvas_init_mc.cd(ipt+1)
-                h_mc_init_rebin.Draw()
-                mass_fitter_mc_init[-1].Draw("same")
-                mass_fitter_mc_init.append(h_mc_init_rebin)
-                #mass_fitter_mc_init[ipt].DrawHere(gPad, self.p_nsigma_signal)
-
-                # Now, try also for data
-                fit_status[imult][ipt]["init_data"] = {}
-                histname = "hmass"
-                if self.apply_weights is True:
-                    histname = "h_invmass_weight"
-                    self.logger.info("*********** I AM USING WEIGHTED HISTOGRAMS")
-                # Weighted histograms onnly for data at the moment
-                h_invmass_init = lfile.Get(histname + suffix)
-                h_data_init_rebin_ = AliVertexingHFUtils.RebinHisto(h_invmass_init,
-                                                                    self.rebins[bin_mult_int][ipt],
-                                                                    -1)
-                h_data_init_rebin = TH1F()
-                h_data_init_rebin_.Copy(h_data_init_rebin)
-                h_data_init_rebin.SetTitle("%.1f < #it{p}_{T} < %.1f (prob > %.2f)" \
-                                           % (self.lpt_finbinmin[ipt], self.lpt_finbinmax[ipt], \
-                                              self.lpt_probcutfin[bin_id]))
-                h_data_init_rebin.GetXaxis().SetTitle("#it{M}_{inv} (GeV/#it{c}^{2})")
-                h_data_init_rebin.GetYaxis().SetTitle("Entries/(%.0f MeV/#it{c}^{2})" \
-                                                      % (h_data_init_rebin.GetBinWidth(1) * 1000))
-                h_data_init_rebin.GetYaxis().SetTitleOffset(1.1)
-
-                mass_fitter_data_init.append(AliHFInvMassFitter(h_data_init_rebin,
-                                                                self.p_massmin[ipt],
-                                                                self.p_massmax[ipt],
-                                                                self.bkg_fmap[self.p_bkgfunc[ipt]],
-                                                                self.sig_fmap[self.p_sgnfunc[ipt]]))
-
-                # Force to go on with final fit although there is no estimated signal
-                mass_fitter_data_init[ipt].SetCheckSignalCountsAfterFirstFit(False)
-                if self.p_dolike:
-                    mass_fitter_data_init[ipt].SetUseLikelihoodFit()
-                mass_fitter_data_init[ipt].SetInitialGaussianMean(mean_for_data)
-                mass_fitter_data_init[ipt].SetInitialGaussianSigma(sigma_for_data)
-                mass_fitter_data_init[ipt].SetNSigma4SideBands(self.p_exclude_nsigma_sideband)
-                # Second peak?
-                if self.p_includesecpeaks[bin_mult_int][ipt]:
-                    secpeakwidth = self.p_widthsecpeak * sigma_for_data
-                    mass_fitter_data_init[ipt].IncludeSecondGausPeak(self.p_masssecpeak, \
-                                               self.p_fix_masssecpeaks[bin_mult_int][ipt], \
-                                               secpeakwidth, \
-                                               self.p_fix_widthsecpeak)
-                success = mass_fitter_data_init[ipt].MassFitter(False)
-                fit_status[imult][ipt]["init_data"]["success"] = False
-                fit_status[imult][ipt]["init_data"]["sigma"] = -1.
-                if success == 1:
-                    if ipt not in have_summary_pt_bins:
-                        means_init_data_histos.SetBinContent(ipt + 1, \
-                                mass_fitter_data_init[ipt].GetMean())
-                        means_init_data_histos.SetBinError(ipt + 1, \
-                                mass_fitter_data_init[ipt].GetMeanUncertainty())
-                        sigmas_init_data_histos.SetBinContent(ipt + 1, \
-                                mass_fitter_data_init[ipt].GetSigma())
-                        sigmas_init_data_histos.SetBinError(ipt + 1, \
-                                mass_fitter_data_init[ipt].GetSigmaUncertainty())
-
-                    sigmafit = mass_fitter_data_init[ipt].GetSigma()
-                    if minperc * sigma_for_data < sigmafit < maxperc * sigma_for_data:
-                        means_sigmas_init.insert(0, (1, mass_fitter_data_init[ipt].GetMean(),
-                                                     mass_fitter_data_init[ipt].GetSigma()))
-                        fit_status[imult][ipt]["init_data"]["success"] = True
-                        fit_status[imult][ipt]["init_data"]["sigma"] = \
-                                mass_fitter_data_init[ipt].GetSigma()
-                        if self.init_fits_from[ipt] == "data":
-                            mean_case_user = mass_fitter_data_init[ipt].GetMean()
-                            sigma_case_user = mass_fitter_data_init[ipt].GetSigma()
-                            user_init_success = True
-
-                canvas = TCanvas("fit_canvas_data_init", suffix_write, 700, 700)
-                mass_fitter_data_init[ipt].DrawHere(canvas, self.p_nsigma_signal)
-                canvas.SaveAs(self.make_file_path(self.d_resultsallpdata,
-                                                  "fittedplot_integrated", "eps",
-                                                  None, suffix_write))
-                canvas.Close()
-                canvas_init_data.cd(ipt+1)
-                mass_fitter_data_init[ipt].DrawHere(gPad, self.p_nsigma_signal)
-
-                # Initialize mean and sigma with user seeds.
-                if self.p_use_user_gauss_sigma[ipt] is True:
-                    mean_for_data = self.p_masspeak
-                    sigma_for_data = self.p_sigmaarray[ipt]
-                    means_sigmas_init.insert(0, (3, mean_for_data, sigma_for_data))
-
-                # Remember that we have filled this pT bin
-                have_summary_pt_bins.append(ipt)
-                ######################
-                # END initialize fit #
-                ######################
-
-                # Collect all possible fit cases
-                fit_cases = []
-                for fix in [False, True]:
-                    for ms in means_sigmas_init:
-                        fit_cases.append((ms[0], ms[1], ms[2], fix))
-                if user_init_success and self.p_use_user_gauss_sigma[ipt] is False:
-                    fit_cases.insert(0, (0, mean_case_user, sigma_case_user,
-                                         self.p_fixingaussigma[ipt]))
-                elif self.p_use_user_gauss_sigma[ipt] is True:
-                    fit_cases.insert(0, (0, self.p_masspeak, self.p_sigmaarray[ipt], \
-                                         self.p_fixingaussigma[ipt]))
-                else:
-                    self.logger.error("Cannot initialise fit with what is requested by the " \
-                                      "user... Try fallback options")
-
-                # Now comes the actual fit
-                suffix = "%s%d_%d_%.2f%s_%.2f_%.2f" % \
-                         (self.v_var_binning, self.lpt_finbinmin[ipt],
-                          self.lpt_finbinmax[ipt], self.lpt_probcutfin[bin_id],
-                          self.v_var2_binning, self.lvar2_binmin[imult], self.lvar2_binmax[imult])
-                suffix_write = "%s%d_%d_%s_%.2f_%.2f" % \
-                               (self.v_var_binning, self.lpt_finbinmin[ipt],
-                                self.lpt_finbinmax[ipt],
-                                self.v_var2_binning, self.lvar2_binmin[imult],
-                                self.lvar2_binmax[imult])
-                histname = "hmass"
-                if self.apply_weights is True:
-                    histname = "h_invmass_weight"
-                    self.logger.info("*********** I AM USING WEIGHTED HISTOGRAMS")
-                # Weighted histograms onnly for data at the moment
-                h_invmass = lfile.Get(histname + suffix)
-                h_invmass_rebin_ = AliVertexingHFUtils.RebinHisto(h_invmass,
-                                                                  self.rebins[imult][ipt], -1)
-                h_invmass_rebin = TH1F()
-                h_invmass_rebin_.Copy(h_invmass_rebin)
-                h_invmass_rebin.SetTitle("%.1f < #it{p}_{T} < %.1f (prob > %.2f)" \
-                                         % (self.lpt_finbinmin[ipt], self.lpt_finbinmax[ipt], \
-                                            self.lpt_probcutfin[bin_id]))
-                h_invmass_rebin.GetXaxis().SetTitle("#it{M}_{inv} (GeV/#it{c}^{2})")
-                h_invmass_rebin.GetYaxis().SetTitle("Entries/(%.0f MeV/#it{c}^{2})" \
-                                                    % (h_invmass_rebin.GetBinWidth(1) * 1000))
-                h_invmass_rebin.GetYaxis().SetTitleOffset(1.1)
-
-                h_invmass_mc = lfile_mc.Get("hmass" + suffix)
-                h_invmass_mc_rebin_ = AliVertexingHFUtils.RebinHisto(h_invmass_mc,
-                                                                     self.rebins[imult][ipt], -1)
-                h_invmass_mc_rebin = TH1F()
-                h_invmass_mc_rebin_.Copy(h_invmass_mc_rebin)
-                success = 0
-
-                fit_status[imult][ipt]["data"] = {}
-
-                # First try not fixing sigma for all cases (mean always floating)
-                user_case_success = True
-                for case, mean, sigma, fix in fit_cases:
-
-                    ifit = ifit + 1
-                    mass_fitter.append(AliHFInvMassFitter(h_invmass_rebin, self.p_massmin[ipt],
-                                                          self.p_massmax[ipt],
-                                                          self.bkg_fmap[self.p_bkgfunc[ipt]],
-                                                          self.sig_fmap[self.p_sgnfunc[ipt]]))
-
-                    # Force to go on with final fit although there is no estimated signal
-                    mass_fitter[ifit].SetCheckSignalCountsAfterFirstFit(False)
-                    if self.p_dolike:
-                        mass_fitter[ifit].SetUseLikelihoodFit()
-                    # At this point *_for_data is either
-                    # -> the seed value extracted from integrated data pre-fit if successful
-                    # -> the seed value extracted from integrated MC pre-fit if successful
-                    #    and data pre-fit failed
-                    # -> the seed value set by the user in the database if both
-                    #    data and MC pre-fit fail
-                    mass_fitter[ifit].SetInitialGaussianMean(mean)
-                    mass_fitter[ifit].SetInitialGaussianSigma(sigma)
-                    #if self.p_fixedmean:
-                    #    mass_fitter[ifit].SetFixGaussianMean(mean_for_data)
-                    if fix:
-                        mass_fitter[ifit].SetFixGaussianSigma(sigma)
-
-                    mass_fitter[ifit].SetNSigma4SideBands(self.p_exclude_nsigma_sideband)
-
-                    if self.include_reflection:
-                        h_invmass_refl = AliVertexingHFUtils.AdaptTemplateRangeAndBinning(
-                            lfile_mc.Get("hmass_refl" + suffix), h_invmass_rebin,
-                            self.p_massmin[ipt], self.p_massmax[ipt])
-
-                        if h_invmass_refl.Integral() > 0.:
-                            mass_fitter[ifit].SetTemplateReflections(h_invmass_refl, "1gaus",
-                                                                     self.p_massmin[ipt],
-                                                                     self.p_massmax[ipt])
-                            r_over_s = h_invmass_mc_rebin.Integral(
-                                h_invmass_mc_rebin.FindBin(self.p_massmin[ipt]),
-                                h_invmass_mc_rebin.FindBin(self.p_massmax[ipt]))
-                            if r_over_s > 0.:
-                                r_over_s = h_invmass_refl.Integral(
-                                    h_invmass_refl.FindBin(self.p_massmin[ipt]),
-                                    h_invmass_refl.FindBin(self.p_massmax[ipt])) / r_over_s
-                                mass_fitter[ifit].SetFixReflOverS(r_over_s)
-                        else:
-                            self.logger.warning("Reflection requested but template empty")
-                    if self.p_includesecpeaks[imult][ipt]:
-                        secpeakwidth = self.p_widthsecpeak * sigma
-                        mass_fitter[ifit].IncludeSecondGausPeak(self.p_masssecpeak,
-                                                                self.p_fix_masssecpeaks[imult][ipt],
-                                                                secpeakwidth,
-                                                                self.p_fix_widthsecpeak)
-                    fit_status[imult][ipt]["data"]["fix"] = fix
-                    fit_status[imult][ipt]["data"]["case"] = case
-                    success = mass_fitter[ifit].MassFitter(False)
-                    if success == 1:
-                        sigma_final = mass_fitter[ifit].GetSigma()
-                        if minperc * sigma < sigma_final < maxperc * sigma:
-                            break
-                        self.logger.warning("Free fit succesful, but bad sigma. Skipped!")
-                    if case == 0:
-                        user_case_success = False
-
-                fit_status[imult][ipt]["data"]["success"] = success
-
-                pinfos = TPaveText(0.12, 0.7, 0.47, 0.89, "NDC")
-                pinfos.SetBorderSize(0)
-                pinfos.SetFillStyle(0)
-                pinfos.SetTextAlign(11)
-                pinfos.SetTextSize(0.03)
-                add_draw_objects.append(pinfos)
-                if not user_init_success:
-                    text = pinfos.AddText(f"USER INIT CASE FAILED ({self.init_fits_from[ipt]}, " \
-                            f"sigma fixed {self.p_fixingaussigma[ipt]})")
-                    text.SetTextColor(kRed)
-
-                if not user_case_success:
-                    text = pinfos.AddText(f"FIT WITH USER INIT CASE FAILED " \
-                            f"({self.init_fits_from[ipt]}, " \
-                            f"sigma fixed {self.p_fixingaussigma[ipt]})")
-                    text.SetTextColor(kRed)
-                if not success:
-                    text = pinfos.AddText("FIT FAILED")
-                    text.SetTextColor(kRed)
-
-                canvas = TCanvas("fit_canvas", suffix, 700, 700)
-                mass_fitter[ifit].DrawHere(canvas, self.p_nsigma_signal)
-                canvas.cd()
-                pinfos.Draw()
-                if self.apply_weights is False:
-                    canvas.SaveAs(self.make_file_path(self.d_resultsallpdata, "fittedplot", "eps",
-                                                      None, suffix_write))
-                else:
-                    canvas.SaveAs(self.make_file_path(self.d_resultsallpdata,
-                                                      "fittedplotweights",
-                                                      "eps", None, suffix_write))
-                canvas.Close()
-                canvas_data[imult].cd(ipt+1)
-                mass_fitter[ifit].DrawHere(gPad, self.p_nsigma_signal)
-                pinfos.Draw()
-
-                if success == 1:
-                    # In case of success == 2, no signal was found, in case of 0, fit failed
-                    rawYield = mass_fitter[ifit].GetRawYield()
-                    rawYieldErr = mass_fitter[ifit].GetRawYieldError()
-                    yieldshistos[imult].SetBinContent(ipt + 1, rawYield)
-                    yieldshistos[imult].SetBinError(ipt + 1, rawYieldErr)
-
-                    mean_fit = mass_fitter[ifit].GetMean()
-                    mean_min = min(mean_fit, mean_min)
-                    mean_max = max(mean_fit, mean_max)
-
-                    means_histos[imult].SetBinContent(ipt + 1, mean_fit)
-                    means_histos[imult].SetBinError(ipt + 1, mass_fitter[ifit].GetMeanUncertainty())
-
-                    sigma_fit = mass_fitter[ifit].GetSigma()
-                    sigma_min = min(sigma_fit, sigma_min)
-                    sigma_max = max(sigma_fit, sigma_max)
-                    fit_status[imult][ipt]["data"]["sigma"] = sigma_fit
-
-                    sigmas_histos[imult].SetBinContent(ipt + 1, sigma_fit)
-                    sigmas_histos[imult].SetBinError(ipt + 1, \
-                                                     mass_fitter[ifit].GetSigmaUncertainty())
-
-                    # Residual plot
-                    c_res = TCanvas('cRes', 'The Fit Canvas', 800, 800)
-                    c_res.cd()
-                    h_pulls = h_invmass_rebin.Clone(f"{h_invmass_rebin.GetName()}_pull")
-                    h_residual_trend = \
-                            h_invmass_rebin.Clone(f"{h_invmass_rebin.GetName()}_residual_trend")
-                    h_pulls_trend = \
-                            h_invmass_rebin.Clone(f"{h_invmass_rebin.GetName()}_pulls_trend")
-                    _ = mass_fitter[ifit].GetOverBackgroundResidualsAndPulls( \
-                            h_pulls, h_residual_trend, h_pulls_trend, self.p_massmin[ipt],
-                            self.p_massmax[ipt])
-
-                    h_residual_trend.Draw()
-                    c_res.SaveAs(self.make_file_path(self.d_resultsallpdata, "residual", "eps",
-                                                     None, suffix_write))
-                    c_res.Close()
-
-                else:
-                    self.logger.error("Fit failed for suffix %s", suffix_write)
-
-                # Write fitters to file
-                fit_root_dir = fileout.mkdir(suffix)
-                fit_root_dir.WriteObject(mass_fitter_mc_init[ipt], "gaus_mc_init")
-                fit_root_dir.WriteObject(mass_fitter_data_init[ipt], "fitter_data_init")
-                fit_root_dir.WriteObject(mass_fitter[ifit], "fitter")
-
-            #####################
-            # Back in mult loop #
-            #####################
-
-            suffix2 = "%s_%.2f_%.2f" % (self.v_var2_binning, self.lvar2_binmin[imult], \
-                                        self.lvar2_binmax[imult])
-            if imult == 0:
-                canvas_init_mc.SaveAs(self.make_file_path(self.d_resultsallpdata,
-                                                          "canvas_InitMC",
-                                                          "eps", None, suffix2))
-                canvas_init_mc.Close()
-                canvas_init_data.SaveAs(self.make_file_path(self.d_resultsallpdata,
-                                                            "canvas_InitData",
-                                                            "eps", None, suffix2))
-                canvas_init_data.Close()
-            canvas_data[imult].SaveAs(self.make_file_path(self.d_resultsallpdata,
-                                                          "canvas_FinalData",
-                                                          "eps", None, suffix2))
-            #canvas_data[imult].Close()
-            fileout.cd()
-            yieldshistos[imult].Write()
-            means_histos[imult].Write()
-            sigmas_histos[imult].Write()
-
-            del mass_fitter_mc_init[:]
-            del mass_fitter_data_init[:]
-
-        del mass_fitter[:]
-
-        # Write the fit status dict
-        dump_yaml_from_dict(fit_status, self.make_file_path(self.d_resultsallpdata, "fit_status",
-                                                            "yaml"))
-
-        # Plot some summary historgrams
-        leg_strings = [f"{self.lvar2_binmin[imult]} #leq {self.p_latexbin2var} < " \
-                       f"{self.lvar2_binmax[imult]}" for imult in range(self.p_nbin2)]
-        save_name = self.make_file_path(self.d_resultsallpdata, "Yields", "eps", None,
-                                        [self.case, self.typean])
-        # Yields summary plot
-        plot_histograms(yieldshistos, True, True, leg_strings, "uncorrected yields",
-                        "#it{p}_{T} (GeV/#it{c})",
-                        f"Uncorrected yields {self.p_latexnmeson} {self.typean}", "mult. / int.",
-                        save_name)
-        save_name = self.make_file_path(self.d_resultsallpdata, "Means", "eps", None,
-                                        [self.case, self.typean])
-        # Means summary plot
-        plot_histograms(means_histos, False, True, leg_strings, "Means",
-                        "#it{p}_{T} (GeV/#it{c})",
-                        "#mu_{fit} " + f"{self.p_latexnmeson} {self.typean}", "mult. / int.",
-                        save_name)
-        save_name = self.make_file_path(self.d_resultsallpdata, "Sigmas", "eps", None,
-                                        [self.case, self.typean])
-        #Sigmas summary plot
-        plot_histograms(sigmas_histos, False, True, leg_strings, "Sigmas",
-                        "#it{p}_{T} (GeV/#it{c})",
-                        "#sigma_{fit} " + f"{self.p_latexnmeson} {self.typean}", "mult. / int.",
-                        save_name)
-
-        # Plot the initialized means and sigma for MC and data
-        save_name = self.make_file_path(self.d_resultsallpdata, "Means_mult_int", "eps", None,
-                                        [self.case, self.typean])
-        plot_histograms([means_init_mc_histos, means_init_data_histos], False, False,
-                        ["MC", "data"], "Means of int. mult.", "#it{p}_{T} (GeV/#it{c})",
-                        "#mu_{fit} " + f"{self.p_latexnmeson} {self.typean}", "", save_name)
-
-        save_name = self.make_file_path(self.d_resultsallpdata, "Sigmas_mult_int", "eps", None,
-                                        [self.case, self.typean])
-        plot_histograms([sigmas_init_mc_histos, sigmas_init_data_histos], False, False,
-                        ["MC", "data"], "Sigmas of int. mult.", "#it{p}_{T} (GeV/#it{c})",
-                        "#sigma_{fit} " + f"{self.p_latexnmeson} {self.typean}", "", save_name)
-
+        self.fitter.draw_fits(self.d_resultsallpdata, fileout)
         fileout.Close()
+        fileout_name = os.path.join(self.d_resultsallpdata,
+                                    f"{self.fits_dirname}_{self.case}_{self.typean}")
+        self.fitter.save_fits(fileout_name)
         # Reset to former mode
         gROOT.SetBatch(tmp_is_root_batch)
+
 
     # pylint: disable=too-many-locals, too-many-nested-blocks, too-many-branches
     # pylint: disable=import-outside-toplevel
     def yield_syst(self):
-        if self.mt_syst_dict is None:
-            self.logger.warning("Could not find parameters for doing systemtics. Skip...")
-            return
         # Enable ROOT batch mode and reset in the end
         tmp_is_root_batch = gROOT.IsBatch()
         gROOT.SetBatch(True)
+        if not self.fitter:
+            fileout_name = os.path.join(self.d_resultsallpdata,
+                                        f"{self.fits_dirname}_{self.case}_{self.typean}")
+            self.fitter = MLFitter(self.datap, self.typean, self.n_filemass, self.n_filemass_mc)
+            if not self.fitter.load_fits(fileout_name):
+                self.logger.error("Cannot load fits from dir %s", fileout_name)
+                return
 
-        # Load configurable multi trial variations
-        rebin = self.mt_syst_dict.get("rebin", None)
-        fit_ranges_low = self.mt_syst_dict.get("massmin", None)
-        fit_ranges_up = self.mt_syst_dict.get("massmax", None)
-        bincount_sigma = self.mt_syst_dict.get("bincount_sigma", None)
-        bkg_funcs = self.mt_syst_dict.get("bkg_funcs", None)
-        # Sigma of MT can either be initialized from MC ("mc"), data ("data")
-        # or central ("central" ==> default)
-        initialize_sigma_from = self.mt_syst_dict.get("init_sigma_from", "central")
-        if not isinstance(initialize_sigma_from, list):
-            initialize_sigma_from = [initialize_sigma_from] * self.p_nptbins
-        if not isinstance(initialize_sigma_from[0], list):
-            initialize_sigma_from = [initialize_sigma_from] * self.p_nbin2
-
-        if not bkg_funcs:
-            self.logger.error("You need to choose at least one background function for " \
-                              "the multi trial")
-            return
-
-        from ROOT import AliHFInvMassMultiTrialFit, AliVertexingHFUtils
-
-        if not os.path.exists(self.d_mt_results_path):
-            os.makedirs(self.d_mt_results_path)
-
-        lfile = TFile.Open(self.n_filemass, "READ")
-        lfile_mc = TFile.Open(self.n_filemass_mc, "READ")
-
-        file_fits_name = self.make_file_path(self.d_resultsallpdata, self.yields_filename, "root",
-                                             None, [self.case, self.typean])
-        file_fits = TFile(file_fits_name, "READ")
-
-        # Collect arguments for parallelized multi trial run
-        for imult in range(self.p_nbin2):
-            for ipt in range(self.p_nptbins):
-                bin_id = self.bin_matching[ipt]
-
-                suffix = "%s%d_%d_%.2f%s_%.2f_%.2f" % \
-                         (self.v_var_binning, self.lpt_finbinmin[ipt],
-                          self.lpt_finbinmax[ipt], self.lpt_probcutfin[bin_id],
-                          self.v_var2_binning, self.lvar2_binmin[imult], self.lvar2_binmax[imult])
-
-                suffix_write = "%s%d_%d_%s_%.2f_%.2f" % \
-                         (self.v_var_binning, self.lpt_finbinmin[ipt],
-                          self.lpt_finbinmax[ipt],
-                          self.v_var2_binning, self.lvar2_binmin[imult], self.lvar2_binmax[imult])
-
-
-                # That we need to obtain the yield of the central fit and the initial mean
-                # set to the multi trial
-                mass_fitter_nominal = file_fits.GetDirectory(suffix).Get("fitter")
-                histname = "hmass"
-                if self.apply_weights is True:
-                    histname = "h_invmass_weight"
-                    self.logger.info("*********** I AM USING WEIGHTED HISTOGRAMS")
-                # Weighted histograms onnly for data at the moment
-                h_invmass_ = lfile.Get(histname + suffix)
-
-                h_invmass = TH1D()
-                h_invmass_.Copy(h_invmass)
-
-                # Next we need the sigma to be used for the multi trial
-                sigma_init = mass_fitter_nominal.GetSigma()
-
-                if initialize_sigma_from[imult][ipt] == "user":
-                    sigma_init = self.p_sigmaarray[ipt]
-                elif initialize_sigma_from[imult][ipt] == "mc":
-                    fit = file_fits.GetDirectory(suffix).Get("gaus_mc_init")
-                    sigma_init = fit.GetParameter(2)
-                elif initialize_sigma_from[imult][ipt] == "data":
-                    fit = file_fits.GetDirectory(suffix).Get("fitter_data_init")
-                    sigma_init = fit.GetSigma()
-
-                # Initialize the multi trial
-                multi_trial = AliHFInvMassMultiTrialFit()
-
-                multi_trial.SetSuffixForHistoNames("")
-                multi_trial.SetDrawIndividualFits(False)
-                # This is always the mean of the central fit
-                multi_trial.SetMass(mass_fitter_nominal.GetMean())
-                multi_trial.SetSigmaGaussMC(sigma_init)
-
-                # First, disable all
-                multi_trial.SetUseExpoBackground(False)
-                multi_trial.SetUseLinBackground(False)
-                multi_trial.SetUsePol2Background(False)
-                multi_trial.SetUsePol3Background(False)
-                multi_trial.SetUsePol4Background(False)
-                multi_trial.SetUsePol5Background(False)
-                multi_trial.SetUsePowerLawBackground(False)
-                multi_trial.SetUsePowerLawTimesExpoBackground(False)
-
-
-                for bkg in bkg_funcs:
-                    if bkg == "kExpo":
-                        multi_trial.SetUseExpoBackground(True)
-                        continue
-                    if bkg == "kLin":
-                        multi_trial.SetUseLinBackground(True)
-                        continue
-                    if bkg == "Pol2":
-                        multi_trial.SetUsePol2Background(True)
-                        continue
-                    if bkg == "Pol3":
-                        multi_trial.SetUsePol3Background(True)
-                        continue
-                    if bkg == "Pol4":
-                        multi_trial.SetUsePol4Background(True)
-                        continue
-                    if bkg == "Pol5":
-                        multi_trial.SetUsePol5Background(True)
-                        continue
-
-                    self.logger.fatal("Unknown background %s for multi trial", bkg)
-
-                if rebin:
-                    rebin_steps = [self.rebins[imult][ipt] + rel_rb \
-                            if self.rebins[imult][ipt] + rel_rb > 0 else 1 for rel_rb in rebin]
-                    # To only have unique values and we don't care about the order we can just do
-                    rebin_steps = list(set(rebin_steps))
-                    rebin_steps = array("i", rebin_steps)
-                    multi_trial.ConfigureRebinSteps(len(rebin_steps), rebin_steps)
-                if fit_ranges_low:
-                    low_lim_steps = array("d", fit_ranges_low)
-                    multi_trial.ConfigureLowLimFitSteps(len(fit_ranges_low),
-                                                        low_lim_steps)
-                if fit_ranges_up:
-                    up_lim_steps = array("d", fit_ranges_up)
-                    multi_trial.ConfigureUpLimFitSteps(len(fit_ranges_up), up_lim_steps)
-
-                if bincount_sigma:
-                    multi_trial.ConfigurenSigmaBinCSteps(len(bincount_sigma),
-                                                         array("d", bincount_sigma))
-
-                # Prepare for reflections if requested
-                h_invmass_mc = None
-                h_invmass_mc_refl = None
-                if self.include_reflection:
-                    h_invmass_mc_ = lfile_mc.Get("hmass" + suffix)
-                    h_invmass_mc_rebin_ = AliVertexingHFUtils.RebinHisto(h_invmass_mc_,
-                                                                         self.rebins[imult][ipt],
-                                                                         -1)
-                    h_invmass_mc = TH1F()
-                    h_invmass_mc_rebin_.Copy(h_invmass_mc)
-                    h_invmass_mc_refl_ = lfile_mc.Get("hmass_refl" + suffix)
-                    h_invmass_mc_refl = AliVertexingHFUtils.AdaptTemplateRangeAndBinning(
-                        h_invmass_mc_refl_, h_invmass,
-                        self.p_massmin[ipt], self.p_massmax[ipt])
-                    if h_invmass_mc_refl.Integral() > 0.:
-                        multi_trial.SetTemplatesForReflections(h_invmass_mc_refl, h_invmass_mc_)
-                        r_over_s = h_invmass_mc.Integral(
-                            h_invmass_mc.FindBin(self.p_massmin[ipt]),
-                            h_invmass_mc.FindBin(self.p_massmax[ipt]))
-                        if r_over_s > 0.:
-                            r_over_s = h_invmass_mc_refl.Integral(
-                                h_invmass_mc_refl.FindBin(self.p_massmin[ipt]),
-                                h_invmass_mc_refl.FindBin(self.p_massmax[ipt])) / r_over_s
-                            multi_trial.SetFixRefoS(r_over_s)
-                    else:
-                        self.logger.warning("Reflection requested but template empty")
-
-                if self.p_includesecpeaks[imult][ipt]:
-                    # To init the second peak we need to know what the user has chosen to be the
-                    # initialisation for the central fit since from that the sec. peak width was
-                    # derived
-                    sigma_sec = None
-                    if self.p_use_user_gauss_sigma[ipt] is True:
-                        sigma_sec = self.p_sigmaarray[ipt] * self.p_widthsecpeak
-                    elif self.init_fits_from[ipt] == "data":
-                        fit = file_fits.GetDirectory(suffix).Get("fitter_data_init")
-                        sigma_sec = fit.GetSigma() * self.p_widthsecpeak
-                    else:
-                        fit = file_fits.GetDirectory(suffix).Get("gaus_mc_init")
-                        sigma_sec = fit.GetParameter(2) * self.p_widthsecpeak
-                    #p_widthsecpeak to be fixed
-                    multi_trial.IncludeSecondGausPeak(self.p_masssecpeak,
-                                                      self.p_fix_masssecpeaks[imult][ipt],
-                                                      sigma_sec,
-                                                      self.p_fix_widthsecpeak)
-
-                # Just make sure it's kept until the workflow is done
-                self.root_objects.append(multi_trial)
-                mt_filename = self.make_file_path(self.d_mt_results_path, "multi_trial",
-                                                  "root", None, suffix_write)
-
-                if multi_trial.DoMultiTrials(h_invmass):
-                    multi_trial.SaveToRoot(mt_filename)
-
-        self.plot_multi_trial()
+        self.fitter.print_fits()
+        #self.fitter.perform_syst()
+        #self.plot_multi_trial()
 
         # Reset to former mode
         gROOT.SetBatch(tmp_is_root_batch)
@@ -1430,27 +673,36 @@ class Analyzer:
     def side_band_sub(self):
         self.loadstyle()
         lfile = TFile.Open(self.n_filemass)
-        func_filename = self.make_file_path(self.d_resultsallpdata, self.yields_filename, "root",
-                                            None, [self.case, self.typean])
-        func_file = TFile.Open(func_filename, "READ")
         eff_file = TFile.Open("%s/efficiencies%s%s.root" % \
                               (self.d_resultsallpmc, self.case, self.typean))
         fileouts = TFile.Open("%s/side_band_sub%s%s.root" % \
                               (self.d_resultsallpdata, self.case, self.typean), "recreate")
+
+        # Try to recover fitter and hence all fits which are assumed to be done in a previous run
+        if not self.fitter:
+            fileout_name = os.path.join(self.d_resultsallpdata,
+                                        f"{self.fits_dirname}_{self.case}_{self.typean}")
+            self.fitter = MLFitter(self.datap, self.typean, self.n_filemass, self.n_filemass_mc)
+            if not self.fitter.load_fits(fileout_name):
+                self.logger.error("Cannot load fits from dir %s", fileout_name)
+                return
+
         for imult in range(self.p_nbin2):
             heff = eff_file.Get("eff_mult%d" % imult)
             hz = None
             for ipt in range(self.p_nptbins):
+                fit = self.fitter.get_central_fit(ipt, imult)
+                if not fit:
+                    self.logger.fatal("Cannot access fit in bins (%i, %i)", ipt, imult)
+                ali_hf_fit = fit.kernel
                 bin_id = self.bin_matching[ipt]
                 suffix = "%s%d_%d_%.2f%s_%.2f_%.2f" % \
                          (self.v_var_binning, self.lpt_finbinmin[ipt],
                           self.lpt_finbinmax[ipt], self.lpt_probcutfin[bin_id],
                           self.v_var2_binning, self.lvar2_binmin[imult], self.lvar2_binmax[imult])
                 hzvsmass = lfile.Get("hzvsmass" + suffix)
-                load_dir = func_file.GetDirectory(suffix)
-                mass_fitter = load_dir.Get("fitter")
-                mean = mass_fitter.GetMean()
-                sigma = mass_fitter.GetSigma()
+                mean = ali_hf_fit.GetMean()
+                sigma = ali_hf_fit.GetSigma()
                 binmasslow2sig = hzvsmass.GetXaxis().FindBin(mean - 2*sigma)
                 masslow2sig = mean - 2*sigma
                 binmasshigh2sig = hzvsmass.GetXaxis().FindBin(mean + 2*sigma)
@@ -1476,7 +728,7 @@ class Analyzer:
                 hzbkg = hzbkgleft.Clone("hzbkg" + suffix)
                 hzbkg.Add(hzbkgright)
                 hzbkg_scaled = hzbkg.Clone("hzbkg_scaled" + suffix)
-                bkg_fit = mass_fitter.GetBackgroundRecalcFunc()
+                bkg_fit = ali_hf_fit.GetBackgroundRecalcFunc()
                 area_scale_denominator = bkg_fit.Integral(masslow9sig, masslow4sig) + \
                 bkg_fit.Integral(masshigh4sig, masshigh9sig)
                 area_scale = bkg_fit.Integral(masslow2sig, masshigh2sig)/area_scale_denominator

--- a/machine_learning_hep/fitting/__init__.py
+++ b/machine_learning_hep/fitting/__init__.py
@@ -1,0 +1,13 @@
+#############################################################################
+##  © Copyright CERN 2018. All rights not expressly granted are reserved.  ##
+##                 Author: Gian.Michele.Innocenti@cern.ch                  ##
+## This program is free software: you can redistribute it and/or modify it ##
+##  under the terms of the GNU General Public License as published by the  ##
+## Free Software Foundation, either version 3 of the License, or (at your  ##
+## option) any later version. This program is distributed in the hope that ##
+##  it will be useful, but WITHOUT ANY WARRANTY; without even the implied  ##
+##     warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.    ##
+##           See the GNU General Public License for more details.          ##
+##    You should have received a copy of the GNU General Public License    ##
+##   along with this program. if not, see <https://www.gnu.org/licenses/>. ##
+#############################################################################

--- a/machine_learning_hep/fitting/fitters.py
+++ b/machine_learning_hep/fitting/fitters.py
@@ -1,0 +1,636 @@
+#############################################################################
+##  © Copyright CERN 2018. All rights not expressly granted are reserved.  ##
+##                 Author: Gian.Michele.Innocenti@cern.ch                  ##
+## This program is free software: you can redistribute it and/or modify it ##
+##  under the terms of the GNU General Public License as published by the  ##
+## Free Software Foundation, either version 3 of the License, or (at your  ##
+## option) any later version. This program is distributed in the hope that ##
+##  it will be useful, but WITHOUT ANY WARRANTY; without even the implied  ##
+##     warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.    ##
+##           See the GNU General Public License for more details.          ##
+##    You should have received a copy of the GNU General Public License    ##
+##   along with this program. if not, see <https://www.gnu.org/licenses/>. ##
+#############################################################################
+
+"""
+Definition of FitterBase, Fitter and SystFitter classes
+Definition of FitBase, FitAliHF, FitROOT classes
+"""
+
+from copy import deepcopy
+from array import array
+
+# pylint: disable=import-error, no-name-in-module, unused-import
+from ROOT import AliHFInvMassFitter, AliVertexingHFUtils, AliHFInvMassMultiTrialFit
+from ROOT import TH1F, TF1, kBlue
+
+from machine_learning_hep.logger import get_logger
+
+# pylint: disable=too-many-instance-attributes
+class FitBase:
+    """
+    Common base class for FitAliHF and FitROOT.
+    """
+
+    def __init__(self, init_pars):
+        self.logger = get_logger()
+        # If nit/fitting attempt was made
+        self.has_attempt = False
+        # Whether fitting was successful in the end
+        self.success = False
+        # Initialisation parameters
+        self.user_init_pars = deepcopy(init_pars)
+        self.init_pars = None
+        # Default init parameters (to be modified for deriving classes)
+        self.default_init_pars = {"mean": None,
+                                  "fix_mean": False,
+                                  "sigma": None,
+                                  "fix_sigma": False,
+                                  "rebin": None,
+                                  "fit_range_low": None,
+                                  "fit_range_up": None,
+                                  "likelihood": True,
+                                  "n_sigma_sideband": None,
+                                  "sig_func_name": None,
+                                  "bkg_func_name": None}
+        # Fitted parameters (to be modified for deriving classes)
+        self.fit_pars = {}
+        # The fit kernel
+        self.kernel = None
+
+
+    def make_default_init_pars(self):
+        """
+        Small wrapper for constructing default inititalisation parameters
+        # Returns:
+            Dictionary of default initialisation parameters
+        """
+        return deepcopy(self.default_init_pars)
+
+
+    def get_fit_pars(self):
+        """
+        Small wrapper providing deep copy of fit parameters
+        # Returns:
+            Dictionary of fitted parameters
+        """
+        return deepcopy(self.fit_pars)
+
+    def override_init_pars(self, **init_pars):
+        for par, val in init_pars.items():
+            if par in self.user_init_pars:
+                self.user_init_pars[par] = val
+
+
+    def init_fit(self):
+        """
+        Few common things, but core to be implemented in deriving classes
+        """
+        self.logger.info("Init fit")
+
+        # Potentially found a fit to initialise from
+        self.init_pars = self.make_default_init_pars()
+
+        # Collect key which haven't changed
+        pars_not_changed = []
+        for k in list(self.init_pars.keys()):
+            if k in self.user_init_pars:
+                self.init_pars[k] = self.user_init_pars.pop(k)
+                continue
+            pars_not_changed.append(k)
+
+        self.logger.debug("Following default parameters are used")
+        for p in pars_not_changed:
+            print(p)
+
+        return True
+
+
+    def init_kernel(self):
+        self.logger.debug("Init kernel")
+        return True
+
+
+    def fit_kernel(self):
+        self.logger.debug("Fit kernel")
+        return True
+
+
+    def set_fit_pars(self):
+        pass
+
+
+    def fit(self):
+        if self.has_attempt:
+            self.logger.info("Was already fitted. Skip...")
+            return
+        if self.init_fit():
+            if self.init_kernel():
+                self.success = self.fit_kernel()
+                if self.success:
+                    self.set_fit_pars()
+        self.has_attempt = True
+
+
+    def draw(self, root_pad, title=None, x_axis_label=None, y_axis_label=None, **draw_args):
+        # Keep like this to be able to insert common draw procedure here
+        if not self.has_attempt:
+            self.logger.info("Fit not done yet, nothing to draw. Skip...")
+            return
+        self.draw_kernel(root_pad, title=title, x_axis_label=x_axis_label,
+                         y_axis_label=y_axis_label, **draw_args)
+
+
+    # pylint: disable=unused-argument
+    def draw_kernel(self, root_pad, **draw_args):
+        self.logger.debug("Draw kernel")
+
+# pylint: enable=too-many-instance-attributes
+
+
+class FitROOT(FitBase):
+
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.root_objects = None
+
+
+    def set_root_objects(self, root_objects):
+        self.root_objects = root_objects
+        self.update_root_objects()
+
+    def update_root_objects(self):
+        pass
+
+
+    def __str__(self):
+        string = f"--------------------------------\n" \
+                 f"Class: {self.__class__.__name__}\n" \
+                 f"Kernel: {self.kernel.__class__.__name__}, {self.kernel}\n" \
+                 f"Init parameters:\n"
+        string += str(self.init_pars)
+        string += "\nROOT objects\n"
+        for name, obj in self.root_objects.items():
+            string += f"\tName: {name}, object: {obj}\n"
+        string += "--------------------------------"
+        return string
+
+
+class FitAliHF(FitROOT):
+    """
+    Class with AliHFMassFitter as core fitting utility
+    """
+    def __init__(self, *args, histo=None, histo_mc=None, histo_reflections=None, **base_args):
+        super().__init__(*args, **base_args)
+        self.histo = histo
+        self.histo_mc = histo_mc
+        self.histo_reflections = histo_reflections
+        # AliHF fitter
+
+        self.default_init_pars = {"mean": None,
+                                  "fix_mean": False,
+                                  "sigma": None,
+                                  "fix_sigma": False,
+                                  "include_sec_peak": False,
+                                  "sec_mean": None,
+                                  "fix_sec_mean": False,
+                                  "sec_sigma": None,
+                                  "fix_sec_sigma": False,
+                                  "use_sec_peak_rel_sigma": True,
+                                  "include_reflections": False,
+                                  "fix_reflections_s_over_b": True,
+                                  "rebin": None,
+                                  "fit_range_low": None,
+                                  "fit_range_up": None,
+                                  "likelihood": True,
+                                  "n_sigma_sideband": None,
+                                  "rel_sigma_bound": None,
+                                  "sig_func_name": None,
+                                  "bkg_func_name": None}
+        # Fitted parameters (to be modified for deriving classes)
+        # Only those corresponding to init parameters are here. Specific parameters/values
+        # provided by the kernel have to be extracted from that directly.
+        self.fit_pars = {"mean": None,
+                         "sigma": None}
+        self.update_root_objects()
+
+
+    def update_root_objects(self):
+        if self.root_objects is None:
+            self.root_objects = {}
+        self.histo = self.root_objects.get("histo", self.histo)
+        self.histo_mc = self.root_objects.get("histo_mc", self.histo_mc)
+        self.histo_reflections = self.root_objects.get("histo_reflections", self.histo_reflections)
+
+        self.root_objects["histo"] = self.histo
+        self.root_objects["histo_mc"] = self.histo_mc
+        self.root_objects["histo_reflections"] = self.histo_reflections
+
+
+    def init_kernel(self):
+
+        self.update_root_objects()
+
+        if self.init_pars["rebin"]:
+            histo_rebin_ = AliVertexingHFUtils.RebinHisto(self.histo, self.init_pars["rebin"], -1)
+            self.histo = TH1F()
+            histo_rebin_.Copy(self.histo)
+            self.histo.SetName(f"{self.histo.GetName()}_fit_histo")
+        else:
+            self.histo = self.histo.Clone(f"{self.histo.GetName()}_fit_histo")
+
+
+        self.kernel = AliHFInvMassFitter(self.histo,
+                                         self.init_pars["fit_range_low"],
+                                         self.init_pars["fit_range_up"],
+                                         self.init_pars["sig_func_name"],
+                                         self.init_pars["bkg_func_name"])
+        self.kernel.SetCheckSignalCountsAfterFirstFit(False)
+        if self.init_pars["likelihood"]:
+            self.kernel.SetUseLikelihoodFit()
+        self.kernel.SetInitialGaussianMean(self.init_pars["mean"])
+        self.kernel.SetInitialGaussianSigma(self.init_pars["sigma"])
+        self.kernel.SetNSigma4SideBands(self.init_pars["n_sigma_sideband"])
+        if self.init_pars["fix_sigma"]:
+            self.kernel.SetFixGaussianSigma(self.init_pars["sigma"])
+
+        if self.init_pars["include_reflections"]:
+
+            self.histo_reflections = AliVertexingHFUtils.AdaptTemplateRangeAndBinning( \
+                    self.histo_reflections, self.histo, self.init_pars["fit_range_low"],
+                    self.init_pars["fit_range_up"])
+
+            if not self.init_pars["fix_reflections_s_over_b"]:
+                self.kernel.SetTemplateReflections(self.histo_reflections, "1gaus",
+                                                   self.init_pars["fit_range_low"],
+                                                   self.init_pars["fit_range_up"])
+            else:
+                if self.init_pars["rebin"]:
+                    histo_mc_rebin_ = AliVertexingHFUtils.RebinHisto(self.histo_mc,
+                                                                     self.init_pars["rebin"], -1)
+
+                    self.histo_mc = TH1F()
+                    histo_mc_rebin_.Copy(self.histo_mc)
+                    self.histo_mc.SetName(f"{self.histo_mc.GetName()}_fit_histo")
+                else:
+                    self.histo_mc = self.histo_mc.Clone(f"{self.histo_mc.GetName()}_fit_histo")
+
+                r_over_s = self.histo_mc.Integral(
+                    self.histo_mc.FindBin(self.init_pars["fit_range_low"]),
+                    self.histo_mc.FindBin(self.init_pars["fit_range_up"]))
+                if r_over_s > 0.:
+                    r_over_s = self.histo_reflections.Integral(
+                        self.histo_reflections.FindBin(self.init_pars["fit_range_low"]),
+                        self.histo_reflections.FindBin(self.init_pars["fit_range_up"])) / r_over_s
+                    self.kernel.SetTemplateReflections(self.histo_reflections, "1gaus",
+                                                       self.init_pars["fit_range_low"],
+                                                       self.init_pars["fit_range_up"])
+                    self.kernel.SetFixReflOverS(r_over_s)
+
+        if self.init_pars["include_sec_peak"]:
+            sec_sigma = self.init_pars["sigma"] * self.init_pars["sec_sigma"] \
+                    if self.init_pars["use_sec_peak_rel_sigma"] \
+                    else self.init_pars["sec_sigma"]
+            self.kernel.IncludeSecondGausPeak(self.init_pars["sec_mean"],
+                                              self.init_pars["fix_sec_mean"],
+                                              sec_sigma,
+                                              self.init_pars["fix_sec_sigma"])
+
+        return True
+
+
+    def fit_kernel(self):
+        success = self.kernel.MassFitter(False)
+        if success:
+            if self.kernel.GetRawYield() < 0.:
+                return False
+            if self.init_pars["rel_sigma_bound"]:
+                fit_sigma = self.kernel.GetSigma()
+                min_sigma = (1 - self.init_pars["rel_sigma_bound"]) * self.init_pars["sigma"]
+                max_sigma = (1 + self.init_pars["rel_sigma_bound"]) * self.init_pars["sigma"]
+                return min_sigma < fit_sigma < max_sigma
+        return success
+
+
+    def set_fit_pars(self):
+        self.fit_pars["mean"] = self.kernel.GetMean()
+        self.fit_pars["sigma"] = self.kernel.GetSigma()
+
+
+    def draw_kernel(self, root_pad, **draw_args):
+
+        title = draw_args.pop("title", "")
+        x_axis_label = draw_args.pop("x_axis_label", "")
+        y_axis_label = draw_args.pop("y_axis_label", "")
+        sigma_signal = draw_args.pop("sigma_signal", 3)
+
+        add_root_objects = draw_args.pop("add_root_objects", None)
+
+
+        if draw_args:
+            self.logger.warning("There are unknown draw arguments")
+
+        self.histo.SetTitle(title)
+        self.histo.GetXaxis().SetTitle(x_axis_label)
+        self.histo.GetYaxis().SetTitle(y_axis_label)
+
+        self.histo.GetYaxis().SetTitleOffset(1.1)
+
+        self.kernel.DrawHere(root_pad, sigma_signal)
+        root_pad.cd()
+
+        if add_root_objects:
+            for aro in add_root_objects:
+                aro.Draw()
+
+
+class FitROOTGauss(FitROOT):
+    """
+    Class with specific ROOT TF1 as core fitting utility
+    """
+    def __init__(self, *args, histo=None, **base_args):
+        super().__init__(*args, **base_args)
+        self.histo = histo
+
+        self.default_init_pars = {"mean": None,
+                                  "sigma": None,
+                                  "rebin": None,
+                                  "use_user_fit_range": False,
+                                  "fit_range_low": None,
+                                  "fit_range_up": None,
+                                  "likelihood": True}
+        # Fitted parameters (to be modified for deriving classes)
+        # Only those corresponding to init parameters are here. Specific parameters/values
+        # provided by the kernel have to be extracted from that directly.
+        self.fit_pars = {"mean": None,
+                         "sigma": None}
+
+        self.update_root_objects()
+
+    def update_root_objects(self):
+        if self.root_objects is None:
+            self.root_objects = {}
+        self.histo = self.root_objects.get("histo", self.histo)
+        self.root_objects["histo"] = self.histo
+
+
+    def init_kernel(self):
+
+        self.update_root_objects()
+
+        if self.init_pars["rebin"]:
+            histo_rebin_ = AliVertexingHFUtils.RebinHisto(self.histo, self.init_pars["rebin"], -1)
+            self.histo = TH1F()
+            histo_rebin_.Copy(self.histo)
+        return True
+
+
+    def fit_kernel_(self, mean_init, sigma_init, int_init, fit_range_low, fit_range_up):
+        fit_func = TF1("fit_func", "gaus", fit_range_low, fit_range_up)
+        fit_func.SetParameter(0, int_init)
+        fit_func.SetParameter(1, mean_init)
+        fit_func.SetParameter(2, sigma_init)
+        fit_string = "BE0+"
+        if self.init_pars["likelihood"]:
+            fit_string += "L"
+        self.histo.Fit(fit_func, fit_string, "", fit_range_low, fit_range_up)
+
+        int_fit = fit_func.GetParameter(0)
+        mean_fit = fit_func.GetParameter(1)
+        sigma_fit = fit_func.GetParameter(2)
+        chi2ndf = fit_func.GetNDF()
+        chi2ndf = fit_func.GetChisquare() / chi2ndf if chi2ndf > 0. else 0.
+
+        success = True
+        if int_fit * sigma_fit < 0. \
+                or mean_init - sigma_init > mean_fit or mean_fit > mean_init + sigma_init \
+                or 1.1 * sigma_init < sigma_fit or chi2ndf <= 0.:
+            success = False
+
+        return fit_func, success
+
+
+    def fit_kernel(self):
+        guess_mean = self.histo.GetMean()
+        guess_sigma = self.histo.GetRMS()
+
+        if self.init_pars["use_user_fit_range"]:
+            guess_int = self.histo.Integral(self.histo.FindBin(self.init_pars["fit_range_low"]),
+                                            self.histo.FindBin(self.init_pars["fit_range_up"]),
+                                            "width")
+            self.kernel, success = self.fit_kernel_(guess_mean, guess_sigma, guess_int,
+                                                    self.init_pars["fit_range_low"],
+                                                    self.init_pars["fit_range_up"])
+            return success
+
+        for r in range(2, 8):
+            guess_fit_range_low = guess_mean - r * guess_sigma
+            guess_fit_range_up = guess_mean + r * guess_sigma
+            guess_int = self.histo.Integral(self.histo.FindBin(guess_fit_range_low),
+                                            self.histo.FindBin(guess_fit_range_up),
+                                            "width")
+            self.kernel, success = self.fit_kernel_(guess_mean, guess_sigma, guess_int,
+                                                    guess_fit_range_low, guess_fit_range_up)
+            if success:
+                return success
+
+        return False
+
+
+    def set_fit_pars(self):
+        self.fit_pars["mean"] = self.kernel.GetParameter(1)
+        self.fit_pars["sigma"] = self.kernel.GetParameter(2)
+
+
+    def draw_kernel(self, root_pad, **draw_args):
+
+        title = draw_args.pop("title", "")
+        x_axis_label = draw_args.pop("x_axis_label", "")
+        y_axis_label = draw_args.pop("y_axis_label", "")
+
+        if draw_args:
+            self.logger.warning("There are unknown draw arguments")
+
+        self.histo.SetTitle(title)
+        self.histo.GetXaxis().SetTitle(x_axis_label)
+        self.histo.GetYaxis().SetTitle(y_axis_label)
+
+        self.histo.GetYaxis().SetTitleOffset(1.1)
+
+        root_pad.cd()
+
+        self.kernel.SetLineColor(kBlue)
+        self.histo.Draw()
+        self.kernel.Draw("same")
+
+
+# pylint: disable=too-many-instance-attributes
+class FitSystAliHF(FitROOT):
+    """
+    Class with AliHFMassFitter as core fitting utility
+    """
+
+    def __init__(self, *args, histo=None, histo_mc=None, histo_reflections=None, **base_args):
+        super().__init__(**base_args)
+        self.histo = histo
+        self.histo_mc = histo_mc
+        self.histo_reflections = histo_reflections
+
+        self.default_init_pars = {"mean": None,
+                                  "sigma": None,
+                                  "mean_central": None,
+                                  "sigma_central": None,
+                                  "include_sec_peak": False,
+                                  "sec_mean": None,
+                                  "fix_sec_mean": False,
+                                  "sec_sigma": None,
+                                  "fix_sec_sigma": False,
+                                  "use_sec_peak_rel_sigma": True,
+                                  "include_reflections": False,
+                                  "fix_reflections_s_over_b": True,
+                                  "rebin": None,
+                                  "rebin_central": None,
+                                  "fit_range_low": None,
+                                  "fit_range_up": None,
+                                  "fit_range_low_central": None,
+                                  "fit_range_up_central": None,
+                                  "bin_count_sigma": None,
+                                  "bkg_func_names": None,
+                                  "likelihood": True,
+                                  "n_sigma_sideband": None}
+        # Fitted parameters (to be modified for deriving classes)
+        # Only those corresponding to init parameters are here. Specific parameters/values
+        # provided by the kernel have to be extracted from that directly.
+        self.fit_pars = None
+        self.results_path = None
+        self.update_root_objects()
+
+
+    def update_root_objects(self):
+        if self.root_objects is None:
+            self.root_objects = {}
+        self.histo = self.root_objects.get("histo", self.histo)
+        self.histo_mc = self.root_objects.get("histo_mc", self.histo_mc)
+        self.histo_reflections = self.root_objects.get("histo_reflections", self.histo_reflections)
+
+        self.root_objects["histo"] = self.histo
+        self.root_objects["histo_mc"] = self.histo_mc
+        self.root_objects["histo_reflections"] = self.histo_reflections
+
+
+    def init_kernel(self):
+
+        self.update_root_objects()
+
+        self.histo = self.histo.Clone(f"{self.histo.GetName()}_fit_histo")
+        self.kernel = AliHFInvMassMultiTrialFit()
+
+        self.kernel.SetSuffixForHistoNames("")
+        self.kernel.SetDrawIndividualFits(False)
+        # This is always the mean of the central fit
+        self.kernel.SetMass(self.init_pars["mean"])
+        self.kernel.SetSigmaGaussMC(self.init_pars["sigma"])
+
+        # First, disable all
+        self.kernel.SetUseExpoBackground("kExpo" in self.init_pars["bkg_func_names"])
+        self.kernel.SetUseLinBackground("kLin" in self.init_pars["bkg_func_names"])
+        self.kernel.SetUsePol2Background("Pol2" in self.init_pars["bkg_func_names"])
+        self.kernel.SetUsePol3Background("Pol3" in self.init_pars["bkg_func_names"])
+        self.kernel.SetUsePol4Background("Pol4" in self.init_pars["bkg_func_names"])
+        self.kernel.SetUsePol5Background("Pol5" in self.init_pars["bkg_func_names"])
+        # NOTE Not used at the momemnt
+        self.kernel.SetUsePowerLawBackground(False)
+        self.kernel.SetUsePowerLawTimesExpoBackground(False)
+
+        if self.init_pars["rebin"]:
+            rebin_steps = [self.init_pars["rebin_central"] + rel_rb \
+                    if self.init_pars["rebin_central"] + rel_rb > 0 \
+                    else 1 for rel_rb in self.init_pars["rebin"]]
+            # To only have unique values and we don't care about the order we can just do
+            rebin_steps = array("i", list(set(rebin_steps)))
+            self.kernel.ConfigureRebinSteps(len(rebin_steps), rebin_steps)
+        if self.init_pars["fit_range_low"]:
+            low_lim_steps = array("d", self.init_pars["fit_range_low"])
+            self.kernel.ConfigureLowLimFitSteps(len(self.init_pars["fit_range_low"]),
+                                                low_lim_steps)
+        if self.init_pars["fit_range_up"]:
+            up_lim_steps = array("d", self.init_pars["fit_range_up"])
+            self.kernel.ConfigureUpLimFitSteps(len(self.init_pars["fit_range_up"]), up_lim_steps)
+
+        if self.init_pars["bincount_sigma"]:
+            self.kernel.ConfigurenSigmaBinCSteps(len(self.init_pars["bincount_sigma"]),
+                                                 array("d", self.init_pars["bincount_sigma"]))
+
+        if self.init_pars["include_reflections"]:
+            histo_mc_ = AliVertexingHFUtils.RebinHisto(self.histo_mc,
+                                                       self.init_pars["rebin_central"],
+                                                       -1)
+            self.histo_mc = TH1F()
+            histo_mc_.Copy(self.histo_mc)
+            self.histo_reflections = AliVertexingHFUtils.AdaptTemplateRangeAndBinning(
+                self.histo_reflections, self.histo,
+                self.init_pars["fit_range_low_central"], self.init_pars["fit_range_up_central"])
+            if self.histo_reflections.Integral() > 0.:
+                self.kernel.SetTemplatesForReflections(self.histo_reflections, self.histo_mc)
+                r_over_s = self.histo_mc.Integral(
+                    self.histo_mc.FindBin(self.init_pars["fit_range_low_central"]),
+                    self.histo_mc.FindBin(self.init_pars["fit_range_up_central"]))
+                if r_over_s > 0.:
+                    r_over_s = self.histo_reflections.Integral(
+                        self.histo_reflections.FindBin(self.init_pars["fit_range_low_central"]),
+                        self.histo_reflections.FindBin(self.init_pars["fit_range_up_central"])) \
+                                / r_over_s
+                    self.kernel.SetFixRefoS(r_over_s)
+            else:
+                self.logger.warning("Reflection requested but template empty")
+
+        if self.init_pars["include_sec_peaks"]:
+            #p_widthsecpeak to be fixed
+            sec_sigma = self.init_pars["sigma"] * self.init_pars["sec_sigma"] \
+                    if self.init_pars["use_sec_peak_rel_sigma"] \
+                    else self.init_pars["sec_sigma"]
+            self.kernel.IncludeSecondGausPeak(self.init_pars["sec_mean"],
+                                              self.init_pars["fix_sec_mean"],
+                                              sec_sigma,
+                                              self.init_pars["fix_sec_sigma"])
+
+
+    def fit_kernel(self):
+        success = self.kernel.DoMultiTrials(self.histo)
+        if success and self.results_path:
+            self.kernel.SaveToRoot(self.results_path)
+        return success
+
+
+    def set_fit_pars(self):
+        self.fit_pars["mean"] = self.kernel.GetMean()
+        self.fit_pars["sigma"] = self.kernel.GetSigma()
+
+
+    def draw_kernel(self, root_pad, **draw_args):
+
+        title = draw_args.pop("title", "")
+        x_axis_label = draw_args.pop("x_axis_label", "")
+        y_axis_label = draw_args.pop("y_axis_label", "")
+        sigma_signal = draw_args.pop("sigma_signal", 3)
+
+        add_root_objects = draw_args.pop("add_objects", None)
+
+
+        if draw_args:
+            self.logger.warning("There are unknown draw arguments")
+
+        self.histo.SetTitle(title)
+        self.histo.GetXaxis().SetTitle(x_axis_label)
+        self.histo.GetYaxis().SetTitle(y_axis_label)
+
+        self.histo.GetYaxis().SetTitleiOffset(1.1)
+
+        root_pad.cd()
+        self.kernel.DrawHere(root_pad, sigma_signal)
+
+        if add_root_objects:
+            for aro in add_root_objects:
+                aro.Draw("same")
+# pylint: enable=too-many-instance-attributes

--- a/machine_learning_hep/fitting/helpers.py
+++ b/machine_learning_hep/fitting/helpers.py
@@ -1,0 +1,751 @@
+#############################################################################
+##  © Copyright CERN 2018. All rights not expressly granted are reserved.  ##
+##                 Author: Gian.Michele.Innocenti@cern.ch                  ##
+## This program is free software: you can redistribute it and/or modify it ##
+##  under the terms of the GNU General Public License as published by the  ##
+## Free Software Foundation, either version 3 of the License, or (at your  ##
+## option) any later version. This program is distributed in the hope that ##
+##  it will be useful, but WITHOUT ANY WARRANTY; without even the implied  ##
+##     warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.    ##
+##           See the GNU General Public License for more details.          ##
+##    You should have received a copy of the GNU General Public License    ##
+##   along with this program. if not, see <https://www.gnu.org/licenses/>. ##
+#############################################################################
+
+
+from os.path import join
+from glob import glob
+from array import array
+
+#pylint: disable=no-name-in-module
+from ROOT import TFile, TH1F, TCanvas, TPaveText, gStyle, kRed
+#pylint: enable=no-name-in-module
+
+from machine_learning_hep.logger import get_logger
+from machine_learning_hep.utilities import make_file_path
+from machine_learning_hep.utilities_plot import plot_histograms
+from machine_learning_hep.fitting.utils import save_fit, load_fit
+from machine_learning_hep.fitting.fitters import FitAliHF, FitROOTGauss, FitSystAliHF
+
+# pylint: disable=too-many-instance-attributes, too-many-statements
+class MLFitParsFactory:
+
+    SIG_FUNC_MAP = {"kGaus": 0, "k2Gaus": 1, "kGausSigmaRatioPar": 2}
+    BKG_FUNC_MAP = {"kExpo": 0, "kLin": 1, "Pol2": 2, "kNoBk": 3, "kPow": 4, "kPowEx": 5}
+
+    def __init__(self, database: dict, ana_type: str, file_data_name: str, file_mc_name: str):
+
+        self.logger = get_logger()
+
+        ana_config = database["analysis"][ana_type]
+
+        self.prob_cut_fin = database["mlapplication"]["probcutoptimal"]
+
+        # File config
+        self.file_data_name = file_data_name
+        self.file_mc_name = file_mc_name
+
+        # Binning
+        self.bin1_name = database["var_binning"]
+        self.bins1_edges_low = ana_config["sel_an_binmin"]
+        self.bins1_edges_up = ana_config["sel_an_binmax"]
+        self.n_bins1 = len(self.bins1_edges_low)
+        self.bin2_name = ana_config["var_binning2"]
+        self.bin2_gen_name = ana_config["var_binning2_gen"]
+        self.bins2_edges_low = ana_config["sel_binmin2"]
+        self.bins2_edges_up = ana_config["sel_binmax2"]
+        self.n_bins2 = len(self.bins2_edges_low)
+        self.bin_matching = ana_config["binning_matching"]
+
+        bineff = ana_config["usesinglebineff"]
+        self.bins2_int_bin = bineff if bineff is not None else 0
+        # Fit method flags
+        self.init_fits_from = ana_config["init_fits_from"]
+        self.sig_func_name = ana_config["sgnfunc"]
+        self.bkg_func_name = ana_config["bkgfunc"]
+        self.fit_range_low = ana_config["massmin"]
+        self.fit_range_up = ana_config["massmax"]
+        self.likelihood = ana_config["dolikelihood"]
+        self.rebin = ana_config["rebin"]
+        try:
+            iter(self.rebin[0])
+        except TypeError:
+            self.rebin = [self.rebin for _ in range(self.n_bins2)]
+
+        # Initial fit parameters
+        self.mean = ana_config["masspeak"]
+        self.fix_mean = ana_config["FixedMean"]
+        self.use_user_mean = ana_config["SetInitialGaussianMean"]
+        self.sigma = ana_config["sigmaarray"]
+        self.fix_sigma = ana_config["SetFixGaussianSigma"]
+        self.use_user_sigma = ana_config["SetInitialGaussianSigma"]
+        self.max_rel_sigma_diff = ana_config["MaxPercSigmaDeviation"]
+        self.n_sigma_sideband = ana_config["exclude_nsigma_sideband"]
+        self.n_sigma_signal = ana_config["nsigma_signal"]
+        self.rel_sigma_bound = ana_config["MaxPercSigmaDeviation"]
+
+        # Second peak flags
+        self.include_sec_peak = ana_config.get("includesecpeak", [False] * self.n_bins1)
+        try:
+            iter(self.include_sec_peak[0])
+        except TypeError:
+            self.inculde_sec_peak = [self.include_sec_peak for _ in range(self.n_bins2)]
+
+        self.sec_mean = ana_config["masssecpeak"] if self.include_sec_peak else None
+        self.fix_sec_mean = ana_config.get("fix_masssecpeak", [False] * self.n_bins1)
+        try:
+            iter(self.fix_sec_mean[0])
+        except TypeError:
+            self.fix_sec_mean = [self.fix_sec_mean for _ in range(self.n_bins2)]
+        self.sec_sigma = ana_config["widthsecpeak"] if self.include_sec_peak else None
+        self.fix_sec_sigma = ana_config["fix_widthsecpeak"] if self.include_sec_peak else None
+
+        # Reflections flag
+        self.include_reflections = ana_config.get("include_reflection", False)
+
+        # Is this a trigger weighted histogram?
+        self.apply_weights = ana_config["triggersel"]["weighttrig"]
+
+        # Systematics
+        self.syst_pars = ana_config.get("systematics", None)
+        self.syst_init_sigma_from = None
+        if self.syst_pars:
+            self.syst_init_sigma_from = self.syst_pars.get("init_sigma_from", "central")
+            try:
+                iter(self.syst_init_sigma_from)
+            except TypeError:
+                self.syst_init_sigma_from = [self.syst_init_sigma_from] * self.n_bins1
+            try:
+                iter(self.syst_init_sigma_from[0])
+            except TypeError:
+                self.syst_init_sigma_from = [self.syst_init_sigma_from] * self.n_bins2
+
+
+    def make_ali_hf_fit_pars(self, ibin1, ibin2):
+
+        fit_pars = {"sig_func_name": MLFitParsFactory.SIG_FUNC_MAP[self.sig_func_name[ibin1]],
+                    "bkg_func_name": MLFitParsFactory.BKG_FUNC_MAP[self.bkg_func_name[ibin1]],
+                    "likelihood": self.likelihood,
+                    "rebin": self.rebin[ibin2][ibin1],
+                    "fit_range_low": self.fit_range_low[ibin1],
+                    "fit_range_up": self.fit_range_up[ibin1],
+                    "n_sigma_sideband": self.n_sigma_sideband,
+                    "rel_sigma_bound": self.rel_sigma_bound,
+                    "mean": self.mean,
+                    "sigma": self.sigma[ibin1],
+                    "fix_mean": self.fix_mean,
+                    "fix_sigma": self.fix_sigma[ibin1]}
+
+        fit_pars["include_sec_peak"] = self.include_sec_peak[ibin2][ibin1]
+        if self.include_sec_peak[ibin2][ibin1]:
+            fit_pars["sec_mean"] = self.sec_mean
+            fit_pars["fix_sec_mean"] = self.fix_sec_mean[ibin2][ibin1]
+            fit_pars["sec_sigma"] = self.sec_sigma
+            fit_pars["fix_sec_sigma"] = self.fix_sec_sigma
+            fit_pars["use_sec_peak_rel_sigma"] = True
+
+        if self.include_reflections:
+            fit_pars["include_reflections"] = True
+            fit_pars["fix_reflections_s_over_b"] = True
+        else:
+            fit_pars["include_reflections"] = False
+
+        return fit_pars
+
+
+    def make_ali_hf_syst_pars(self, ibin1, ibin2):
+
+        fit_pars = {"bkg_func_names": self.syst_pars.get("bkg_funcs", None),
+                    "rebin": self.syst_pars.get("rebin", None),
+                    "fit_range_low": self.syst_pars.get("massmin", None),
+                    "fit_range_up": self.syst_pars.get("massmax", None),
+                    "bin_count_sigma": self.syst_pars.get("bincount_sigma", None),
+                    "n_sigma_sideband": self.n_sigma_sideband,
+                    "likelihood": self.likelihood,
+                    "mean": self.mean,
+                    "sigma": self.sigma[ibin1],
+                    "fit_range_low_central": self.fit_range_low[ibin1],
+                    "fit_range_up_central": self.fit_range_up[ibin1],
+                    "mean_central": self.mean,
+                    "sigma_central": self.sigma[ibin1],
+                    "rebin_central": self.rebin[ibin2][ibin1]}
+
+        fit_pars["include_sec_peak"] = self.include_sec_peak[ibin2][ibin1]
+        if self.include_sec_peak[ibin2][ibin1]:
+            fit_pars["sec_mean"] = self.sec_mean
+            fit_pars["fix_sec_mean"] = self.fix_sec_mean[ibin2][ibin1]
+            fit_pars["sec_sigma"] = self.sec_sigma
+            fit_pars["fix_sec_sigma"] = self.fix_sec_sigma
+            fit_pars["use_sec_peak_rel_sigma"] = True
+
+        if self.include_reflections:
+            fit_pars["include_reflections"] = True
+            fit_pars["fix_reflections_s_over_b"] = True
+        else:
+            fit_pars["include_reflections"] = False
+
+        return fit_pars
+
+
+    def make_suffix(self, ibin1, ibin2):
+        bin_id_match = self.bin_matching[ibin1]
+        return "%s%d_%d_%.2f%s_%.2f_%.2f" % \
+               (self.bin1_name, self.bins1_edges_low[ibin1],
+                self.bins1_edges_up[ibin1], self.prob_cut_fin[bin_id_match],
+                self.bin2_name, self.bins2_edges_low[ibin2],
+                self.bins2_edges_up[ibin2])
+
+
+    def get_histograms(self, ibin1, ibin2, get_data=True, get_mc=False, get_reflections=False):
+        suffix = self.make_suffix(ibin1, ibin2)
+
+        histo_data = None
+        if get_data:
+            file_data = TFile.Open(self.file_data_name, "READ")
+            histo_name = "h_invmass_weight" if self.apply_weights else "hmass"
+            histo_data = file_data.Get(histo_name + suffix)
+            histo_data.SetDirectory(0)
+
+        if not (get_mc or get_reflections):
+            return histo_data, None, None
+
+        file_mc = TFile.Open(self.file_mc_name, "READ")
+        histo_mc = None
+        histo_reflections = None
+        if get_mc:
+            histo_mc = file_mc.Get("hmass_sig" + suffix)
+            histo_mc.SetDirectory(0)
+        if get_reflections:
+            histo_reflections = file_mc.Get("hmass_refl" + suffix)
+            histo_reflections.SetDirectory(0)
+
+        return histo_data, histo_mc, histo_reflections
+
+
+    def get_fit_pars(self, ibin1, ibin2):
+
+        fit_pars = self.make_ali_hf_fit_pars(ibin1, ibin2)
+        histo_data, histo_mc, histo_reflections = self.get_histograms(ibin1, ibin2, \
+                get_data=True, get_mc=True, \
+                get_reflections=fit_pars["include_reflections"])
+
+        lock_override_init = ["sigma"] if self.use_user_sigma[ibin1] else None
+
+        return {"histograms": {"data": histo_data,
+                               "mc": histo_mc,
+                               "reflections": histo_reflections},
+                "init_from": self.init_fits_from[ibin1],
+                "lock_override_init": lock_override_init,
+                "init_pars": fit_pars}
+
+
+    def get_syst_pars(self, ibin1, ibin2):
+
+        if not self.syst_pars:
+            self.logger.warning("There are no systematics parameters defined. Skip...")
+            return None
+
+        fit_pars = self.make_ali_hf_syst_pars(ibin1, ibin2)
+        histo_data, histo_mc, histo_reflections = self.get_histograms(ibin1, ibin2, \
+                get_data=True, get_mc=fit_pars["include_reflections"], \
+                get_reflections=fit_pars["include_reflections"])
+
+        return {"histograms": {"data": histo_data,
+                               "mc": histo_mc,
+                               "reflections": histo_reflections},
+                "init_from": self.syst_init_sigma_from[ibin2][ibin1],
+                "init_pars": fit_pars}
+
+
+    def yield_fit_pars(self):
+        for ibin2 in range(self.n_bins2):
+            for ibin1 in range(self.n_bins1):
+                yield ibin1, ibin2, self.get_fit_pars(ibin1, ibin2)
+
+
+    def yield_syst_pars(self):
+        for ibin2 in range(self.n_bins2):
+            for ibin1 in range(self.n_bins1):
+                yield ibin1, ibin2, self.get_syst_pars(ibin1, ibin2)
+
+# pylint: enable=too-many-instance-attributes, too-many-statements
+
+
+# pylint: disable=too-many-instance-attributes
+class MLFitter:
+
+
+    def __init__(self, database: dict, ana_type: str, data_out_dir: str, mc_out_dir: str):
+
+        self.logger = get_logger()
+
+        self.case = next(iter(database))
+        self.ana_type = ana_type
+        self.ana_config = database["analysis"][ana_type]
+
+        self.pars_factory = MLFitParsFactory(database, ana_type, data_out_dir, mc_out_dir)
+
+        self.pre_fits_mc = None
+        self.pre_fits_data = None
+        self.central_fits = None
+        self.init_central_fits_from = None
+        self.lock_override_init = None
+        self.syst_fits = None
+        self.init_syst_fits_from = None
+
+        # Flags
+        self.is_initialized_fits = False
+        self.done_pre_fits = False
+        self.done_central_fits = False
+        self.is_initialized_syst = False
+        self.done_syst = False
+
+
+    def initialize_fits(self):
+        if self.is_initialized_fits:
+            self.logger.warning("Fits already initialized. Skip...")
+            return
+        self.pre_fits_mc = {}
+        self.pre_fits_data = {}
+        self.central_fits = {}
+        self.init_central_fits_from = {}
+        self.lock_override_init = {}
+
+        pre_fits_bins1 = []
+        for ibin1, ibin2, pars in self.pars_factory.yield_fit_pars():
+            self.central_fits[(ibin1, ibin2)] = FitAliHF( \
+                    pars["init_pars"], \
+                    histo=pars["histograms"]["data"], \
+                    histo_mc=pars["histograms"]["mc"], \
+                    histo_reflections=pars["histograms"]["reflections"])
+            self.init_central_fits_from[(ibin1, ibin2)] = pars["init_from"]
+            self.lock_override_init[(ibin1, ibin2)] = pars["lock_override_init"]
+            if ibin1 in pre_fits_bins1:
+                continue
+
+            pre_fits_bins1.append(ibin1)
+
+            self.pre_fits_mc[ibin1] = FitROOTGauss(pars["init_pars"],
+                                                   histo=pars["histograms"]["mc"])
+            self.pre_fits_data[ibin1] = FitAliHF( \
+                    pars["init_pars"], \
+                    histo=pars["histograms"]["data"], \
+                    histo_mc=pars["histograms"]["mc"], \
+                    histo_reflections=pars["histograms"]["reflections"])
+        self.is_initialized_fits = True
+
+
+    def perform_pre_fits(self):
+        if self.done_pre_fits:
+            self.logger.warning("Pre-fits already done. Skip...")
+            return
+
+        if not self.is_initialized_fits:
+            self.initialize_fits()
+
+        for fit in self.pre_fits_mc.values():
+            fit.override_init_pars(fix_mean=False, fix_sigma=False)
+            fit.fit()
+        for fit in self.pre_fits_data.values():
+            fit.override_init_pars(fix_mean=False, fix_sigma=False)
+            fit.fit()
+        self.done_pre_fits = True
+
+
+    def perform_central_fits(self):
+        if self.done_central_fits:
+            self.logger.warning("Central fits already done. Skip...")
+            return
+
+        if not self.done_pre_fits:
+            self.perform_pre_fits()
+
+        for (ibin1, ibin2), fit in self.central_fits.items():
+            override_init_pars = None
+            pre_fit = None
+            if self.init_central_fits_from[(ibin1, ibin2)] == "mc":
+                pre_fit = self.pre_fits_mc[ibin1]
+            else:
+                pre_fit = self.pre_fits_data[ibin1]
+            if not pre_fit.success:
+                self.logger.warning("Requested pre-fit on %s not successful but requested for " \
+                                    "central fit in bins (%i, %i). Skip...",
+                                    self.init_central_fits_from[(ibin1, ibin2)], ibin1, ibin2)
+                continue
+            override_init_pars = pre_fit.get_fit_pars()
+            if self.lock_override_init[(ibin1, ibin2)]:
+                for name in self.lock_override_init[(ibin1, ibin2)]:
+                    _ = override_init_pars.pop(name, None)
+
+            fit.override_init_pars(**override_init_pars)
+            fit.fit()
+
+        self.done_central_fits = True
+
+
+    def get_central_fit(self, ibin1, ibin2):
+        return self.central_fits.get((ibin1, ibin2), None)
+
+
+    def print_fits(self):
+        self.logger.info("Print all fits")
+        print("Pre-fits for data")
+        for ibin1, fit in self.pre_fits_data.items():
+            print(f"Bin1: {ibin1}")
+            print(fit)
+        print("\n ####################################\n")
+        print("Pre-fits for MC")
+        for ibin1, fit in self.pre_fits_mc.items():
+            print(f"Bin1: {ibin1}")
+            print(fit)
+        print("\n ####################################\n")
+        print("Central fits")
+        for (ibin1, ibin2), fit in self.central_fits.items():
+            print(f"Bin1, bin2: ({ibin1}, {ibin2})")
+            print(fit)
+        self.logger.info("Print all fits done")
+
+
+    def initialize_syst(self):
+        if self.is_initialized_syst:
+            self.logger.warning("Syst already initialized. Skip...")
+            return
+        if not self.done_central_fits:
+            self.logger.warning("Fits have not been done yet. Skip...")
+            return
+
+        self.syst_fits = {}
+        self.init_syst_fits_from = {}
+
+        for ibin1, ibin2, pars in self.pars_factory.yield_syst_pars():
+            self.syst_fits[(ibin1, ibin2)] = FitSystAliHF( \
+                    pars["init_pars"], \
+                    histo=pars["histograms"]["data"], \
+                    histo_mc=pars["histograms"]["mc"], \
+                    histo_reflections=pars["histograms"]["reflections"])
+            self.init_syst_fits_from[(ibin1, ibin2)] = pars["init_from"]
+
+        self.is_initialized_syst = True
+
+
+    def perform_syst(self):
+        if self.done_syst:
+            self.logger.warning("Syst already fitted. Skip...")
+            return
+
+        if not self.is_initialized_syst:
+            self.initialize_syst()
+
+        for (ibin1, ibin2), fit in self.syst_fits():
+            if not self.central_fits[(ibin1, ibin2)].success:
+                self.logger.warning("Central fit not successful for bins (%i, %i). Skip...",
+                                    ibin1, ibin2)
+                continue
+            pre_fit = None
+            init_from = self.init_syst_fits_from[(ibin1, ibin2)]
+            if init_from == "mc":
+                pre_fit = self.pre_fits_mc[ibin1]
+            elif init_from == "data":
+                pre_fit = self.pre_fits_data[ibin1]
+            else:
+                pre_fit = self.central_fits[(ibin1, ibin2)]
+            if not pre_fit.success:
+                self.logger.warning("Initial sigma for systematics cannot be set as the pre-fit " \
+                                    "on %s parameters failed for bins (%i, %i). Skip...",
+                                    init_from, ibin1, ibin2)
+                continue
+            central_fit_pars = self.central_fits[(ibin1, ibin2)].get_fit_pars()
+            mean_central = central_fit_pars["mean"]
+            sigma_central = central_fit_pars["sigma"]
+            sigma = pre_fit.get_fit_pars()["sigma"]
+
+            fit.override_init(mean=mean_central, sigma=sigma, mean_central=mean_central,
+                              sigma_central=sigma_central)
+            fit.fit()
+
+        self.done_syst = True
+
+
+    def get_bins2(self):
+        bins2 = []
+        for (_, ibin2) in self.central_fits:
+            if ibin2 in bins2:
+                continue
+            bins2.append(ibin2)
+        return bins2
+
+
+    # pylint: disable=too-many-branches, too-many-statements, too-many-locals
+    def draw_fits(self, save_dir, root_dir=None):
+        gStyle.SetOptStat(0)
+        gStyle.SetOptStat(0000)
+        gStyle.SetPalette(1)
+        gStyle.SetCanvasColor(0)
+        gStyle.SetFrameFillColor(0)
+
+        bins2 = self.get_bins2()
+        bins1_ranges = self.pars_factory.bins1_edges_low.copy()
+        bins1_ranges.append(self.pars_factory.bins1_edges_up[-1])
+        n_bins1 = len(bins1_ranges) - 1
+
+        # Summarize in mult histograms in pT bins
+        yieldshistos = {ibin2: TH1F("hyields%d" % (ibin2), "", \
+                n_bins1, array("d", bins1_ranges)) for ibin2 in bins2}
+        means_histos = {ibin2:TH1F("hmeanss%d" % (ibin2), "", \
+                n_bins1, array("d", bins1_ranges)) for ibin2 in bins2}
+        sigmas_histos = {ibin2: TH1F("hsigmas%d" % (ibin2), "", \
+                n_bins1, array("d", bins1_ranges)) for ibin2 in bins2}
+        have_summary_pt_bins = []
+        means_init_mc_histos = TH1F("hmeans_init_mc", "", n_bins1, array("d", bins1_ranges))
+        sigmas_init_mc_histos = TH1F("hsigmas_init_mc", "", n_bins1, array("d", bins1_ranges))
+        means_init_data_histos = TH1F("hmeans_init_data", "", n_bins1, array("d", bins1_ranges))
+        sigmas_init_data_histos = TH1F("hsigmas_init_data", "", n_bins1, array("d", bins1_ranges))
+
+        nx = 4
+        ny = 2
+        canvy = 533
+        if n_bins1 > 12:
+            nx = 5
+            ny = 4
+            canvy = 1200
+        elif n_bins1 > 8:
+            nx = 4
+            ny = 3
+            canvy = 800
+
+        canvas_init_mc = TCanvas("canvas_init_mc", "MC", 1000, canvy)
+        canvas_init_data = TCanvas("canvas_init_data", "Data", 1000, canvy)
+        canvas_data = {ibin2: TCanvas("canvas_data%d" % (ibin2), "Data", 1000, canvy) \
+                       for ibin2 in bins2}
+        canvas_init_mc.Divide(nx, ny)
+        canvas_init_data.Divide(nx, ny)
+
+        for c in canvas_data.values():
+            c.Divide(nx, ny)
+
+        # Need to cache some object for which the canvas is only written after the loop...
+        keep_root_objects = []
+        for (ibin1, ibin2), fit in self.central_fits.items():
+            bin_id_match = self.pars_factory.bin_matching[ibin1]
+
+            # Some variables set for drawing
+            title = f"{self.pars_factory.bins1_edges_low[ibin1]:.1f} < #it{{p}}_{{T}} < " \
+                    f"{self.pars_factory.bins1_edges_up[ibin1]:.1f}" \
+                    f"(prob > {self.pars_factory.prob_cut_fin[bin_id_match]:.2f})"
+
+            x_axis_label = "#it{M}_{inv} (GeV/#it{c}^{2})"
+            n_sigma_signal = self.pars_factory.n_sigma_signal
+
+            suffix_write = self.pars_factory.make_suffix(ibin1, ibin2)
+            if fit.success:
+
+                kernel = fit.kernel
+                histo = fit.histo
+
+                yieldshistos[ibin2].SetBinContent(ibin1 + 1, kernel.GetRawYield())
+                yieldshistos[ibin2].SetBinError(ibin1 + 1, kernel.GetRawYieldError())
+
+                means_histos[ibin2].SetBinContent(ibin1 + 1, kernel.GetMean())
+                means_histos[ibin2].SetBinError(ibin1 + 1, kernel.GetMeanUncertainty())
+
+                sigmas_histos[ibin2].SetBinContent(ibin1 + 1, kernel.GetSigma())
+                sigmas_histos[ibin2].SetBinError(ibin1 + 1, kernel.GetSigmaUncertainty())
+
+
+                # Residual plot
+                c_res = TCanvas('cRes', 'The Fit Canvas', 800, 800)
+                c_res.cd()
+                h_pulls = histo.Clone(f"{histo.GetName()}_pull")
+                h_residual_trend = histo.Clone(f"{histo.GetName()}_residual_trend")
+                h_pulls_trend = histo.Clone(f"{histo.GetName()}_pulls_trend")
+                _ = kernel.GetOverBackgroundResidualsAndPulls( \
+                        h_pulls, h_residual_trend, h_pulls_trend, \
+                        self.pars_factory.fit_range_low[ibin1], \
+                        self.pars_factory.fit_range_up[ibin1])
+                h_residual_trend.Draw()
+                c_res.SaveAs(make_file_path(save_dir, "residual", "eps", None, suffix_write))
+                c_res.Close()
+
+            add_root_objects = []
+            if not fit.success:
+                print(f"Add FIT FAILED label for {suffix_write}")
+                pinfos = TPaveText(0.12, 0.7, 0.47, 0.89, "NDC")
+                pinfos.SetBorderSize(0)
+                pinfos.SetFillStyle(0)
+                pinfos.SetTextAlign(11)
+                pinfos.SetTextSize(0.03)
+                text = pinfos.AddText("FIT FAILED")
+                text.SetTextColor(kRed)
+                add_root_objects.append(pinfos)
+                keep_root_objects.append(pinfos)
+
+            y_axis_label = \
+                    f"Entries/({histo.GetBinWidth(1) * 1000:.0f} MeV/#it{{c}}^{{2}})"
+            canvas = TCanvas("fit_canvas", suffix_write, 700, 700)
+            fit.draw(canvas, sigma_signal=n_sigma_signal, x_axis_label=x_axis_label,
+                     y_axis_label=y_axis_label, title=title,
+                     add_root_objects=add_root_objects)
+            if self.pars_factory.apply_weights is False:
+                canvas.SaveAs(make_file_path(save_dir, "fittedplot", "eps", None,
+                                             suffix_write))
+            else:
+                canvas.SaveAs(make_file_path(save_dir, "fittedplotweights", "eps", None,
+                                             suffix_write))
+            canvas.Close()
+            fit.draw(canvas_data[ibin2].cd(ibin1+1), sigma_signal=n_sigma_signal,
+                     x_axis_label=x_axis_label, y_axis_label=y_axis_label,
+                     title=title, add_root_objects=add_root_objects)
+
+
+            if ibin1 in have_summary_pt_bins:
+                continue
+
+            have_summary_pt_bins.append(ibin1)
+
+            suffix_write = self.pars_factory.make_suffix(ibin1, self.pars_factory.bins2_int_bin)
+
+            pre_fit_mc = self.pre_fits_mc[ibin1]
+            if pre_fit_mc.success:
+                kernel = pre_fit_mc.kernel
+                histo = pre_fit_mc.histo
+
+                means_init_mc_histos.SetBinContent(ibin1 + 1, kernel.GetParameter(1))
+                means_init_mc_histos.SetBinError(ibin1 + 1, kernel.GetParError(1))
+                sigmas_init_mc_histos.SetBinContent(ibin1 + 1, kernel.GetParameter(2))
+                sigmas_init_mc_histos.SetBinError(ibin1 + 1, kernel.GetParError(2))
+
+                y_axis_label = \
+                        f"Entries/({histo.GetBinWidth(1) * 1000:.0f} MeV/#it{{c}}^{{2}})"
+                canvas = TCanvas("fit_canvas_mc_init", suffix_write, 700, 700)
+                pre_fit_mc.draw(canvas, x_axis_label=x_axis_label, y_axis_label=y_axis_label,
+                                title=title)
+
+                canvas.SaveAs(make_file_path(save_dir, "fittedplot_integrated_mc", "eps", None,
+                                             suffix_write))
+                canvas.Close()
+                pre_fit_mc.draw(canvas_init_mc.cd(ibin1+1), x_axis_label=x_axis_label,
+                                y_axis_label=y_axis_label, title=title)
+
+            pre_fit_data = self.pre_fits_data[ibin1]
+            if pre_fit_data.success:
+                kernel = pre_fit_data.kernel
+                histo = pre_fit_data.histo
+
+                means_init_data_histos.SetBinContent(ibin1 + 1, kernel.GetMean())
+                means_init_data_histos.SetBinError(ibin1 + 1, kernel.GetMeanUncertainty())
+                sigmas_init_data_histos.SetBinContent(ibin1 + 1, kernel.GetSigma())
+                sigmas_init_data_histos.SetBinError(ibin1 + 1, kernel.GetSigmaUncertainty())
+
+                y_axis_label = \
+                        f"Entries/({histo.GetBinWidth(1) * 1000:.0f} MeV/#it{{c}}^{{2}})"
+                canvas = TCanvas("fit_canvas_data_init", suffix_write, 700, 700)
+                pre_fit_data.draw(canvas, sigma_signal=n_sigma_signal, x_axis_label=x_axis_label,
+                                  y_axis_label=y_axis_label, title=title)
+                canvas.SaveAs(make_file_path(save_dir, "fittedplot_integrated", "eps", None,
+                                             suffix_write))
+                canvas.Close()
+                pre_fit_data.draw(canvas_init_data.cd(ibin1+1), sigma_signal=n_sigma_signal,
+                                  x_axis_label=x_axis_label, y_axis_label=y_axis_label,
+                                  title=title)
+
+
+        canvas_init_mc.SaveAs(make_file_path(save_dir, "canvas_InitMC", "eps"))
+        canvas_init_mc.Close()
+        canvas_init_data.SaveAs(make_file_path(save_dir, "canvas_InitData", "eps"))
+        canvas_init_data.Close()
+        for ibin2 in bins2:
+            suffix2 = f"ibin2_{ibin2}"
+            canvas_data[ibin2].SaveAs(make_file_path(save_dir, "canvas_FinalData", "eps", None,
+                                                     suffix2))
+            if root_dir:
+                root_dir.cd()
+                yieldshistos[ibin2].Write()
+                means_histos[ibin2].Write()
+                sigmas_histos[ibin2].Write()
+            #canvas_data[ibin2].Close()
+
+
+        latex_bin2_var = self.ana_config["latexbin2var"]
+        latex_meson_name = self.ana_config["latexnamemeson"]
+        # Plot some summary historgrams
+        leg_strings = [f"{self.pars_factory.bins2_edges_low[ibin2]} #leq {latex_bin2_var} < " \
+                       f"{self.pars_factory.bins2_edges_up[ibin2]}" for ibin2 in bins2]
+        save_name = make_file_path(save_dir, "Yields", "eps", None, [self.case, self.ana_type])
+        # Yields summary plot
+        plot_histograms([yieldshistos[ibin2] for ibin2 in bins2], True, True, leg_strings,
+                        "uncorrected yields", "#it{p}_{T} (GeV/#it{c})",
+                        f"Uncorrected yields {latex_meson_name} {self.ana_type}", "mult. / int.",
+                        save_name)
+        save_name = make_file_path(save_dir, "Means", "eps", None, [self.case, self.ana_type])
+        # Means summary plot
+        plot_histograms([means_histos[ibin2] for ibin2 in bins2], False, True, leg_strings, "Means",
+                        "#it{p}_{T} (GeV/#it{c})",
+                        "#mu_{fit} " + f"{latex_meson_name} {self.ana_type}", "mult. / int.",
+                        save_name)
+        save_name = make_file_path(save_dir, "Sigmas", "eps", None, [self.case, self.ana_type])
+        #Sigmas summary plot
+        plot_histograms([sigmas_histos[ibin2] for ibin2 in bins2], False, True, leg_strings,
+                        "Sigmas", "#it{p}_{T} (GeV/#it{c})",
+                        "#sigma_{fit} " + f"{latex_meson_name} {self.ana_type}", "mult. / int.",
+                        save_name)
+
+        # Plot the initialized means and sigma for MC and data
+        save_name = make_file_path(save_dir, "Means_mult_int", "eps", None,
+                                   [self.case, self.ana_type])
+        plot_histograms([means_init_mc_histos, means_init_data_histos], False, False,
+                        ["MC", "data"], "Means of int. mult.", "#it{p}_{T} (GeV/#it{c})",
+                        "#mu_{fit} " + f"{latex_meson_name} {self.ana_type}", "", save_name)
+
+        save_name = make_file_path(save_dir, "Sigmas_mult_int", "eps", None,
+                                   [self.case, self.ana_type])
+        plot_histograms([sigmas_init_mc_histos, sigmas_init_data_histos], False, False,
+                        ["MC", "data"], "Sigmas of int. mult.", "#it{p}_{T} (GeV/#it{c})",
+                        "#sigma_{fit} " + f"{latex_meson_name} {self.ana_type}", "", save_name)
+
+
+    @staticmethod
+    def save_all_(fits, save_dir):
+        for i, (key, fit) in enumerate(fits.items()):
+            save_dir_fit = join(save_dir, f"fit_{i}")
+            annotations = {"key": key}
+            save_fit(fit, save_dir_fit, annotations)
+
+
+    def save_fits(self, top_save_dir):
+        self.save_all_(self.pre_fits_mc, join(top_save_dir, "pre_fits_mc"))
+        self.save_all_(self.pre_fits_data, join(top_save_dir, "pre_fits_data"))
+        self.save_all_(self.central_fits, join(top_save_dir, "central_fits"))
+
+
+    @staticmethod
+    def load_all_(fits, save_dir):
+        fit_dirs = [d for d in glob(join(save_dir, "*")) if "fit_" in d]
+        if not fit_dirs:
+            return False
+        for d in fit_dirs:
+            fit, annotations = load_fit(d)
+            fit.has_attempt = True
+            key = annotations["key"]
+            try:
+                key = tuple(key)
+            except TypeError:
+                pass
+            fits[key] = fit
+        return True
+
+
+    def load_fits(self, top_save_dir):
+        if self.pre_fits_mc or self.pre_fits_data or self.central_fits:
+            self.logger.warning("Overriding fits")
+        self.pre_fits_mc = {}
+        self.pre_fits_data = {}
+        self.central_fits = {}
+        success = self.load_all_(self.pre_fits_mc, join(top_save_dir, "pre_fits_mc")) and \
+                  self.load_all_(self.pre_fits_data, join(top_save_dir, "pre_fits_data")) and \
+                  self.load_all_(self.central_fits, join(top_save_dir, "central_fits"))
+        # Flags
+        self.is_initialized_fits = True
+        self.done_pre_fits = True
+        self.done_central_fits = False
+        return success
+# pylint: enable=too-many-instance-attributes

--- a/machine_learning_hep/fitting/utils.py
+++ b/machine_learning_hep/fitting/utils.py
@@ -1,0 +1,106 @@
+#############################################################################
+##  © Copyright CERN 2018. All rights not expressly granted are reserved.  ##
+##                 Author: Gian.Michele.Innocenti@cern.ch                  ##
+## This program is free software: you can redistribute it and/or modify it ##
+##  under the terms of the GNU General Public License as published by the  ##
+## Free Software Foundation, either version 3 of the License, or (at your  ##
+## option) any later version. This program is distributed in the hope that ##
+##  it will be useful, but WITHOUT ANY WARRANTY; without even the implied  ##
+##     warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.    ##
+##           See the GNU General Public License for more details.          ##
+##    You should have received a copy of the GNU General Public License    ##
+##   along with this program. if not, see <https://www.gnu.org/licenses/>. ##
+#############################################################################
+
+
+"""
+Common utility functions for fitting.
+Interfacing with
+    1. OS / serialization of fitters
+    2. user configuration database
+Providing and storing fitters
+"""
+from os.path import join
+import inspect
+
+# pylint: disable=import-error, no-name-in-module, unused-import
+from ROOT import TFile
+
+from machine_learning_hep.io import parse_yaml, dump_yaml_from_dict, checkdir
+from machine_learning_hep.logger import get_logger
+
+def save_fit(fit, save_dir, annotations=None):
+
+    if not fit.has_attempt:
+        get_logger().warning("Fit has not been done and will hence not be saved")
+        return
+
+    checkdir(save_dir)
+
+    root_file_name = join(save_dir, "root_objects.root")
+    root_file = TFile.Open(root_file_name, "RECREATE")
+    root_file.cd()
+
+    for name, root_object in fit.root_objects.items():
+        if root_object:
+            root_object.Write(name)
+    fit.kernel.Write("kernel")
+
+    yaml_path = join(save_dir, "init_pars.yaml")
+    dump_yaml_from_dict(fit.init_pars, yaml_path)
+
+    yaml_path = join(save_dir, "fit_pars.yaml")
+    dump_yaml_from_dict(fit.fit_pars, yaml_path)
+
+    class_name = fit.__class__.__name__
+    meta_info = {"fit_class": class_name,
+                 "success": fit.success}
+    if annotations:
+        meta_info["annotations"] = annotations
+
+    yaml_path = join(save_dir, "meta.yaml")
+    dump_yaml_from_dict(meta_info, yaml_path)
+
+
+def load_fit(save_dir):
+    yaml_path = join(save_dir, "meta.yaml")
+    meta_info = parse_yaml(yaml_path)
+
+    yaml_path = join(save_dir, "init_pars.yaml")
+
+    #pylint: disable=import-outside-toplevel
+    import machine_learning_hep.fitting.fitters as search_module
+    #pylint: enable=import-outside-toplevel
+    fit_classes = {f[0]: getattr(search_module, f[0]) \
+            for f in inspect.getmembers(search_module, inspect.isclass) \
+            if f[1].__module__ == search_module.__name__}
+    fit = None
+    if meta_info["fit_class"] in fit_classes:
+        fit = fit_classes[meta_info["fit_class"]](parse_yaml(yaml_path))
+    else:
+        get_logger().fatal("Fit class %s is invalid")
+
+    yaml_path = join(save_dir, "fit_pars.yaml")
+    fit.fit_pars = parse_yaml(yaml_path)
+
+    root_file_name = join(save_dir, "root_objects.root")
+    root_file = TFile.Open(root_file_name, "READ")
+
+    keys = root_file.GetListOfKeys()
+
+    root_objects = {}
+    for k in keys:
+        if k.GetName() == "kernel":
+            fit.kernel = k.ReadObj()
+            continue
+        obj = k.ReadObj()
+        obj.SetDirectory(0)
+        root_objects[k.GetName()] = obj
+
+    fit.set_root_objects(root_objects)
+    fit.init_fit()
+    fit.success = meta_info["success"]
+
+    if "annotations" not in meta_info:
+        return fit
+    return fit, meta_info["annotations"]

--- a/machine_learning_hep/multianalyzer.py
+++ b/machine_learning_hep/multianalyzer.py
@@ -63,8 +63,8 @@ class MultiAnalyzer: # pylint: disable=too-many-instance-attributes, too-many-st
         if self.doperiodbyperiod is True:
             for indexp in range(self.prodnumber):
                 if self.p_useperiod[indexp] == 1:
-                    self.process_listsample[indexp].fitter()
-        self.myanalyzertot.fitter()
+                    self.process_listsample[indexp].fit()
+        self.myanalyzertot.fit()
 
     def multi_yield_syst(self):
         if self.doperiodbyperiod is True:

--- a/machine_learning_hep/utilities.py
+++ b/machine_learning_hep/utilities.py
@@ -214,6 +214,28 @@ def mergerootfiles(listfiles, mergedfile, tmp_dir):
     outstring = " ".join(tmp_files)
     os.system("hadd -f -j 30 %s  %s " % (mergedfile, outstring))
 
+def make_pre_suffix(args):
+    """
+    Construct a common file suffix from args
+    """
+    try:
+        iter(args)
+    except TypeError:
+        args = [args]
+    else:
+        if isinstance(args, str):
+            args = [args]
+    args = [str(a) for a in args]
+    return "_".join(args)
+
+def make_file_path(directory, filename, extension, prefix=None, suffix=None):
+    if prefix is not None:
+        filename = make_pre_suffix(prefix) + "_" + filename
+    if suffix is not None:
+        filename = filename + "_" + make_pre_suffix(suffix)
+    extension = extension.replace(".", "")
+    return os.path.join(directory, filename + "." + extension)
+
 def parallelizer(function, argument_list, maxperchunk, max_n_procs=2):
     """
     A centralized version for quickly parallelizing basically identical to what can found in


### PR DESCRIPTION
Fitting in the package has been moved to the sub-module fitting where
there are
1) fitters.py
  Containing actual fitting classes. Basically independent of the MLHEP
  package. No need to know anything about user-interfaces or workflows.
2) utils.py
  Here are common functions dealing with a fitter. At the moment there
  are 2 functions taking care of writing/reading fitters to/from disk.
3) helpers.py
  These are helper classes being aware of e.g. the MLHEP database
  configuration and providing fast construction and access to fit needed
  within the MLHEP workflow.

1) and 2) are independent of the MLHEP package and they don't  know
anything about user-interfaces or workflows. 3) is then providing the
interface to the MLHEP workflows and some implementations.

NOTE: The systematic (aka multi-trial) has not been moved entirely yet.
This will be done until January 2020.