### PR TITLE
Make (multi)analyzer analysis calls flexible

### DIFF
--- a/machine_learning_hep/analysis/analyzer.py
+++ b/machine_learning_hep/analysis/analyzer.py
@@ -126,3 +126,16 @@ class Analyzer:
         extension = extension.replace(".", "")
         return os.path.join(directory, filename + "." + extension)
 
+
+    def analysis_step(self, step: str):
+        """
+        Given an analysis steps as string, find the corresponding method and call it.
+        Args:
+            step: analysis step as string
+        Returns:
+            True if the analysis step was found and executed, False otherwise
+        """
+        if not hasattr(self, step):
+            return False
+        getattr(self, step)()
+        return True

--- a/machine_learning_hep/fitting/fitters.py
+++ b/machine_learning_hep/fitting/fitters.py
@@ -93,16 +93,16 @@ class FitBase:
         self.init_pars = self.make_default_init_pars()
 
         # Collect key which haven't changed
-        pars_not_changed = []
+        #pars_not_changed = []
         for k in list(self.init_pars.keys()):
             if k in self.user_init_pars:
                 self.init_pars[k] = self.user_init_pars.pop(k)
-                continue
-            pars_not_changed.append(k)
+        #        continue
+        #    pars_not_changed.append(k)
 
-        self.logger.debug("Following default parameters are used")
-        for p in pars_not_changed:
-            print(p)
+        #self.logger.debug("Following default parameters are used")
+        #for p in pars_not_changed:
+            #print(p)
 
         return True
 

--- a/machine_learning_hep/fitting/helpers.py
+++ b/machine_learning_hep/fitting/helpers.py
@@ -565,20 +565,20 @@ class MLFitter:
                 c_res.SaveAs(make_file_path(save_dir, "residual", "eps", None, suffix_write))
                 c_res.Close()
 
-            y_axis_label = \
-                    f"Entries/({histo.GetBinWidth(1) * 1000:.0f} MeV/#it{{c}}^{{2}})"
-            canvas = TCanvas("fit_canvas", suffix_write, 700, 700)
-            fit.draw(canvas, sigma_signal=n_sigma_signal, x_axis_label=x_axis_label,
-                     y_axis_label=y_axis_label, title=title)
-            if self.pars_factory.apply_weights is False:
-                canvas.SaveAs(make_file_path(save_dir, "fittedplot", "eps", None,
-                                             suffix_write))
-            else:
-                canvas.SaveAs(make_file_path(save_dir, "fittedplotweights", "eps", None,
-                                             suffix_write))
-            canvas.Close()
-            fit.draw(canvas_data[ibin2].cd(ibin1+1), sigma_signal=n_sigma_signal,
-                     x_axis_label=x_axis_label, y_axis_label=y_axis_label, title=title)
+                y_axis_label = \
+                        f"Entries/({histo.GetBinWidth(1) * 1000:.0f} MeV/#it{{c}}^{{2}})"
+                canvas = TCanvas("fit_canvas", suffix_write, 700, 700)
+                fit.draw(canvas, sigma_signal=n_sigma_signal, x_axis_label=x_axis_label,
+                         y_axis_label=y_axis_label, title=title)
+                if self.pars_factory.apply_weights is False:
+                    canvas.SaveAs(make_file_path(save_dir, "fittedplot", "eps", None,
+                                                 suffix_write))
+                else:
+                    canvas.SaveAs(make_file_path(save_dir, "fittedplotweights", "eps", None,
+                                                 suffix_write))
+                canvas.Close()
+                fit.draw(canvas_data[ibin2].cd(ibin1+1), sigma_signal=n_sigma_signal,
+                         x_axis_label=x_axis_label, y_axis_label=y_axis_label, title=title)
 
 
             if ibin1 in have_summary_pt_bins:


### PR DESCRIPTION
The multianalyzer calls the analyzer base class with the desired
analysis steps as string. The presence of a corresponding method is
checked which is then executed. Non-present analysis steps are collected
and reported to be missing at the end.
In that way the multianalyzer does not need to be aware of any analysis
method but just tries the analyzer classes.