### PR TITLE
Move preparenorm for mult analysis

### DIFF
--- a/machine_learning_hep/analysis/utils.py
+++ b/machine_learning_hep/analysis/utils.py
@@ -15,8 +15,11 @@
 from os.path import join
 
 from machine_learning_hep.utilities import mergerootfiles, get_timestamp_string
+from machine_learning_hep.logger import get_logger
 
 def multi_preparenorm(database, case, typean, doperiodbyperiod):
+
+    logger = get_logger()
 
     lper_normfilesorig = []
     lper_normfiles = []
@@ -35,6 +38,8 @@ def multi_preparenorm(database, case, typean, doperiodbyperiod):
     useperiod = database["analysis"][typean]["useperiod"]
 
     for indexp in range(len(resultsdata)):
+        logger.info("Origin path: %s, target path: %s", lper_normfilesorig[indexp],
+                    lper_normfiles[indexp])
         mergerootfiles([lper_normfilesorig[indexp]], lper_normfiles[indexp], tmp_merged)
         if doperiodbyperiod and useperiod[indexp]:
             listempty.append(lper_normfiles[indexp])

--- a/machine_learning_hep/steer_analysis.py
+++ b/machine_learning_hep/steer_analysis.py
@@ -408,14 +408,17 @@ def do_entire_analysis(data_config: dict, data_param: dict, data_model: dict, gr
     if dohistomassmc is True:
         mymultiprocessmc.multi_histomass()
     if dohistomassdata is True:
+        # After-burner in case of a mult analysis to obtain "correctionsweight.root"
+        # for merged-period data
+        # pylint: disable=fixme
+        # FIXME Can only be run here because result directories are constructed when histomass
+        #       is run. If this step was independent, histomass would always complain that the
+        #       result directory already exists.
+        if "mult" in proc_type:
+            multi_preparenorm(data_param[case], case, typean, doanaperperiod)
         mymultiprocessdata.multi_histomass()
     if doefficiency is True:
         mymultiprocessmc.multi_efficiency()
-
-    # After-burner in case of a mult analysis to obtain "correctionsweight.root"
-    # for merged-period data
-    if "mult" in proc_type:
-        multi_preparenorm(data_param[case], case, typean, doanaperperiod)
 
     # Collect all desired analysis steps
     analyze_steps = []


### PR DESCRIPTION
Only works if result directories per period and merged result directory
already exist. Cannot at the moment not be run independent of mass
histogram creation as this would always complain if the a result
directory already exists.