### PR TITLE
Small updates

### DIFF
--- a/machine_learning_hep/analysis/analyzerdhadrons_mult.py
+++ b/machine_learning_hep/analysis/analyzerdhadrons_mult.py
@@ -252,7 +252,7 @@ class AnalyzerDhadrons_mult(Analyzer): # pylint: disable=invalid-name
             fileouteff.cd()
             h_sel_pr.SetName("eff_mult%d" % imult)
             h_sel_pr.Write()
-            legeffstring = "%.1f #leq %s < %.1f GeV/#it{c}" % \
+            legeffstring = "%.1f #leq %s < %.1f" % \
                     (self.lvar2_binmin[imult], self.p_latexbin2var, self.lvar2_binmax[imult])
             legeff.AddEntry(h_sel_pr, legeffstring, "LEP")
             h_sel_pr.GetXaxis().SetTitle("#it{p}_{T} (GeV/#it{c})")
@@ -287,7 +287,7 @@ class AnalyzerDhadrons_mult(Analyzer): # pylint: disable=invalid-name
             fileouteff.cd()
             h_sel_fd.SetName("eff_fd_mult%d" % imult)
             h_sel_fd.Write()
-            legeffFDstring = "%.1f #leq %s < %.1f GeV/#it{c}" % \
+            legeffFDstring = "%.1f #leq %s < %.1f" % \
                     (self.lvar2_binmin[imult], self.p_latexbin2var, self.lvar2_binmax[imult])
             legeffFD.AddEntry(h_sel_fd, legeffFDstring, "LEP")
             h_sel_fd.GetXaxis().SetTitle("#it{p}_{T} (GeV/#it{c})")
@@ -348,7 +348,7 @@ class AnalyzerDhadrons_mult(Analyzer): # pylint: disable=invalid-name
                                        (self.p_latexnmeson, self.typean))
             hcross.SetName("hcross%d" % imult)
             hcross.GetYaxis().SetRangeUser(1e1, 1e10)
-            legvsvar1endstring = "%.1f < %s < %.1f GeV/#it{c}" % \
+            legvsvar1endstring = "%.1f < %s < %.1f" % \
                     (self.lvar2_binmin[imult], self.p_latexbin2var, self.lvar2_binmax[imult])
             legvsvar1.AddEntry(hcross, legvsvar1endstring, "LEP")
             hcross.Draw("same")
@@ -552,7 +552,7 @@ class AnalyzerDhadrons_mult(Analyzer): # pylint: disable=invalid-name
             hcross.GetYaxis().SetTitle("Corrected yield/events (%s) %s" %
                                        (self.p_latexnmeson, self.typean))
             hcross.GetYaxis().SetRangeUser(1e-10, 1)
-            legvsvar1endstring = "%.1f #leq %s < %.1f GeV/#it{c}" % \
+            legvsvar1endstring = "%.1f #leq %s < %.1f" % \
                     (self.lvar2_binmin[imult], self.p_latexbin2var, self.lvar2_binmax[imult])
             legvsvar1.AddEntry(hcross, legvsvar1endstring, "LEP")
             hcross.Draw("same")

--- a/machine_learning_hep/data/data_prod_20200304/database_ml_parameters_LcpK0spp_20200301.yml
+++ b/machine_learning_hep/data/data_prod_20200304/database_ml_parameters_LcpK0spp_20200301.yml
@@ -598,7 +598,7 @@ LcpK0spp:
       FixedSigma: true
       fitcase: Lc
       latexnamemeson: "#Lambda_{c}^{pK0s}"
-      latexbin2var: "n_{trkl}"
+      latexbin2var: "v0m perc"
       nevents: null
       dodoublecross: false
 

--- a/machine_learning_hep/steer_analysis.py
+++ b/machine_learning_hep/steer_analysis.py
@@ -23,6 +23,10 @@ import argparse
 from os.path import exists
 import yaml
 from pkg_resources import resource_stream
+
+# To set batch mode immediately
+from ROOT import gROOT # pylint: disable=import-error, no-name-in-module
+
 from machine_learning_hep.multiprocesser import MultiProcesser
 from machine_learning_hep.processer import Processer
 from machine_learning_hep.processerdhadrons import ProcesserDhadrons
@@ -69,6 +73,9 @@ except Exception as e: # pylint: disable=broad-except
 
 
 def do_entire_analysis(data_config: dict, data_param: dict, data_model: dict, run_param: dict): # pylint: disable=too-many-locals, too-many-statements, too-many-branches
+
+    # Disable any graphical stuff. No TCanvases opened and shown by default
+    gROOT.SetBatch(True)
 
     logger = get_logger()
     logger.info("Do analysis chain")


### PR DESCRIPTION
* Don't print GeV for multiplicity bins in final result plots

* Set ROOT batch mode right from the beginning to avoid printing/showing
default TCanvas

* Change mult label in v0m_perc analysis