### PR TITLE
Add max chi2 and min signif for ML syst

### DIFF
--- a/machine_learning_hep/data/data_prod_20200304/database_ml_parameters_LcpK0spp_20200301.yml
+++ b/machine_learning_hep/data/data_prod_20200304/database_ml_parameters_LcpK0spp_20200301.yml
@@ -625,6 +625,9 @@ LcpK0spp:
       cutvarmaxrange: [0.80, 0.80, 0.80, 0.80, 0.80] #Max starting point for scan
       fixedmean: True #Fix mean cutvar histo to central fit
       fixedsigma: True #Fix sigma cutvar histo to central fit
+      min_signif_fit: 3.
+      max_red_chi2_fit: 2.
+
     mcptshape:
       #FONLL / generated LHC19h4c1
       weights: [1.000000]


### PR DESCRIPTION
This is just a small PR, however, introducing minimal significance and maximum red. chi2 for ML systematic fits so it's centrally available in the database now