### PR TITLE
Add fixed sigma variation multi-trial

### DIFF
--- a/machine_learning_hep/data/data_prod_20200304/database_ml_parameters_D0pp_0304.yml
+++ b/machine_learning_hep/data/data_prod_20200304/database_ml_parameters_D0pp_0304.yml
@@ -549,18 +549,6 @@ D0pp:
         bkg_funcs: [kExpo, Pol2]
         # Whether to include the free sigma option in the derivation of raw yield uncertainty in given pT bin
         consider_free_sigma: [True, True, True, True, True, True]
-        # Chose which sigma should be taken to initialize the multi trial
-        # If nothing is specified the value of the central fit is taken
-        # can be a sigle value taken for all pT and mult bins
-        #init_sigma_from: "central"
-        # Can be a list covering all pT bins
-        init_sigma_from: ["user", "user", "data", "data", "data", "data"]
-        # Or a 2D list for all mult. and pT bins individually
-        #init_sigma_from:
-        #  - ["mc", "data", "data", "data", "data", "data"]
-        #  - ["mc", "data", "data", "data", "data", "data"]
-        #  - ["mc", "data", "data", "data", "data", "data"]
-        #  - ["mc", "data", "data", "data", "data", "data"]
 
     MBvspt_ntrkl:
       proc_type: Dhadrons_mult
@@ -656,18 +644,6 @@ D0pp:
         bkg_funcs: [kExpo, Pol2]
         # Whether to include the free sigma option in the derivation of raw yield uncertainty in given pT bin
         consider_free_sigma: [True, True, True, True, True, True]
-        # Chose which sigma should be taken to initialize the multi trial
-        # If nothing is specified the value of the central fit is taken
-        # can be a sigle value taken for all pT and mult bins
-        #init_sigma_from: "central"
-        # Can be a list covering all pT bins
-        init_sigma_from: ["user", "user", "data", "data", "data", "data"]
-        # Or a 2D list for all mult. and pT bins individually
-        #init_sigma_from:
-        #  - ["mc", "data", "data", "data", "data", "data"]
-        #  - ["mc", "data", "data", "data", "data", "data"]
-        #  - ["mc", "data", "data", "data", "data", "data"]
-        #  - ["mc", "data", "data", "data", "data", "data"]
 
     MBvspt_perc_v0m:
       proc_type: Dhadrons_mult
@@ -762,18 +738,6 @@ D0pp:
         bkg_funcs: [kExpo, Pol2]
         # Whether to include the free sigma option in the derivation of raw yield uncertainty in given pT bin
         consider_free_sigma: [True, True, True, True, True]
-        # Chose which sigma should be taken to initialize the multi trial
-        # If nothing is specified the value of the central fit is taken
-        # can be a sigle value taken for all pT and mult bins
-        #init_sigma_from: "central"
-        # Can be a list covering all pT bins
-        init_sigma_from: ["user", "data", "data", "data", "data"]
-        # Or a 2D list for all mult. and pT bins individually
-        #init_sigma_from:
-        #  - ["mc", "data", "data", "data", "data", "data"]
-        #  - ["mc", "data", "data", "data", "data", "data"]
-        #  - ["mc", "data", "data", "data", "data", "data"]
-        #  - ["mc", "data", "data", "data", "data", "data"]
 
 
   systematics:

--- a/machine_learning_hep/data/data_prod_20200304/database_ml_parameters_LcpK0spp_0304.yml
+++ b/machine_learning_hep/data/data_prod_20200304/database_ml_parameters_LcpK0spp_0304.yml
@@ -530,6 +530,12 @@ LcpK0spp:
         bkg_funcs: [kExpo, kLin, Pol2, Pol3, Pol4, Pol5]
         # Whether to include the free sigma option in the derivation of raw yield uncertainty in given pT bin
         consider_free_sigma: [False, False, False, False, False, False]
+        # Put relative variation from central sigma separately for varying up/donw, e.g.
+        # rel_var_sigma_up: [0.1, 0.05, False, 0.2, False, False]
+        # rel_var_sigma_down: [False, 0.1, False, False, 0.1, False]
+        # Whenever it evaluates to False it's not taken into account
+        rel_var_sigma_up: [False, False, False, False, False, False]
+        rel_var_sigma_down: [False, False, False, False, False, False]
 
 
     SPDvspt_ntrkl:

--- a/machine_learning_hep/fitting/README.md
+++ b/machine_learning_hep/fitting/README.md
@@ -34,6 +34,28 @@ This class builds an abstraction layer and is responsible to understand the fit 
 **MLFitter**
 All fits used in an analysis run are handled here.
 
+## Database settings
+
+A full configuration of the raw yield (aka multi trial) systematics in a database looks like
+
+```yaml
+systematics:
+  # For now don't do these things per pT bin
+  max_chisquare_ndf: 2.
+  rebin: [-1,0,1] # required, for no variation just put [0]
+  massmin: [2.14, 2.13, 2.12, 2.15, 2.17] # required, for no variation put [<min_value>]
+  massmax: [2.436, 2.435, 2.434, 2.437, 2.438] # required, for no variation put [<max_value>]
+  bincount_sigma: [3, 5] # required (at the moment, will be made optional)
+  bkg_funcs: [kExpo, kLin, Pol2, Pol3, Pol4, Pol5] # required
+  # Whether to include the free sigma option in the derivation of raw yield uncertainty in given pT bin
+  consider_free_sigma: [False, False, False, False, False, False] # optional, one value for each pT bin, choose between True or False
+  # Put relative variation from central sigma separately for varying up/donw, e.g.
+  # Whenever it evaluates to False it's not taken into account
+  rel_var_sigma_up: [0.1, 0.05, False, 0.2, False, False] # optional
+  rel_var_sigma_down: [False, 0.1, False, False, 0.1, False] # optional
+```
+
+The bin count is at the moment always taken into account and it should be seen as a cross-check
 
 ## Example usage
 

--- a/machine_learning_hep/fitting/fitters.py
+++ b/machine_learning_hep/fitting/fitters.py
@@ -803,6 +803,8 @@ class FitSystAliHF(FitROOT):
                                   "bkg_func_names_syst": None,
                                   "rebin_syst": None,
                                   "consider_free_sigma_syst": None,
+                                  "rel_var_sigma_up_syst": None,
+                                  "rel_var_sigma_down_syst": None,
                                   "signif_min_syst": None,
                                   "chi2_max_syst": None}
         # Fitted parameters (to be modified for deriving classes)
@@ -848,6 +850,13 @@ class FitSystAliHF(FitROOT):
         # NOTE Not used at the momemnt
         self.kernel.SetUsePowerLawBackground(False)
         self.kernel.SetUsePowerLawTimesExpoBackground(False)
+
+        # Relative sigma variation wrt nominal
+        rel_sigma_up = self.init_pars["rel_var_sigma_up_syst"] \
+                if self.init_pars["rel_var_sigma_up_syst"] else 0
+        rel_sigma_down = self.init_pars["rel_var_sigma_down_syst"] \
+                if self.init_pars["rel_var_sigma_down_syst"] else 0
+        self.kernel.SetSigmaMCVariation(rel_sigma_up, rel_sigma_down)
 
         if self.init_pars["rebin_syst"]:
             rebin_steps = [self.init_pars["rebin"] + rel_rb \
@@ -961,8 +970,8 @@ class FitSystAliHF(FitROOT):
         max_bc_range = n_bins_bincount
         n_bc_ranges = n_bins_bincount
         conf_case = ["FixedSigFreeMean",
-                     "FixedSigUp",
-                     "FixedSigDw",
+                     "FixedSigUpFreeMean",
+                     "FixedSigDwFreeMean",
                      "FreeSigFreeMean",
                      "FreeSigFixedMean",
                      "FixedSigFixedMean"]
@@ -989,6 +998,11 @@ class FitSystAliHF(FitROOT):
                 if self.init_pars["consider_free_sigma_syst"]:
                     mask[18+i] = plot_case
                     mask[24+i] = plot_case
+                if self.init_pars["rel_var_sigma_up_syst"]:
+
+                    mask[6+i] = plot_case
+                if self.init_pars["rel_var_sigma_down_syst"]:
+                    mask[12+i] = plot_case
 
         # Extract histograms from file
         histo6 = [None] * tot_cases
@@ -1155,6 +1169,13 @@ class FitSystAliHF(FitROOT):
         ##################
         # Extract yields #
         ##################
+        # Cache min/max values for plotting later
+        sigma_max = 0.
+        sigma_min = 1.
+        mean_max = -1.
+        mean_min = 10000.
+        chi2_max = -1.
+        chi2_min = 10000.
         for nc in range(tot_cases):
             if not mask[nc]:
                 continue
@@ -1224,10 +1245,17 @@ class FitSystAliHF(FitROOT):
                 counts += 1.
                 h_sigma_all_bkgs[bkg_func_name].SetBinContent(first[nc] + ib, sig)
                 h_sigma_all_bkgs[bkg_func_name].SetBinError(first[nc] + ib, esig)
+                # Collect maximum and minimum for plotting later
+                sigma_max = max(sig + esig, sigma_max)
+                sigma_min = min(sig - esig, sigma_min)
                 h_mean_all_bkgs[bkg_func_name].SetBinContent(first[nc] + ib, pos)
                 h_mean_all_bkgs[bkg_func_name].SetBinError(first[nc] + ib, epos)
+                mean_max = max(pos + epos, mean_max)
+                mean_min = min(pos - epos, mean_min)
                 h_chi2_all_bkgs[bkg_func_name].SetBinContent(first[nc] + ib, chi2)
                 h_chi2_all_bkgs[bkg_func_name].SetBinError(first[nc] + ib, 0.000001)
+                chi2_max = max(chi2, chi2_max)
+                chi2_min = min(chi2, chi2_min)
 
                 if mask[nc] == 2:
                     for iy in range(min_bc_range, max_bc_range + 1):
@@ -1299,9 +1327,14 @@ class FitSystAliHF(FitROOT):
         sigma_pad = root_pad.cd(1)
         sigma_pad.SetLeftMargin(0.13)
         sigma_pad.SetRightMargin(0.06)
+        sigma_delta = (sigma_max - sigma_min)
+        sigma_min = sigma_min - 0.1 * sigma_delta
+        sigma_max = sigma_max + 0.1 * sigma_delta
+
         for histo in  h_sigma_all_bkgs.values():
             histo.GetYaxis().SetTitleOffset(1.7)
             histo.Draw("same")
+            histo.GetYaxis().SetRangeUser(sigma_min, sigma_max)
             root_objects.append(histo)
             histo.SetDirectory(0)
 
@@ -1314,8 +1347,12 @@ class FitSystAliHF(FitROOT):
         mean_pad = root_pad.cd(2)
         mean_pad.SetLeftMargin(0.13)
         mean_pad.SetRightMargin(0.06)
+        mean_delta = (mean_max - mean_min)
+        mean_min = mean_min - 1.1 * mean_delta
+        mean_max = mean_max + 0.1 * mean_delta
         for name, histo in  h_mean_all_bkgs.items():
             histo.GetYaxis().SetTitleOffset(1.7)
+            histo.GetYaxis().SetRangeUser(mean_min, mean_max)
             histo.Draw("same")
             root_objects.append(histo)
             histo.SetDirectory(0)
@@ -1325,9 +1362,13 @@ class FitSystAliHF(FitROOT):
         chi2_pad = root_pad.cd(3)
         chi2_pad.SetLeftMargin(0.13)
         chi2_pad.SetRightMargin(0.06)
+        chi2_delta = (chi2_max - chi2_min)
+        chi2_min = chi2_min - 0.1 * chi2_delta
+        chi2_max = chi2_max + 0.1 * chi2_delta
 
         for histo in h_chi2_all_bkgs.values():
             histo.GetYaxis().SetTitleOffset(1.7)
+            histo.GetYaxis().SetRangeUser(chi2_min, chi2_max)
             histo.Draw("same")
             root_objects.append(histo)
             histo.SetDirectory(0)

--- a/machine_learning_hep/fitting/helpers.py
+++ b/machine_learning_hep/fitting/helpers.py
@@ -123,6 +123,8 @@ class MLFitParsFactory:
         self.syst_pars = ana_config.get("systematics", {})
         self.syst_init_sigma_from = None
         self.syst_consider_free_sigma = None
+        self.syst_rel_var_sigma_up = None
+        self.syst_rel_var_sigma_down = None
         if self.syst_pars:
             self.syst_init_sigma_from = self.syst_pars.get("init_sigma_from", "central")
             if not isinstance(self.syst_init_sigma_from, list):
@@ -135,6 +137,18 @@ class MLFitParsFactory:
                 iter(self.syst_consider_free_sigma)
             except TypeError:
                 self.syst_consider_free_sigma = [self.syst_consider_free_sigma] * self.n_bins1
+
+            self.syst_rel_var_sigma_up = self.syst_pars.get("rel_var_sigma_up", None)
+            try:
+                iter(self.syst_rel_var_sigma_up)
+            except TypeError:
+                self.syst_rel_var_sigma_up = [self.syst_rel_var_sigma_up] * self.n_bins1
+
+            self.syst_rel_var_sigma_down = self.syst_pars.get("rel_var_sigma_down", None)
+            try:
+                iter(self.syst_rel_var_sigma_down)
+            except TypeError:
+                self.syst_rel_var_sigma_down = [self.syst_rel_var_sigma_down] * self.n_bins1
 
 
     def make_ali_hf_fit_pars(self, ibin1, ibin2):
@@ -205,6 +219,8 @@ class MLFitParsFactory:
                     "rebin_syst": self.syst_pars.get("rebin", None),
                     # Check DB
                     "consider_free_sigma_syst": self.syst_consider_free_sigma[ibin1],
+                    "rel_var_sigma_up_syst": self.syst_rel_var_sigma_up[ibin1],
+                    "rel_var_sigma_down_syst": self.syst_rel_var_sigma_down[ibin1],
                     "signif_min_syst": self.syst_pars.get("signif_min_syst", 3.),
                     "chi2_max_syst": self.syst_pars.get("chi2_max_syst", 2.)}
 


### PR DESCRIPTION
Decide separately on relative up- and downward variation of central
sigma per pT bin.
This is optional in the analysis part in the database (within the
systematic section)

`rel_var_sigma_up: [val_up_pT_bin0, val_up_pT_bin1, ...]`
`rel_var_sigma_down: [val_down_pT_bin0, val_down_pT_bin1, ...]`

Values that evaluate to `False` are ignore.