### PR TITLE
Trigger efficiency fix corrected yield macro

### DIFF
--- a/machine_learning_hep/HFPtSpectrum.C
+++ b/machine_learning_hep/HFPtSpectrum.C
@@ -1135,8 +1135,8 @@ void HFPtSpectrum ( Int_t decayChan=kDplusKpipi,
 }
 
 void HFPtSpectrum2 (const char *inputCrossSection,
-                    Double_t triggereff = 1,
-                    Double_t triggereffunc = 0,
+                    Double_t triggereff = 1, //bug fixed 22/04/20
+                    Double_t triggereffunc = 0, //not used in calculation
                     const char *efffilename="Efficiencies.root",
                     const char *nameeffprompt= "eff",
                     const char *nameefffeed = "effB",
@@ -1228,6 +1228,13 @@ void HFPtSpectrum2 (const char *inputCrossSection,
   }else{
     printf("Histogram with number of events for norm not found in raw yiled file\n");
     printf("  nevents = %.0f will be used\n",nevents);
+  }
+  if(triggereff != 1){
+    printf("\nTrigger efficiency set: %.4f!\n",triggereff);
+    printf("Scaling nevents (multiplicity bin convention): nevents_new = nevents / eff_trig");
+    Double_t neventsold = nevents;
+    nevents = nevents / triggereff;
+    printf("  nevents = %.0f will be used (old nevents = %.0f)\n",nevents,neventsold);
   }
 
   Int_t fnPtBins = hRECpt->GetNbinsX();
@@ -1334,9 +1341,9 @@ void HFPtSpectrum2 (const char *inputCrossSection,
     Double_t x = histoYieldCorr->GetBinCenter(ibin);
 
     // Sigma calculation
-    //   Sigma = ( 1. / (lumi * delta_y * BR_c * ParticleAntiPartFactor * eff_trig * eff_c ) ) * spectra (corrected for feed-down)
+    //   Sigma = ( 1. / (lumi * delta_y * BR_c * ParticleAntiPartFactor * eff_c ) ) * spectra (corrected for feed-down)
     if (hDirectEffpt->GetBinContent(ibin) && hDirectEffpt->GetBinContent(ibin)!=0. && hRECpt->GetBinContent(ibin)>0.) {
-      value = histoYieldCorr->GetBinContent(ibin) / ( deltaY * branchingRatioC * fParticleAntiParticle * fLuminosity[0] * fTrigEfficiency[0] * hDirectEffpt->GetBinContent(ibin) );
+      value = histoYieldCorr->GetBinContent(ibin) / ( deltaY * branchingRatioC * fParticleAntiParticle * fLuminosity[0] * hDirectEffpt->GetBinContent(ibin) );
     }
 
     // Sigma statistical uncertainty:

--- a/machine_learning_hep/data/data_prod_20200304/database_ml_parameters_D0pp_0304.yml
+++ b/machine_learning_hep/data/data_prod_20200304/database_ml_parameters_D0pp_0304.yml
@@ -456,21 +456,21 @@ D0pp:
     SPDvspt_ntrkl:
       proc_type: Dhadrons_mult
       useperiod: [0,0,1]
-      plotbin: [0,0,0,0,1]
+      plotbin: [0,0,0,0,0,1]
       usesinglebineff: 3
       fprompt_from_mb: true
       corresp_mb_typean: MBvspt_ntrkl
-      corrEffMult: [false, true, true, true, true]
-      sel_binmin2: [1,1,10,30,60] #list of var2 splittng nbins
-      sel_binmax2: [9999,9,29,59,100] #list of var2 splitting nbins
+      corrEffMult: [false, false, true, true, true, true]
+      sel_binmin2: [0,1,1,10,30,60] #list of var2 splittng nbins
+      sel_binmax2: [9999,9999,9,29,59,100] #list of var2 splitting nbins
       var_binning2: n_tracklets_corr_sub
       var_binning2_gen: n_tracklets_corr
       nbinshisto: 200
       minvaluehisto: -0.5
       maxvaluehisto: 199.5
       # here the trigger efficiency is set to 1. Corrections are implemented in the analysis step
-      triggereff: [1.,1.,1.,1.,1.]
-      triggereffunc: [0.,0.,0.,0.,0.]
+      triggereff: [1.,1.,1.,1.,1.,1.]
+      triggereffunc: [0.,0.,0.,0.,0.,0.]
       triggerbit: HighMultSPD
       isNbx2: False    #Estimate the feeddown systematic with Nb and Nbx2 method convolution
       event_cand_validation: True
@@ -509,10 +509,10 @@ D0pp:
       masspeak: 1.864
       massmin: [1.74,1.7,1.7,1.7,1.7,1.7]
       massmax: [2.1,2.1,2.1,2.1,2.1,2.1]
-      rebin: [[6,6,6,6,6,6], [6,6,6,6,6,6], [6,6,6,6,6,6], [6,6,6,6,6,6], [6,6,6,6,6,6]]
-      includesecpeak: [[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false]]
+      rebin: [[6,6,6,6,6,6], [6,6,6,6,6,6], [6,6,6,6,6,6], [6,6,6,6,6,6], [6,6,6,6,6,6], [6,6,6,6,6,6]]
+      includesecpeak: [[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false]]
       masssecpeak: -1.0
-      fix_masssecpeak: [[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false]]
+      fix_masssecpeak: [[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false]]
       #Fraction Dplus/Ds (taken from pp5TeV as we don't store it in TTrees)
       widthsecpeak: -1
       fix_widthsecpeak: false
@@ -553,20 +553,20 @@ D0pp:
     MBvspt_ntrkl:
       proc_type: Dhadrons_mult
       useperiod: [1,1,1]
-      plotbin: [1,1,1,1,0]
+      plotbin: [1,1,1,1,1,0]
       usesinglebineff: null
       fprompt_from_mb: true
       corresp_mb_typean: null
-      corrEffMult: [false,true,true,true,true]
-      sel_binmin2: [1,1,10,30,60] #list of var2 splittng nbins
-      sel_binmax2: [9999,9,29,59,99] #list of var2 splitting nbins
+      corrEffMult: [false,false,true,true,true,true]
+      sel_binmin2: [0,1,1,10,30,60] #list of var2 splittng nbins
+      sel_binmax2: [9999,9999,9,29,59,99] #list of var2 splitting nbins
       var_binning2: n_tracklets_corr_sub
       var_binning2_gen: n_tracklets_corr
       nbinshisto: 200
       minvaluehisto: -0.5
       maxvaluehisto: 199.5
-      triggereff: [0.92,0.862,1,1,1]
-      triggereffunc: [0.003,0.018,0,0,0]
+      triggereff: [1,0.92,0.862,1,1,1]
+      triggereffunc: [0,0.003,0.018,0,0,0]
       triggerbit: INT7
       event_cand_validation: True
       sel_an_binmin: [1,2,4,6,8,12]  # [1,2,4,6,8,12] #list of pt nbins
@@ -604,10 +604,10 @@ D0pp:
       masspeak: 1.864
       massmin: [1.75,1.7,1.7,1.7,1.7,1.7]
       massmax: [2.1,2.1,2.1,2.1,2.1,2.1]
-      rebin: [[6,6,6,6,6,6], [6,6,6,6,6,6], [6,6,6,6,6,6], [6,6,6,6,6,6], [6,6,6,6,6,6]]
-      includesecpeak: [[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false]]
+      rebin: [[6,6,6,6,6,6], [6,6,6,6,6,6], [6,6,6,6,6,6], [6,6,6,6,6,6], [6,6,6,6,6,6], [6,6,6,6,6,6]]
+      includesecpeak: [[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false]]
       masssecpeak: -1.0
-      fix_masssecpeak: [[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false]]
+      fix_masssecpeak: [[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false]]
       #Fraction Dplus/Ds (taken from pp5TeV as we don't store it in TTrees)
       widthsecpeak: -1
       fix_widthsecpeak: false

--- a/machine_learning_hep/data/data_prod_20200304/database_ml_parameters_Dspp.yml
+++ b/machine_learning_hep/data/data_prod_20200304/database_ml_parameters_Dspp.yml
@@ -270,20 +270,20 @@ Dspp:
     MBvspt_ntrkl:
       proc_type: Dhadrons_mult
       useperiod: [1,1,1]
-      plotbin: [1,1,1,1,0]
+      plotbin: [1,1,1,1,1,0]
       usesinglebineff: null
       fprompt_from_mb: true
       corresp_mb_typean: null
-      corrEffMult: [false,true,true,true,true]
-      sel_binmin2: [1,1,10,30,60] #list of var2 splittng nbins
-      sel_binmax2: [9999,9,29,59,99] #list of var2 splitting nbins
+      corrEffMult: [false,false,true,true,true,true]
+      sel_binmin2: [0,1,1,10,30,60] #list of var2 splittng nbins
+      sel_binmax2: [9999,9999,9,29,59,99] #list of var2 splitting nbins
       var_binning2: n_tracklets_corr_sub
       var_binning2_gen: n_tracklets_corr
       nbinshisto: 200
       minvaluehisto: -0.5
       maxvaluehisto: 199.5
-      triggereff: [0.92,0.862,1,1,1]
-      triggereffunc: [0.003,0.018,0,0,0]
+      triggereff: [1,0.92,0.862,1,1,1]
+      triggereffunc: [0,0.003,0.018,0,0,0]
       triggerbit: INT7
       sel_an_binmin: [2,4,6,8,12]  # [1,2,4,6,8,12] #list of pt nbins
       sel_an_binmax: [4,6,8,12,24]  # [2,4,6,8,12,24] #list of pt nbins
@@ -319,10 +319,10 @@ Dspp:
       masspeak: 1.969
       massmin: [1.75,1.75,1.75,1.75,1.75]
       massmax: [2.15,2.15,2.15,2.15,2.15]
-      rebin: [[5,8,8,8,12], [6,8,8,8,12], [5,8,8,8,12], [5,8,8,8,12], [8,10,10,10,12]]
-      includesecpeak: [[true, true, true, true, true],[true, true, true, true, true],[true, true, true, true, true],[true, true, true, true, true],[false, false, false, false, false]]
+      rebin: [[5,8,8,8,12], [5,8,8,8,12], [6,8,8,8,12], [5,8,8,8,12], [5,8,8,8,12], [8,10,10,10,12]]
+      includesecpeak: [[true, true, true, true, true],[true, true, true, true, true],[true, true, true, true, true],[true, true, true, true, true],[true, true, true, true, true],[false, false, false, false, false]]
       masssecpeak: 1.869
-      fix_masssecpeak: [[false, false, false, false, false],[true, false, true, false, true],[false, false, false, false, true],[true, false, false, false, true],[true, true, true, true, true]]
+      fix_masssecpeak: [[false, false, false, false, false],[false, false, false, false, false],[true, false, true, false, true],[false, false, false, false, true],[true, false, false, false, true],[true, true, true, true, true]]
       #Fraction Dplus/Ds (taken from pp5TeV as we don't store it in TTrees)
       widthsecpeak: 0.92
       fix_widthsecpeak: true

--- a/machine_learning_hep/data/data_prod_20200304/database_ml_parameters_LcpK0spp_0304.yml
+++ b/machine_learning_hep/data/data_prod_20200304/database_ml_parameters_LcpK0spp_0304.yml
@@ -444,7 +444,7 @@ LcpK0spp:
       usesinglebineff: null
       fprompt_from_mb: true
       corresp_mb_typean: null
-      corrEffMult: [false, true, true, true, true]
+      corrEffMult: [false, false, true, true, true]
       sel_binmin2: [0,1,1,10,30] #list of var2 splittng nbins
       sel_binmax2: [9999,9999,9,29,59] #list of var2 splitting nbins
       var_binning2: n_tracklets_corr_sub
@@ -586,9 +586,9 @@ LcpK0spp:
       massmax: [2.436,2.436,2.436,2.436,2.436,2.436]
       rebin: [7,7,8,9,10,12]
 
-      includesecpeak: [[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false]]
+      includesecpeak: [[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false]]
       masssecpeak: 2.2864
-      fix_masssecpeak: [[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false]]
+      fix_masssecpeak: [[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false]]
       widthsecpeak: 0.01
       fix_widthsecpeak: true
 

--- a/machine_learning_hep/data/data_prod_20200304/database_ml_parameters_LcpK0spp_0304.yml
+++ b/machine_learning_hep/data/data_prod_20200304/database_ml_parameters_LcpK0spp_0304.yml
@@ -539,7 +539,7 @@ LcpK0spp:
       usesinglebineff: 3
       fprompt_from_mb: true
       corresp_mb_typean: MBvspt_ntrkl
-      corrEffMult: [false, true, true, true, true]
+      corrEffMult: [false, false, true, true, true, true]
       sel_binmin2: [0,1,1,10,30,60] #list of var2 splittng nbins
       sel_binmax2: [9999,9999,9,29,59,100] #list of var2 splitting nbins
       var_binning2: n_tracklets_corr_sub

--- a/machine_learning_hep/data/data_prod_20200417/database_ml_parameters_D0pp_0417.yml
+++ b/machine_learning_hep/data/data_prod_20200417/database_ml_parameters_D0pp_0417.yml
@@ -567,7 +567,7 @@ D0pp:
       fprompt_from_mb: true
       corresp_mb_typean: null
       corrEffMult: [false,false,true,true,true,true]
-      sel_binmin2: [1,1,1,10,30,60] #list of var2 splittng nbins
+      sel_binmin2: [0,1,1,10,30,60] #list of var2 splittng nbins
       sel_binmax2: [9999,9999,9,29,59,99] #list of var2 splitting nbins
       var_binning2: n_tracklets_corr_sub
       var_binning2_gen: n_tracklets_corr

--- a/machine_learning_hep/data/data_prod_20200417/database_ml_parameters_D0pp_0417.yml
+++ b/machine_learning_hep/data/data_prod_20200417/database_ml_parameters_D0pp_0417.yml
@@ -465,21 +465,21 @@ D0pp:
     SPDvspt_ntrkl:
       proc_type: Dhadrons_mult
       useperiod: [0,0,1]
-      plotbin: [0,0,0,0,1]
+      plotbin: [0,0,0,0,0,1]
       usesinglebineff: 3
       fprompt_from_mb: true
       corresp_mb_typean: MBvspt_ntrkl
-      corrEffMult: [false, true, true, true, true]
-      sel_binmin2: [1,1,10,30,60] #list of var2 splittng nbins
-      sel_binmax2: [9999,9,29,59,100] #list of var2 splitting nbins
+      corrEffMult: [false, false, true, true, true, true]
+      sel_binmin2: [0,1,1,10,30,60] #list of var2 splittng nbins
+      sel_binmax2: [9999,9999,9,29,59,100] #list of var2 splitting nbins
       var_binning2: n_tracklets_corr_sub
       var_binning2_gen: n_tracklets_corr
       nbinshisto: 200
       minvaluehisto: -0.5
       maxvaluehisto: 199.5
       # here the trigger efficiency is set to 1. Corrections are implemented in the analysis step
-      triggereff: [1.,1.,1.,1.,1.]
-      triggereffunc: [0.,0.,0.,0.,0.]
+      triggereff: [1.,1.,1.,1.,1.,1.]
+      triggereffunc: [0.,0.,0.,0.,0.,0.]
       triggerbit: HighMultSPD
       isNbx2: False    #Estimate the feeddown systematic with Nb and Nbx2 method convolution
       event_cand_validation: True
@@ -518,10 +518,10 @@ D0pp:
       masspeak: 1.864
       massmin: [1.74,1.7,1.7,1.7,1.7,1.7]
       massmax: [2.1,2.1,2.1,2.1,2.1,2.1]
-      rebin: [[6,6,6,6,6,6], [6,6,6,6,6,6], [6,6,6,6,6,6], [6,6,6,6,6,6], [6,6,6,6,6,6]]
-      includesecpeak: [[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false]]
+      rebin: [[6,6,6,6,6,6], [6,6,6,6,6,6], [6,6,6,6,6,6], [6,6,6,6,6,6], [6,6,6,6,6,6], [6,6,6,6,6,6]]
+      includesecpeak: [[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false]]
       masssecpeak: -1.0
-      fix_masssecpeak: [[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false]]
+      fix_masssecpeak: [[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false]]
       #Fraction Dplus/Ds (taken from pp5TeV as we don't store it in TTrees)
       widthsecpeak: -1
       fix_widthsecpeak: false
@@ -562,20 +562,20 @@ D0pp:
     MBvspt_ntrkl:
       proc_type: Dhadrons_mult
       useperiod: [1,1,1]
-      plotbin: [1,1,1,1,0]
+      plotbin: [1,1,1,1,1,0]
       usesinglebineff: null
       fprompt_from_mb: true
       corresp_mb_typean: null
-      corrEffMult: [false,true,true,true,true]
-      sel_binmin2: [1,1,10,30,60] #list of var2 splittng nbins
-      sel_binmax2: [9999,9,29,59,99] #list of var2 splitting nbins
+      corrEffMult: [false,false,true,true,true,true]
+      sel_binmin2: [1,1,1,10,30,60] #list of var2 splittng nbins
+      sel_binmax2: [9999,9999,9,29,59,99] #list of var2 splitting nbins
       var_binning2: n_tracklets_corr_sub
       var_binning2_gen: n_tracklets_corr
       nbinshisto: 200
       minvaluehisto: -0.5
       maxvaluehisto: 199.5
-      triggereff: [0.92,0.862,1,1,1]
-      triggereffunc: [0.003,0.018,0,0,0]
+      triggereff: [1,0.92,0.862,1,1,1]
+      triggereffunc: [0,0.003,0.018,0,0,0]
       triggerbit: INT7
       event_cand_validation: True
       sel_an_binmin: [1,2,4,6,8,12]  # [1,2,4,6,8,12] #list of pt nbins
@@ -613,10 +613,10 @@ D0pp:
       masspeak: 1.864
       massmin: [1.75,1.7,1.7,1.7,1.7,1.7]
       massmax: [2.1,2.1,2.1,2.1,2.1,2.1]
-      rebin: [[6,6,6,6,6,6], [6,6,6,6,6,6], [6,6,6,6,6,6], [6,6,6,6,6,6], [6,6,6,6,6,6]]
-      includesecpeak: [[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false]]
+      rebin: [[6,6,6,6,6,6], [6,6,6,6,6,6], [6,6,6,6,6,6], [6,6,6,6,6,6], [6,6,6,6,6,6], [6,6,6,6,6,6]]
+      includesecpeak: [[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false]]
       masssecpeak: -1.0
-      fix_masssecpeak: [[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false]]
+      fix_masssecpeak: [[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false]]
       #Fraction Dplus/Ds (taken from pp5TeV as we don't store it in TTrees)
       widthsecpeak: -1
       fix_widthsecpeak: false


### PR DESCRIPTION
Fixed the HFPtSpectrum macro for the trigger efficiency bug (Nevents * eff_trig -> Nevents / eff_trig) coming from a misunderstanding of a variable called TriggerEfficiency in the AliPhysics HFPtSpectrum.C macro.

PR = WIP because our analyzer is now not doing it correctly ([this part](https://github.com/ginnocen/MachineLearningHEP/blob/5e07d5456940b919f0bf9487e2b77c31f6b1ed98/machine_learning_hep/analysis/analyzerdhadrons_mult.py#L471-L506)). Correct strategy is:
1. Run AliPhysics HFPtSpectrum macro (HFPtSpectrum() in our macro) for yield-efficiency-nEvents in [0-9999], no trigger efficiency. So the usual cross section case. Need to do this to get the MB fprompt.
2. Run the for-multiplicity-bins changed HFPtSpectrum macro (HFPtSpectrum2() in our macro) for yield-efficiency-nEvents in {[1-9999], [1-9], [10-29], etc}, adding the trigger efficiency for [1-9999] and [1-9], and the MB fprompt calculated in step 1). 

What should do the job is to add the [0-9999] case in the DBs at the first position:
```
      sel_binmin2:  [0,   1,    1, 10, 30] #list of var2 splittng nbins
      sel_binmax2: [9999, 9999, 9, 29, 59] #list of var2 splitting nbins
      triggereff:    [1, 0.92,  0.862, 1, 1, 1]
      triggereffunc: [0, 0.003, 0.018, 0, 0, 0]
      corrEffMult: [false, true, true, true, true]
      #...all other arrays...
```
@ginnocen, if you agree I update all DBs and add it in this PR. I think it is also good to automatically have the MB cross section as output.