### PR TITLE
[WIP] Revise ML application

### DIFF
--- a/machine_learning_hep/multiprocesser.py
+++ b/machine_learning_hep/multiprocesser.py
@@ -20,7 +20,7 @@ from machine_learning_hep.processer import Processer # pylint: disable=unused-im
 from machine_learning_hep.utilities import merge_method, mergerootfiles, get_timestamp_string
 class MultiProcesser: # pylint: disable=too-many-instance-attributes, too-many-statements
     species = "multiprocesser"
-    def __init__(self, case, proc_class, datap, typean, run_param, mcordata):
+    def __init__(self, case, proc_class, datap, typean, run_param, mcordata, run_config):
         self.case = case
         self.datap = datap
         self.typean = typean
@@ -98,8 +98,8 @@ class MultiProcesser: # pylint: disable=too-many-instance-attributes, too-many-s
 
         self.process_listsample = []
         for indexp in range(self.prodnumber):
-            myprocess = proc_class(self.case, self.datap, self.run_param, self.mcordata,
-                                   self.p_maxfiles[indexp], self.dlper_root[indexp],
+            myprocess = proc_class(run_config, self.case, self.datap, self.run_param,
+                                   self.mcordata, self.p_maxfiles[indexp], self.dlper_root[indexp],
                                    self.dlper_pkl[indexp], self.dlper_pklsk[indexp],
                                    self.dlper_pklml[indexp],
                                    self.p_period[indexp], self.p_chunksizeunp[indexp],

--- a/machine_learning_hep/processerdhadrons_jet.py
+++ b/machine_learning_hep/processerdhadrons_jet.py
@@ -132,12 +132,12 @@ class ProcesserDhadrons_jet(Processer): # pylint: disable=invalid-name, too-many
 
     # Initializer / Instance Attributes
     # pylint: disable=too-many-statements, too-many-arguments, line-too-long
-    def __init__(self, case, datap, run_param, mcordata, p_maxfiles,
+    def __init__(self, run_config, case, datap, run_param, mcordata, p_maxfiles,
                  d_root, d_pkl, d_pklsk, d_pkl_ml, p_period,
                  p_chunksizeunp, p_chunksizeskim, p_maxprocess,
                  p_frac_merge, p_rd_merge, d_pkl_dec, d_pkl_decmerged,
                  d_results, typean, runlisttrigger, d_mcreweights):
-        super().__init__(case, datap, run_param, mcordata, p_maxfiles,
+        super().__init__(run_config, case, datap, run_param, mcordata, p_maxfiles,
                          d_root, d_pkl, d_pklsk, d_pkl_ml, p_period,
                          p_chunksizeunp, p_chunksizeskim, p_maxprocess,
                          p_frac_merge, p_rd_merge, d_pkl_dec, d_pkl_decmerged,

--- a/machine_learning_hep/utilities.py
+++ b/machine_learning_hep/utilities.py
@@ -142,20 +142,21 @@ def checkdir(mydir):
         exfolders = -1
     return exfolders
 
+def checkmakedir(*dirlist):
+    """
+    Makes directory using 'mkdir'
+    """
+    for mydir in dirlist:
+        if os.path.exists(mydir):
+            continue
+        print("creating folder ", mydir)
+        os.makedirs(mydir)
+
 def checkmakedirlist(dirlist):
     """
     Makes directories from list using 'mkdir'
     """
-    for mydir in dirlist:
-        print("creating folder ", mydir)
-        os.makedirs(mydir)
-
-def checkmakedir(mydir):
-    """
-    Makes directory using 'mkdir'
-    """
-    print("creating folder ", mydir)
-    os.makedirs(mydir)
+    checkmakedir(*dirlist)
 
 def delete_dir(path: str):
     """


### PR DESCRIPTION
* only safe ML predictions at application stage
* on the fly select at analysis stage

Note: Indices in skimmed pickled dataframes and prediction pickled
dataframes correspond to each other. Therefore, it is possible to cut on
one dataframe and select the rows with corresponding indices in the
other one.

This is a major improvement

* no duplication of data in application stage
* no pre-selection applied, any selection on ML value can be applied
  during analysis
* many prediction dataframes can be pickled and are saved side-by-side.
  On the fly select the model during analysis the cut should be used
  from.
* apply only once per model
  (most important as this is exremely time-cosuming)

This development is still backward-compatible. Setting
`mlapplication:apply_old = True` in the `submission/default_<type>.yml`
the old way of application is used.

Please note that this option will be removed in version v.0.0.6