### PR TITLE
Restructure and add inclusive analyzer

### DIFF
--- a/ci/flake8-ignore
+++ b/ci/flake8-ignore
@@ -1,6 +1,5 @@
 # Legacy code
 machine_learning_hep/analysis/analyzer_jet_legacy.py
-machine_learning_hep/analysis/analyzer_Dhadrons.py
 
 # Don't pylint setup
 setup.py

--- a/ci/pylint-ignore
+++ b/ci/pylint-ignore
@@ -1,6 +1,5 @@
 # Legacy code
 machine_learning_hep/analysis/analyzer_jet_legacy.py
-machine_learning_hep/analysis/analyzer_Dhadrons.py
 
 # Don't pylint setup
 setup.py

--- a/machine_learning_hep/analysis/analyzer.py
+++ b/machine_learning_hep/analysis/analyzer.py
@@ -17,12 +17,15 @@ from os import makedirs
 
 # HF specific imports
 from machine_learning_hep.workflow.workflow_base import WorkflowBase
+from machine_learning_hep.processing.utils import ProcesserHelper
 from machine_learning_hep.io import dump_yaml_from_dict
 
 
 class Analyzer(WorkflowBase):
     def __init__(self, datap, case, typean, period):
         super().__init__(datap, case, typean, period)
+
+        self.processer_helper = ProcesserHelper(datap, case, typean, period)
 
         # The only thing here is to dump the database in the data analysis directory
         for mcordata in ("mc", "data"):

--- a/machine_learning_hep/analysis/analyzer_jet.py
+++ b/machine_learning_hep/analysis/analyzer_jet.py
@@ -37,7 +37,7 @@ from machine_learning_hep.do_variations import healthy_structure, format_varname
 from machine_learning_hep.utilities_plot import buildhisto, makefill2dhist, makefill3dhist
 from machine_learning_hep.selectionutils import selectfidacc
 from machine_learning_hep.utilities import seldf_singlevar
-from machine_learning_hep.processerdhadrons_jet import adjust_nsd
+from machine_learning_hep.processing.processerdhadrons_jet import adjust_nsd
 
 def shrink_err_x(graph, width=0.1):
     for i in range(graph.GetN()):

--- a/machine_learning_hep/analysis/analyzerdhadrons_mult.py
+++ b/machine_learning_hep/analysis/analyzerdhadrons_mult.py
@@ -200,13 +200,12 @@ class AnalyzerDhadrons_mult(Analyzer): # pylint: disable=invalid-name
         self.fitter = None
         self.p_performval = datap["analysis"].get("event_cand_validation", None)
 
-    # pylint: disable=import-outside-toplevel
     def fit(self):
         # Enable ROOT batch mode and reset in the end
         tmp_is_root_batch = gROOT.IsBatch()
         gROOT.SetBatch(True)
 
-        self.fitter = MLFitter(self.datap, self.typean, self.n_filemass, self.n_filemass_mc)
+        self.fitter = MLFitter(self.processer_helper, self.n_filemass, self.n_filemass_mc)
         self.fitter.perform_pre_fits()
         self.fitter.perform_central_fits()
         fileout_name = self.make_file_path(self.d_resultsallpdata, self.yields_filename, "root",
@@ -230,7 +229,7 @@ class AnalyzerDhadrons_mult(Analyzer): # pylint: disable=invalid-name
         if not self.fitter:
             fileout_name = os.path.join(self.d_resultsallpdata,
                                         f"{self.fits_dirname}_{self.case}_{self.typean}")
-            self.fitter = MLFitter(self.datap, self.typean, self.n_filemass, self.n_filemass_mc)
+            self.fitter = MLFitter(self.processer_helper, self.n_filemass, self.n_filemass_mc)
             if not self.fitter.load_fits(fileout_name):
                 self.logger.error("Cannot load fits from dir %s", fileout_name)
                 return

--- a/machine_learning_hep/fitting/helpers.py
+++ b/machine_learning_hep/fitting/helpers.py
@@ -38,40 +38,42 @@ class MLFitParsFactory:
     SIG_FUNC_MAP = {"kGaus": 0, "k2Gaus": 1, "kGausSigmaRatioPar": 2}
     BKG_FUNC_MAP = {"kExpo": 0, "kLin": 1, "Pol2": 2, "kNoBk": 3, "kPow": 4, "kPowEx": 5}
 
-    def __init__(self, database: dict, ana_type: str, file_data_name: str, file_mc_name: str):
+    def __init__(self, processer_helper, file_data_name: str, file_mc_name: str):
         """
         Initialize MLFitParsFactory
         Args:
-            database: dictionary of the entire analysis database
-            ana_type: specifying the analysis within the database to be done
+            processer_helper: ProcesserHelper
+                generic helper for retrieving and handling database info
             file_data_name: file path where to find data histograms to fit
             file_mc_name: file path where to find MC histograms to fit
         """
 
         self.logger = get_logger()
 
-        ana_config = database["analysis"][ana_type]
+        self.processer_helper = processer_helper
 
-        self.prob_cut_fin = database["mlapplication"]["probcutoptimal"]
+        ana_config = processer_helper.analysis
+
+        self.prob_cut_fin = processer_helper.database["mlapplication"]["probcutoptimal"]
 
         # File config
         self.file_data_name = file_data_name
         self.file_mc_name = file_mc_name
 
         # Binning
-        self.bin1_name = database["var_binning"]
+        self.bin1_name = processer_helper.database["var_binning"]
         self.bins1_edges_low = ana_config["sel_an_binmin"]
         self.bins1_edges_up = ana_config["sel_an_binmax"]
         self.n_bins1 = len(self.bins1_edges_low)
-        self.bin2_name = ana_config["var_binning2"]
-        self.bin2_gen_name = ana_config["var_binning2_gen"]
-        self.bins2_edges_low = ana_config["sel_binmin2"]
-        self.bins2_edges_up = ana_config["sel_binmax2"]
-        self.n_bins2 = len(self.bins2_edges_low)
         self.bin_matching = ana_config["binning_matching"]
+        self.bin2_name = ana_config.get("var_binning2", None)
+        self.bin2_gen_name = ana_config.get("var_binning2_gen", None)
+        self.bins2_edges_low = ana_config.get("sel_binmin2", None)
+        self.bins2_edges_up = ana_config.get("sel_binmax2", None)
+        self.n_bins2 = len(self.bins2_edges_low) if self.bins2_edges_low else 1
+        self.has_bin2 = bool(self.bin2_name)
 
-        bineff = ana_config["usesinglebineff"]
-        self.bins2_int_bin = bineff if bineff is not None else 0
+        self.bins2_int_bin = ana_config.get("pre_fit_mult_bin", 0)
         # Fit method flags
         self.init_fits_from = ana_config["init_fits_from"]
         self.sig_func_name = ana_config["sgnfunc"]
@@ -242,23 +244,6 @@ class MLFitParsFactory:
         return fit_pars
 
 
-    def make_suffix(self, ibin1, ibin2):
-        """
-        Build name suffix to find histograms in ROOT file
-        Args:
-            ibin1: Number of bin of first binning variable
-            ibin2: Number of bin of second binning variable
-        Returns:
-            Suffix string
-        """
-        bin_id_match = self.bin_matching[ibin1]
-        return "%s%d_%d_%.2f%s_%.2f_%.2f" % \
-               (self.bin1_name, self.bins1_edges_low[ibin1],
-                self.bins1_edges_up[ibin1], self.prob_cut_fin[bin_id_match],
-                self.bin2_name, self.bins2_edges_low[ibin2],
-                self.bins2_edges_up[ibin2])
-
-
     def get_histograms(self, ibin1, ibin2, get_data=True, get_mc=False, get_reflections=False):
         """
         Get histograms according to specified bins
@@ -271,7 +256,7 @@ class MLFitParsFactory:
         Returns:
             histograms as requested. None for each that was not requested
         """
-        suffix = self.make_suffix(ibin1, ibin2)
+        suffix = self.processer_helper.make_mass_histo_suffix(ibin1, ibin2)
 
         histo_data = None
         if get_data:
@@ -376,23 +361,22 @@ class MLFitter:
     """
 
 
-    def __init__(self, database: dict, ana_type: str, data_out_dir: str, mc_out_dir: str):
+    def __init__(self, processer_helper, data_out_dir: str, mc_out_dir: str):
         """
         Initialize MLFitter
         Args:
-            database: dictionary of the entire analysis database
-            ana_type: specifying the analysis within the database to be done
+            processer_helper: ProcesserHelper
+                generic helper for retrieving and handling database info
             file_data_name: file path where to find data histograms to fit
             file_mc_name: file path where to find MC histograms to fit
         """
 
         self.logger = get_logger()
 
-        self.case = next(iter(database))
-        self.ana_type = ana_type
-        self.ana_config = database["analysis"][ana_type]
-
-        self.pars_factory = MLFitParsFactory(database, ana_type, data_out_dir, mc_out_dir)
+        self.pars_factory = MLFitParsFactory(processer_helper, data_out_dir, mc_out_dir)
+        self.processer_helper = processer_helper
+        self.ana_config = processer_helper.analysis
+        self.ana_type = processer_helper.ana_type
 
         self.pre_fits_mc = None
         self.pre_fits_data = None
@@ -716,7 +700,7 @@ class MLFitter:
             x_axis_label = "#it{M}_{inv} (GeV/#it{c}^{2})"
             n_sigma_signal = self.pars_factory.n_sigma_signal
 
-            suffix_write = self.pars_factory.make_suffix(ibin1, ibin2)
+            suffix_write = self.processer_helper.make_mass_histo_suffix(ibin1, ibin2)
 
             kernel = fit.kernel
             histo = fit.histo
@@ -770,7 +754,9 @@ class MLFitter:
             have_summary_pt_bins.append(ibin1)
 
             # Pre-fit MC
-            suffix_write = self.pars_factory.make_suffix(ibin1, self.pars_factory.bins2_int_bin)
+            suffix_write = \
+                    self.processer_helper.make_mass_histo_suffix(ibin1,
+                                                                 self.pars_factory.bins2_int_bin)
 
             pre_fit_mc = self.pre_fits_mc[ibin1]
             kernel = pre_fit_mc.kernel
@@ -843,19 +829,19 @@ class MLFitter:
         # Plot some summary historgrams
         leg_strings = [f"{self.pars_factory.bins2_edges_low[ibin2]} #leq {latex_bin2_var} < " \
                        f"{self.pars_factory.bins2_edges_up[ibin2]}" for ibin2 in bins2]
-        save_name = make_file_path(save_dir, "Yields", "eps", None, [self.case, self.ana_type])
+        save_name = make_file_path(save_dir, "Yields", "eps")
         # Yields summary plot
         plot_histograms([yieldshistos[ibin2] for ibin2 in bins2], True, True, leg_strings,
                         "uncorrected yields", "#it{p}_{T} (GeV/#it{c})",
                         f"Uncorrected yields {latex_hadron_name} {self.ana_type}", "mult. / int.",
                         save_name)
-        save_name = make_file_path(save_dir, "Means", "eps", None, [self.case, self.ana_type])
+        save_name = make_file_path(save_dir, "Means", "eps")
         # Means summary plot
         plot_histograms([means_histos[ibin2] for ibin2 in bins2], False, True, leg_strings, "Means",
                         "#it{p}_{T} (GeV/#it{c})",
                         "#mu_{fit} " + f"{latex_hadron_name} {self.ana_type}", "mult. / int.",
                         save_name)
-        save_name = make_file_path(save_dir, "Sigmas", "eps", None, [self.case, self.ana_type])
+        save_name = make_file_path(save_dir, "Sigmas", "eps")
         #Sigmas summary plot
         plot_histograms([sigmas_histos[ibin2] for ibin2 in bins2], False, True, leg_strings,
                         "Sigmas", "#it{p}_{T} (GeV/#it{c})",
@@ -863,14 +849,12 @@ class MLFitter:
                         save_name)
 
         # Plot the initialized means and sigma for MC and data
-        save_name = make_file_path(save_dir, "Means_mult_int", "eps", None,
-                                   [self.case, self.ana_type])
+        save_name = make_file_path(save_dir, "Means_mult_int", "eps")
         plot_histograms([means_init_mc_histos, means_init_data_histos], False, False,
                         ["MC", "data"], "Means of int. mult.", "#it{p}_{T} (GeV/#it{c})",
                         "#mu_{fit} " + f"{latex_hadron_name} {self.ana_type}", "", save_name)
 
-        save_name = make_file_path(save_dir, "Sigmas_mult_int", "eps", None,
-                                   [self.case, self.ana_type])
+        save_name = make_file_path(save_dir, "Sigmas_mult_int", "eps")
         plot_histograms([sigmas_init_mc_histos, sigmas_init_data_histos], False, False,
                         ["MC", "data"], "Sigmas of int. mult.", "#it{p}_{T} (GeV/#it{c})",
                         "#sigma_{fit} " + f"{latex_hadron_name} {self.ana_type}", "", save_name)
@@ -907,7 +891,7 @@ class MLFitter:
                     f"{self.pars_factory.bins1_edges_up[ibin1]:.1f}" \
                     f"(prob > {self.pars_factory.prob_cut_fin[bin_id_match]:.2f})"
 
-            suffix_write = self.pars_factory.make_suffix(ibin1, ibin2)
+            suffix_write = self.processer_helper.make_mass_histo_suffix(ibin1, ibin2)
 
             fit.results_path = os.path.join(results_dir,
                                             f"multi_trial_bin1_{ibin1}_bin2_{ibin2}.root")

--- a/machine_learning_hep/fitting/helpers.py
+++ b/machine_learning_hep/fitting/helpers.py
@@ -28,8 +28,8 @@ from machine_learning_hep.utilities_plot import plot_histograms
 from machine_learning_hep.fitting.utils import save_fit, load_fit
 from machine_learning_hep.fitting.fitters import FitAliHF, FitROOTGauss, FitSystAliHF
 
-# pylint: disable=too-many-instance-attributes, too-many-statements
-class MLFitParsFactory:
+
+class MLFitParsFactory: # pylint: disable=too-many-instance-attributes, too-many-statements
     """
     Managing MLHEP specific fit parameters and is used to collect and retrieve all information
     required to initialise a (systematic) fit
@@ -351,11 +351,8 @@ class MLFitParsFactory:
             for ibin1 in range(self.n_bins1):
                 yield ibin1, ibin2, self.get_syst_pars(ibin1, ibin2)
 
-# pylint: enable=too-many-instance-attributes, too-many-statements
 
-
-# pylint: disable=too-many-instance-attributes
-class MLFitter:
+class MLFitter: # pylint: disable=too-many-instance-attributes
     """
     Wrapper around all available fits insatntiated and used in an MLHEP analysis run.
     """
@@ -989,4 +986,3 @@ class MLFitter:
         self.done_pre_fits = True
         self.done_central_fits = False
         return success
-# pylint: enable=too-many-instance-attributes

--- a/machine_learning_hep/processing/__init__.py
+++ b/machine_learning_hep/processing/__init__.py
@@ -1,0 +1,13 @@
+#############################################################################
+##  © Copyright CERN 2018. All rights not expressly granted are reserved.  ##
+##                 Author: Gian.Michele.Innocenti@cern.ch                  ##
+## This program is free software: you can redistribute it and/or modify it ##
+##  under the terms of the GNU General Public License as published by the  ##
+## Free Software Foundation, either version 3 of the License, or (at your  ##
+## option) any later version. This program is distributed in the hope that ##
+##  it will be useful, but WITHOUT ANY WARRANTY; without even the implied  ##
+##     warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.    ##
+##           See the GNU General Public License for more details.          ##
+##    You should have received a copy of the GNU General Public License    ##
+##   along with this program. if not, see <https://www.gnu.org/licenses/>. ##
+#############################################################################

--- a/machine_learning_hep/processing/multiprocesser.py
+++ b/machine_learning_hep/processing/multiprocesser.py
@@ -16,7 +16,6 @@
 main script for doing data processing, machine learning and analysis
 """
 import os
-from machine_learning_hep.processer import Processer # pylint: disable=unused-import
 from machine_learning_hep.utilities import merge_method, mergerootfiles, get_timestamp_string
 class MultiProcesser: # pylint: disable=too-many-instance-attributes, too-many-statements
     species = "multiprocesser"

--- a/machine_learning_hep/processing/processer.py
+++ b/machine_learning_hep/processing/processer.py
@@ -32,6 +32,7 @@ from machine_learning_hep.utilities import create_folder_struc, seldf_singlevar,
 from machine_learning_hep.utilities import mergerootfiles
 from machine_learning_hep.utilities import get_timestamp_string
 from machine_learning_hep.models import apply # pylint: disable=import-error
+from machine_learning_hep.processing.utils import ProcesserHelper
 #from machine_learning_hep.logger import get_logger
 
 class Processer: # pylint: disable=too-many-instance-attributes
@@ -46,6 +47,7 @@ class Processer: # pylint: disable=too-many-instance-attributes
                  p_frac_merge, p_rd_merge, d_pkl_dec, d_pkl_decmerged,
                  d_results, typean, runlisttrigger, d_mcreweights):
         #self.logger = get_logger()
+        self.processer_helper = ProcesserHelper(datap, case, typean, p_period)
         self.nprongs = datap["nprongs"]
         self.prongformultsub = datap["prongformultsub"]
         self.doml = datap["doml"]

--- a/machine_learning_hep/processing/processerdhadrons.py
+++ b/machine_learning_hep/processing/processerdhadrons.py
@@ -25,7 +25,7 @@ from machine_learning_hep.bitwise import tag_bit_df
 from machine_learning_hep.utilities import selectdfrunlist
 from machine_learning_hep.utilities import seldf_singlevar, openfile
 from machine_learning_hep.selectionutils import getnormforselevt
-from machine_learning_hep.processer import Processer
+from machine_learning_hep.processing.processer import Processer
 
 class ProcesserDhadrons(Processer): # pylint: disable=too-many-instance-attributes
     # Class Attribute
@@ -95,8 +95,7 @@ class ProcesserDhadrons(Processer): # pylint: disable=too-many-instance-attribut
                 df = df.query(self.s_trigger)
             df = seldf_singlevar(df, self.v_var_binning, \
                                  self.lpt_finbinmin[ipt], self.lpt_finbinmax[ipt])
-            suffix = "%s%d_%d" % \
-                     (self.v_var_binning, self.lpt_finbinmin[ipt], self.lpt_finbinmax[ipt])
+            suffix = self.processer_helper.make_mass_histo_suffix(ipt)
             h_invmass = TH1F("hmass" + suffix, "", self.p_num_bins,
                              self.p_mass_fit_lim[0], self.p_mass_fit_lim[1])
             if self.runlistrigger is not None:

--- a/machine_learning_hep/processing/processerdhadrons_jet.py
+++ b/machine_learning_hep/processing/processerdhadrons_jet.py
@@ -29,7 +29,7 @@ from machine_learning_hep.utilities import selectdfrunlist, seldf_singlevar, ope
 from machine_learning_hep.utilities import create_folder_struc, mergerootfiles, get_timestamp_string
 from machine_learning_hep.utilities import z_calc, z_gen_calc
 from machine_learning_hep.utilities_plot import buildhisto, build2dhisto, fill2dhist, makefill3dhist
-from machine_learning_hep.processer import Processer
+from machine_learning_hep.processing.processer import Processer
 #from machine_learning_hep.selectionutils import selectpid_dzerotokpi
 
 def apply_cut_selpid(df_):

--- a/machine_learning_hep/processing/processerdhadrons_mult.py
+++ b/machine_learning_hep/processing/processerdhadrons_mult.py
@@ -30,7 +30,7 @@ from machine_learning_hep.utilities import mergerootfiles
 from machine_learning_hep.utilities import get_timestamp_string
 from machine_learning_hep.root import create_meta_info, write_meta_info
 #from machine_learning_hep.globalfitter import fitter
-from machine_learning_hep.processer import Processer
+from machine_learning_hep.processing.processer import Processer
 from machine_learning_hep.bitwise import filter_bit_df, tag_bit_df
 from machine_learning_hep.validation.validation_vertex import fill_validation_vertex
 from machine_learning_hep.validation.validation_multiplicity import fill_validation_multiplicity
@@ -234,10 +234,7 @@ class ProcesserDhadrons_mult(Processer): # pylint: disable=too-many-instance-att
                 df = self.apply_cuts_ptbin(df, ipt)
 
             for ibin2 in range(len(self.lvar2_binmin)):
-                suffix = "%s%d_%d_%.2f%s_%.2f_%.2f" % \
-                         (self.v_var_binning, self.lpt_finbinmin[ipt],
-                          self.lpt_finbinmax[ipt], self.lpt_probcutfin[bin_id],
-                          self.v_var2_binning, self.lvar2_binmin[ibin2], self.lvar2_binmax[ibin2])
+                suffix = self.processer_helper.make_mass_histo_suffix(ipt, ibin2)
                 curr_dir = myfile.mkdir(f"bin1_{ipt}_bin2_{ibin2}")
                 meta_info = create_meta_info(self.v_var_binning, self.lpt_finbinmin[ipt],
                                              self.lpt_finbinmax[ipt], self.v_var2_binning,

--- a/machine_learning_hep/processing/utils.py
+++ b/machine_learning_hep/processing/utils.py
@@ -1,0 +1,114 @@
+#############################################################################
+##  © Copyright CERN 2018. All rights not expressly granted are reserved.  ##
+##                 Author: Gian.Michele.Innocenti@cern.ch                  ##
+## This program is free software: you can redistribute it and/or modify it ##
+##  under the terms of the GNU General Public License as published by the  ##
+## Free Software Foundation, either version 3 of the License, or (at your  ##
+## option) any later version. This program is distributed in the hope that ##
+##  it will be useful, but WITHOUT ANY WARRANTY; without even the implied  ##
+##     warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.    ##
+##           See the GNU General Public License for more details.          ##
+##    You should have received a copy of the GNU General Public License    ##
+##   along with this program. if not, see <https://www.gnu.org/licenses/>. ##
+#############################################################################
+
+"""
+utilities for processing
+"""
+
+import sys
+
+
+def make_mass_histo_suffix(bin1_name, bin1_low, bin1_up,
+                           bin2_name=None, bin2_low=None, bin2_up=None,
+                           ml_cut=None):
+    """Make common suffix for mass histograms
+
+    Args:
+        bin1_name: str
+        bin1_low: float
+        bin1_up: float
+        bin2_name: str (optional)
+        bin2_low: float (optional)
+        bin2_up: float (optional)
+        ml_cut: float (optional)
+    Returns:
+        str
+            suffix to be used for mass histograms
+    """
+    suffix = f"{bin1_name}{bin1_low}_{bin1_up}"
+    if ml_cut is not None:
+        suffix = f"{suffix}_{ml_cut:.2f}"
+    if bin2_name is not None and bin2_low is not None and bin2_up is not None:
+        suffix = f"{suffix}{bin2_name}_{bin2_low:.2f}_{bin2_up:.2f}"
+    return suffix
+
+
+class ProcesserHelper: # pylint: disable=too-few-public-methods
+    """Helper class for common database operations
+
+    Helper class useful when processing and analysing to derive
+    names or generic strings (like save suffix) from the database
+
+    """
+    def __init__(self, database, case, ana_type, period=None):
+        """Init
+
+        Args:
+            database: dict
+                configuration database
+                (everything below top node aka case)
+            case: str
+                the particle case
+            ana_type: str
+                name of analysis node sub-section to be used
+            period: int (optional)
+                data taking period number
+                (None indicates all periods merged)
+        """
+        self.database = database
+        self.case = case
+        self. ana_type = ana_type
+        self.period = period
+        self.analysis = database["analysis"][ana_type]
+
+
+    def make_mass_histo_suffix(self, ibin1, ibin2=None):
+        """Derive mass histogram suffix from analysis bins
+
+        Given one (or two) differential bin number(s), derive mass histogram
+        suffix using public make_mass_histo_suffix
+
+        Args:
+            ibin1: int
+                index of first differential bin
+            ibin2: int (optional)
+                index of second differential bin
+        Returns:
+        str
+            suffix to be used for mass histograms
+        """
+        bin1_match_id = self.analysis.get("binning_matching", None)
+        ml_cut = None
+        if bin1_match_id:
+            ml_cut = self.database["mlapplication"]["probcutoptimal"][bin1_match_id[ibin1]]
+        bin1_name = self.database["var_binning"]
+        bin1_low = self.analysis["sel_an_binmin"][ibin1]
+        bin1_up = self.analysis["sel_an_binmax"][ibin1]
+        bin2_name = None
+        bin2_low = None
+        bin2_up = None
+        if ibin2 is not None:
+            bin2_name = self.analysis.get("var_binning2", None)
+            bin2_low = self.analysis.get("sel_binmin2", None)
+            bin2_up = self.analysis.get("sel_binmax2", None)
+            if not bin2_name or not bin2_low or not bin2_up:
+                print(f"Try to derive suffix for ibin2 {ibin2} but either \"var_binning2\", " \
+                      f"\"sel_binmin2\" or \"sel_binmax2\" is missing")
+                sys.exit(1)
+            bin2_low = bin2_low[ibin2]
+            bin2_up = bin2_up[ibin2]
+
+        return make_mass_histo_suffix(bin1_name, bin1_low, bin1_up,
+                                      bin2_name, bin2_low, bin2_up,
+                                      ml_cut)

--- a/machine_learning_hep/steer_analysis.py
+++ b/machine_learning_hep/steer_analysis.py
@@ -27,11 +27,11 @@ from pkg_resources import resource_stream
 # To set batch mode immediately
 from ROOT import gROOT # pylint: disable=import-error, no-name-in-module
 
-from machine_learning_hep.multiprocesser import MultiProcesser
-from machine_learning_hep.processer import Processer
-from machine_learning_hep.processerdhadrons import ProcesserDhadrons
-from machine_learning_hep.processerdhadrons_mult import ProcesserDhadrons_mult
-from machine_learning_hep.processerdhadrons_jet import ProcesserDhadrons_jet
+from machine_learning_hep.processing.multiprocesser import MultiProcesser
+from machine_learning_hep.processing.processer import Processer
+from machine_learning_hep.processing.processerdhadrons import ProcesserDhadrons
+from machine_learning_hep.processing.processerdhadrons_mult import ProcesserDhadrons_mult
+from machine_learning_hep.processing.processerdhadrons_jet import ProcesserDhadrons_jet
 #from machine_learning_hep.doskimming import conversion, merging, merging_period, skim
 #from machine_learning_hep.doclassification_regression import doclassification_regression
 #from machine_learning_hep.doanalysis import doanalysis


### PR DESCRIPTION
* revive analysis/analyerdhadrons.py

* move processer related code to processing sub-directory

* introduce ProcesserHelper for common operation
  (at the moment only construction mass histogram suffices)
  can and should be used in Processer and Analyzer classes. In both
  cases the parent classes have an object self.processer_helper which
  can be used in derivin classes

* updated MLFitter to comply with inclusive analysis