### PR TITLE
Generic MC event reweighting

### DIFF
--- a/machine_learning_hep/data/data_prod_20200304/database_ml_parameters_LcpK0spp_0304.yml
+++ b/machine_learning_hep/data/data_prod_20200304/database_ml_parameters_LcpK0spp_0304.yml
@@ -538,7 +538,7 @@ LcpK0spp:
       usesinglebineff: null
       fprompt_from_mb: true
       corresp_mb_typean: null
-      corrEffMult: [false, false, false, false]
+      corrEffMult: [true, true, true, true]
       sel_binmin2:  [0,30,0.1,0] #list of var2 splittng nbins
       sel_binmax2: [100,100,30,0.1] #list of var2 splitting nbins
       var_binning2: perc_v0m
@@ -553,6 +553,39 @@ LcpK0spp:
       binning_matching: [0,1,2,3,4,5] #list of pt nbins
       presel_gen_eff: "abs(y_cand) < 0.5 and abs(z_vtx_gen) < 10"
       evtsel: is_ev_rej==0
+
+      event_weighting_mc:
+        LHC16pp:
+          - filepath: data/event_weighting_mc/weights_n_tracklets_1cand_data.root
+            histo_name: weights_int_int_LHC16pp
+            according_to: n_tracklets_corr
+          - filepath: data/event_weighting_mc/weights_n_tracklets_1cand_data.root
+            histo_name: weights_perc_v0m_30_100_eq_int_LHC16pp
+            according_to: n_tracklets_corr
+          - filepath: data/event_weighting_mc/weights_n_tracklets_1cand_data.root
+            histo_name: weights_perc_v0m_01_30_eq_int_LHC16pp
+            according_to: n_tracklets_corr
+        LHC17pp:
+          - filepath: data/event_weighting_mc/weights_n_tracklets_1cand_data.root
+            histo_name: weights_int_int_LHC17pp
+            according_to: n_tracklets_corr
+          - filepath: data/event_weighting_mc/weights_n_tracklets_1cand_data.root
+            histo_name: weights_perc_v0m_30_100_eq_int_LHC17pp
+            according_to: n_tracklets_corr
+          - filepath: data/event_weighting_mc/weights_n_tracklets_1cand_data.root
+            histo_name: weights_perc_v0m_01_30_eq_int_LHC17pp
+            according_to: n_tracklets_corr
+        LHC18pp:
+          - filepath: data/event_weighting_mc/weights_n_tracklets_1cand_data.root
+            histo_name: weights_int_int_LHC18pp
+            according_to: n_tracklets_corr
+          - filepath: data/event_weighting_mc/weights_n_tracklets_1cand_data.root
+            histo_name: weights_perc_v0m_30_100_eq_int_LHC18pp
+            according_to: n_tracklets_corr
+          - filepath: data/event_weighting_mc/weights_n_tracklets_1cand_data.root
+            histo_name: weights_perc_v0m_01_30_eq_int_LHC18pp
+            according_to: n_tracklets_corr
+
       triggersel:
         data: "trigger_hasbit_INT7==1"
         mc: null

--- a/machine_learning_hep/data/data_prod_20200417/database_ml_parameters_D0pp_0417.yml
+++ b/machine_learning_hep/data/data_prod_20200417/database_ml_parameters_D0pp_0417.yml
@@ -658,7 +658,7 @@ D0pp:
       usesinglebineff: null
       fprompt_from_mb: true
       corresp_mb_typean: null
-      corrEffMult: [false,false,false,false]
+      corrEffMult: [true, true, true, true]
       sel_binmin2:  [0,30,0.1,0] #list of var2 splittng nbins
       sel_binmax2: [100,100,30,0.1] #list of var2 splitting nbins
       var_binning2: perc_v0m

--- a/machine_learning_hep/data/data_prod_20200417/database_ml_parameters_D0pp_0417.yml
+++ b/machine_learning_hep/data/data_prod_20200417/database_ml_parameters_D0pp_0417.yml
@@ -673,6 +673,39 @@ D0pp:
       include_reflection: True
       presel_gen_eff: "abs(y_cand) < 0.5 and abs(z_vtx_gen) < 10"
       evtsel: is_ev_rej==0
+
+      event_weighting_mc:
+        LHC16pp:
+          - filepath: data/event_weighting_mc/weights_n_tracklets_1cand_data.root
+            histo_name: weights_int_int_LHC16pp
+            according_to: n_tracklets_corr
+          - filepath: data/event_weighting_mc/weights_n_tracklets_1cand_data.root
+            histo_name: weights_perc_v0m_01_30_eq_int_LHC16pp
+            according_to: n_tracklets_corr
+          - filepath: data/event_weighting_mc/weights_n_tracklets_1cand_data.root
+            histo_name: weights_perc_v0m_30_100_eq_int_LHC16pp
+            according_to: n_tracklets_corr
+        LHC17pp:
+          - filepath: data/event_weighting_mc/weights_n_tracklets_1cand_data.root
+            histo_name: weights_int_int_LHC17pp
+            according_to: n_tracklets_corr
+          - filepath: data/event_weighting_mc/weights_n_tracklets_1cand_data.root
+            histo_name: weights_perc_v0m_01_30_eq_int_LHC17pp
+            according_to: n_tracklets_corr
+          - filepath: data/event_weighting_mc/weights_n_tracklets_1cand_data.root
+            histo_name: weights_perc_v0m_30_100_eq_int_LHC17pp
+            according_to: n_tracklets_corr
+        LHC18pp:
+          - filepath: data/event_weighting_mc/weights_n_tracklets_1cand_data.root
+            histo_name: weights_int_int_LHC18pp
+            according_to: n_tracklets_corr
+          - filepath: data/event_weighting_mc/weights_n_tracklets_1cand_data.root
+            histo_name: weights_perc_v0m_01_30_eq_int_LHC18pp
+            according_to: n_tracklets_corr
+          - filepath: data/event_weighting_mc/weights_n_tracklets_1cand_data.root
+            histo_name: weights_perc_v0m_30_100_eq_int_LHC18pp
+            according_to: n_tracklets_corr
+
       triggersel:
         data: "trigger_hasbit_INT7==1"
         mc: null

--- a/machine_learning_hep/processerdhadrons_mult.py
+++ b/machine_learning_hep/processerdhadrons_mult.py
@@ -319,6 +319,11 @@ class ProcesserDhadrons_mult(Processer): # pylint: disable=too-many-instance-att
             float: error
 
         """
+
+        def no_weights(df_):
+            val = len(df_)
+            return val, math.sqrt(val)
+
         event_weighting_mc = {}
         if self.event_weighting_mc and ibin is not None and len(self.event_weighting_mc) < ibin:
             # Check is there is a dictionary with desired info
@@ -331,11 +336,16 @@ class ProcesserDhadrons_mult(Processer): # pylint: disable=too-many-instance-att
         if not os.path.exists(filepath):
             print(f"Could not find filepath {filepath} for MC event weighting." \
                     "Compute unweighted values...")
-            val = len(dfsel)
-            return val, math.sqrt(val)
+            return no_weights(dfsel)
 
         weight_file = TFile.Open(filepath, "read")
-        weights = weight_file.Get(event_weighting_mc.get("histo_name", "Weights0"))
+        histo_name = event_weighting_mc.get("histo_name", "Weights0")
+        weights = weight_file.Get(histo_name)
+
+        if not weights:
+            print(f"Could not find histogram {histo_name} for MC event weighting." \
+                    "Compute unweighted values...")
+            return no_weights(dfsel)
 
         weight_according_to = event_weighting_mc.get("according_to", self.v_var2_binning_gen)
 


### PR DESCRIPTION
* add weight file to data/event_weighting_mc used for weighting in V0M
  analysis

* allow for specification of how MC should be re-weighted in database
  refer to database
  data/data_prd_20200304/database_ml_parameters_LcpK0spp_0304.yml
  and there check the analysis MBvspt_perc_v0m and in there one finds
  the field event_weighting_mc

* this is at the moment only implemented in processerdhadrons_mult.py