### PR TITLE
[WIP] Re-write ML systematics and related updates

### DIFF
--- a/machine_learning_hep/analysis/analyzer_manager.py
+++ b/machine_learning_hep/analysis/analyzer_manager.py
@@ -20,7 +20,7 @@ class AnalyzerManager:
     Manager class handling analysis and systematic objects
     """
 
-    def __init__(self, ana_class, database, case, typean, doperiodbyperiod, *args):
+    def __init__(self, ana_class, database, case, typean, doperiodbyperiod, *args, **kwargs):
 
         self.ana_class = ana_class
         self.database = database
@@ -30,6 +30,8 @@ class AnalyzerManager:
 
         # Additional arguments to be forwarded to the analyzers
         self.add_args = args
+        self.args_per_period = kwargs.get("args_per_period", None)
+        self.kwargs_per_period = kwargs.get("kwargs_per_period", None)
 
         self.logger = get_logger()
 
@@ -38,6 +40,23 @@ class AnalyzerManager:
 
         self.is_initialized = False
 
+    def __add_args_per_period(self, ip):
+        if self.args_per_period:
+            return self.add_args + self.args_per_period[ip]
+        return self.add_args
+
+    
+    def get_analyzers(self, none_for_unused_period=True):
+        if not none_for_unused_period:
+            return self.analyzers
+
+        useperiod = self.database["analysis"][self.typean]["useperiod"]
+        analyzers = [None] * (len(useperiod) + 1)
+        for a in self.analyzers:
+            if a.period is not None:
+                analyzers[a.period] = a
+        analyzers[-1] = self.analyzers[-1]
+        
 
     def initialize(self):
         """
@@ -53,10 +72,12 @@ class AnalyzerManager:
 
         for ip, period in enumerate(useperiod):
             if self.doperiodbyperiod and period:
+                args = self.__add_args_per_period(ip)
                 self.analyzers.append(self.ana_class(self.database, self.case, self.typean, ip,
-                                                     *self.add_args))
+                                                     *args))
+        args = self.__add_args_per_period(-1)
         self.analyzers.append(self.ana_class(self.database, self.case, self.typean, None,
-                                             *self.add_args))
+                                             *args))
 
         if self.doperiodbyperiod:
             # get after-burner, if any

--- a/machine_learning_hep/analysis/analyzer_manager.py
+++ b/machine_learning_hep/analysis/analyzer_manager.py
@@ -20,7 +20,7 @@ class AnalyzerManager:
     Manager class handling analysis and systematic objects
     """
 
-    def __init__(self, ana_class, database, case, typean, doperiodbyperiod, *args, **kwargs):
+    def __init__(self, ana_class, database, case, typean, doperiodbyperiod, *args):
 
         self.ana_class = ana_class
         self.database = database
@@ -30,8 +30,6 @@ class AnalyzerManager:
 
         # Additional arguments to be forwarded to the analyzers
         self.add_args = args
-        self.args_per_period = kwargs.get("args_per_period", None)
-        self.kwargs_per_period = kwargs.get("kwargs_per_period", None)
 
         self.logger = get_logger()
 
@@ -40,13 +38,9 @@ class AnalyzerManager:
 
         self.is_initialized = False
 
-    def __add_args_per_period(self, ip):
-        if self.args_per_period:
-            return self.add_args + self.args_per_period[ip]
-        return self.add_args
 
-    
     def get_analyzers(self, none_for_unused_period=True):
+        self.initialize()
         if not none_for_unused_period:
             return self.analyzers
 
@@ -56,7 +50,8 @@ class AnalyzerManager:
             if a.period is not None:
                 analyzers[a.period] = a
         analyzers[-1] = self.analyzers[-1]
-        
+        return analyzers
+
 
     def initialize(self):
         """
@@ -72,12 +67,10 @@ class AnalyzerManager:
 
         for ip, period in enumerate(useperiod):
             if self.doperiodbyperiod and period:
-                args = self.__add_args_per_period(ip)
                 self.analyzers.append(self.ana_class(self.database, self.case, self.typean, ip,
-                                                     *args))
-        args = self.__add_args_per_period(-1)
+                                                     *self.add_args))
         self.analyzers.append(self.ana_class(self.database, self.case, self.typean, None,
-                                             *args))
+                                             *self.add_args))
 
         if self.doperiodbyperiod:
             # get after-burner, if any

--- a/machine_learning_hep/analysis/systematics.py
+++ b/machine_learning_hep/analysis/systematics.py
@@ -18,192 +18,53 @@ Main script for doing the systematic studies. Standalone, so some parts similar 
 At the moment includes: Cut variation and MC pT shape
 The raw yield systematic is done within analyzer.py
 """
-# pylint: disable=unused-wildcard-import, wildcard-import
 # pylint: disable=no-name-in-module
 # pylint: disable=import-error
 from os.path import join, exists
 from os import makedirs
-import math
-from array import *
-import pickle
-from root_numpy import fill_hist
-from ROOT import gROOT, gPad
-from ROOT import TFile, TH1F, TCanvas, TLegend
+from copy import deepcopy, copy
+from random import shuffle
+
+from ROOT import TFile, TCanvas, TLegend
 from ROOT import kRed, kGreen, kBlack, kBlue, kOrange, kViolet, kAzure, kYellow
-from ROOT import Double
+
 #from machine_learning_hep.utilities import selectdfrunlist
-from machine_learning_hep.utilities import seldf_singlevar, openfile, make_file_path
-from machine_learning_hep.utilities_plot import load_root_style_simple, load_root_style
-from machine_learning_hep.utilities import mergerootfiles, get_timestamp_string
-from machine_learning_hep.analysis.analyzer import Analyzer, AnalyzerAfterBurner
-
-class SystematicsAfterBurner(AnalyzerAfterBurner):
-    # pylint: disable=useless-super-delegation
-    def __init__(self, database, case, typean):
-        super().__init__(database, case, typean)
-
-    def ml_cutvar_mass(self):
-
-        tmp_merged = f"/data/tmp/hadd/{self.case}_{self.typean}/cutvar_mass/" \
-                     f"{get_timestamp_string()}/"
-        # This warning appears since it is set to None in the AnalyzerAfterBurner constructor
-        # But it will have a meaningful value at this point
-        # pylint: disable=not-an-iterable
-        files_mass_cutvar = [syst.n_filemass_cutvar for syst in self.analyzers]
-
-        filename_mass = self.datap["files_names"]["histofilename"].replace(".root", "_cutvar.root")
-        merged_file = join(self.datap["analysis"][self.typean]["data"]["resultsallp"], "cutvar")
-        merged_file = join(merged_file, filename_mass)
-
-        mergerootfiles(files_mass_cutvar, merged_file, tmp_merged)
-
-        # pylint: disable=fixme
-        # Get the cut limits of the latest period and set them for the merged analyzer
-        # FIXME This is not the entirely correct way as it does not correctly reflect
-        #       the efficiency boundaries for the merged case
-        # This warning appears since it is set to None in the AnalyzerAfterBurner constructor
-        # But it will have a meaningful value at this point
-        # pylint: disable=unsubscriptable-object
-        self.analyzer_merged.min_cv_cut = self.analyzers[-1].min_cv_cut
-        self.analyzer_merged.max_cv_cut = self.analyzers[-1].max_cv_cut
-
-    def ml_cutvar_eff(self):
-
-        tmp_merged = f"/data/tmp/hadd/{self.case}_{self.typean}/cutvar_eff/" \
-                     f"{get_timestamp_string()}/"
-        # This warning appears since it is set to None in the AnalyzerAfterBurner constructor
-        # But it will have a meaningful value at this point
-        # pylint: disable=not-an-iterable
-        files_eff_cutvar = [syst.n_fileeff_cutvar for syst in self.analyzers]
-
-        filename_eff = self.datap["files_names"]["efffilename"].replace(".root", "_cutvar.root")
-        merged_file = join(self.datap["analysis"][self.typean]["data"]["resultsallp"], "cutvar")
-        merged_file = join(merged_file, filename_eff)
-
-        mergerootfiles(files_eff_cutvar, merged_file, tmp_merged)
-
-    def mcptshape(self):
-
-        tmp_merged = f"/data/tmp/hadd/{self.case}_{self.typean}/mcptshape_eff/" \
-                     f"{get_timestamp_string()}/"
-        # This warning appears since it is set to None in the AnalyzerAfterBurner constructor
-        # But it will have a meaningful value at this point
-        # pylint: disable=not-an-iterable
-        files_eff_cutvar = [syst.n_fileeff_ptshape for syst in self.analyzers]
-
-        filename_eff = self.datap["files_names"]["efffilename"].replace(".root", "_ptshape.root")
-        merged_file = join(self.datap["analysis"][self.typean]["data"]["resultsallp"],
-                           filename_eff)
-
-        mergerootfiles(files_eff_cutvar, merged_file, tmp_merged)
+from machine_learning_hep.utilities_plot import load_root_style
+from machine_learning_hep.fitting.helpers import MLFitter
+from machine_learning_hep.multiprocesser import MultiProcesser
 
 
 # pylint: disable=too-many-lines
 # pylint: disable=too-many-instance-attributes, too-many-statements, too-many-arguments
 # pylint: disable=too-many-branches, too-many-nested-blocks
-class Systematics(Analyzer):
+class Systematics: # pylint: disable=too-few-public-methods
     species = "systematics"
-    def __init__(self, datap, case, typean, period, run_param):
-        super().__init__(datap, case, typean, period)
+
+    CENT_CV_CUT = []
+    MIN_CV_CUT = []
+    MAX_CV_CUT = []
+
+    NOMINAL_MEANS = []
+    NOMINAL_SIGMAS = []
+
+    ml_wps = []
+    ml_wps_strings = []
+
+    def __init__(self, datap, case, typean, run_param,
+                 analyzers, multiprocesser_mc, multiprocesser_data):
+
+        self.datap = datap
+        self.case = case
+        self.typean = typean
+
+        self.nominal_analyzer_merged = analyzers[-1]
+        self.nominal_processer_mc = multiprocesser_mc.process_listsample[0]
+        self.nominal_processer_data = multiprocesser_data.process_listsample[0]
+        self.multiprocesser_mc = multiprocesser_mc
+        self.multiprocesser_data = multiprocesser_data
+        self.nominal_analyzer = analyzers[-1]
 
         self.run_param = run_param
-        self.p_period = datap["multi"]["data"]["period"][period] if period is not None \
-                else "merged"
-        self.d_pkl_decmerged_mc = datap["mlapplication"]["mc"]["pkl_skimmed_decmerged"][period] \
-                if period is not None else ""
-        self.d_pkl_decmerged_data = \
-                datap["mlapplication"]["data"]["pkl_skimmed_decmerged"][period] \
-                if period is not None else ""
-        self.d_results = datap["analysis"][typean]["data"]["results"][period] \
-                if period is not None else datap["analysis"][typean]["data"]["resultsallp"]
-
-        self.v_var_binning = datap["var_binning"]
-        #Binning used when skimming/training
-        self.lpt_anbinmin = datap["sel_skim_binmin"]
-        self.lpt_anbinmax = datap["sel_skim_binmax"]
-        self.p_nptbins = len(datap["sel_skim_binmax"])
-        #Analysis binning
-        self.lpt_finbinmin = datap["analysis"][self.typean]["sel_an_binmin"]
-        self.lpt_finbinmax = datap["analysis"][self.typean]["sel_an_binmax"]
-        self.p_nptfinbins = len(self.lpt_finbinmin)
-        self.bin_matching = datap["analysis"][self.typean]["binning_matching"]
-        #Second analysis binning
-        self.lvar2_binmin = datap["analysis"][self.typean]["sel_binmin2"]
-        self.lvar2_binmax = datap["analysis"][self.typean]["sel_binmax2"]
-        self.v_var2_binning = datap["analysis"][self.typean]["var_binning2"]
-        self.v_var2_binning_gen = datap["analysis"][self.typean]["var_binning2_gen"]
-
-        #ML model variables
-        self.p_modelname = datap["mlapplication"]["modelname"]
-        self.lpt_probcutfin = datap["mlapplication"]["probcutoptimal"]
-        self.lpt_probcutpre_mc = datap["mlapplication"]["probcutpresel"]["mc"]
-        self.lpt_probcutpre_data = datap["mlapplication"]["probcutpresel"]["data"]
-
-        #Extra pre-selections
-        self.triggerbit = datap["analysis"][self.typean]["triggerbit"]
-        self.s_evtsel = datap["analysis"][self.typean]["evtsel"]
-        self.s_presel_gen_eff = datap["analysis"][self.typean]["presel_gen_eff"]
-        self.s_trigger_mc = datap["analysis"][self.typean]["triggersel"]["mc"]
-        self.s_trigger_data = datap["analysis"][self.typean]["triggersel"]["data"]
-        self.apply_weights = \
-                datap["analysis"][self.typean]["triggersel"].get("usetriggcorrfunc", None) \
-                is not None
-
-        #Build names for input pickle files (data, mc_reco, mc_gen)
-        self.n_reco = datap["files_names"]["namefile_reco"]
-        self.n_gen = datap["files_names"]["namefile_gen"]
-        self.lpt_recodec_mc = [self.n_reco.replace(".pkl", "%d_%d_%.2f.pkl" % \
-                              (self.lpt_anbinmin[i], self.lpt_anbinmax[i], \
-                               self.lpt_probcutpre_mc[i])) for i in range(self.p_nptbins)]
-        self.lpt_recodec_data = [self.n_reco.replace(".pkl", "%d_%d_%.2f.pkl" % \
-                                (self.lpt_anbinmin[i], self.lpt_anbinmax[i], \
-                                 self.lpt_probcutpre_data[i])) for i in range(self.p_nptbins)]
-        self.lpt_recodecmerged_mc = [join(self.d_pkl_decmerged_mc, self.lpt_recodec_mc[ipt])
-                                     for ipt in range(self.p_nptbins)]
-        self.lpt_recodecmerged_data = [join(self.d_pkl_decmerged_data, \
-                                       self.lpt_recodec_data[ipt]) for ipt in range(self.p_nptbins)]
-
-        self.lpt_gensk = [self.n_gen.replace(".pkl", "_%s%d_%d.pkl" % \
-                          (self.v_var_binning, self.lpt_anbinmin[i], self.lpt_anbinmax[i])) \
-                          for i in range(self.p_nptbins)]
-        self.lpt_gendecmerged = [join(self.d_pkl_decmerged_mc, self.lpt_gensk[ipt]) \
-                                 for ipt in range(self.p_nptbins)]
-
-        #Build names for intermediate output ROOT files
-        self.n_filemass = datap["files_names"]["histofilename"]
-        self.n_fileeff = datap["files_names"]["efffilename"]
-        self.n_filemass_cutvar = self.n_filemass.replace(".root", "_cutvar.root")
-        self.n_fileeff_cutvar = self.n_fileeff.replace(".root", "_cutvar.root")
-        self.n_fileeff_ptshape = self.n_fileeff.replace(".root", "_ptshape.root")
-        #Build directories for intermediate output ROOT files
-        self.d_results_cv = join(self.d_results, "cutvar")
-        if not exists(self.d_results_cv):
-            makedirs(self.d_results_cv)
-        self.n_filemass_cutvar = join(self.d_results_cv, self.n_filemass_cutvar)
-        self.n_fileeff_cutvar = join(self.d_results_cv, self.n_fileeff_cutvar)
-        self.n_fileeff_ptshape = join(self.d_results, self.n_fileeff_ptshape)
-        #Final file names for analyzer.py
-        self.yields_filename_std = "yields"
-        self.efficiency_filename_std = "efficiencies"
-        self.cross_filename_std = "finalcross"
-        #Final file names used for systematics
-        self.yields_filename = "yields_cutvar"
-        self.efficiency_filename = "efficiencies_cutvar"
-        self.efficiency_filename_pt = "efficiencies_mcptshape"
-        self.cross_filename = "finalcross_cutvar"
-        self.ptspectra_filename = "ptspectra_for_weights"
-
-        #Variables for cross section/corrected yield calculation (NB: not all corr are applied)
-        self.f_evtnorm = join(self.d_results, "correctionsweights.root")
-        self.p_indexhpt = datap["analysis"]["indexhptspectrum"]
-        self.p_fd_method = datap["analysis"]["fd_method"]
-        self.p_cctype = datap["analysis"]["cctype"]
-        self.p_sigmav0 = datap["analysis"]["sigmav0"]
-        self.p_bineff = datap["analysis"][self.typean]["usesinglebineff"]
-        self.p_fprompt_from_mb = datap["analysis"][self.typean]["fprompt_from_mb"]
-        self.p_triggereff = datap["analysis"][self.typean].get("triggereff", [1] * 10)
-        self.p_triggereffunc = datap["analysis"][self.typean].get("triggereffunc", [0] * 10)
-        self.p_inputfonllpred = datap["analysis"]["inputfonllpred"]
 
         #Variables for the systematic variations
         self.p_cutvar_minrange = datap["systematics"]["probvariation"]["cutvarminrange"]
@@ -220,155 +81,249 @@ class Systematics(Analyzer):
         self.min_signif_fit = datap["systematics"]["probvariation"].get("min_signif_fit", -1.)
         self.max_red_chi2_fit = datap["systematics"]["probvariation"].get("max_red_chi2_fit", -1.)
 
-        #For fitting
-        #For mass histos
-        self.p_mass_fit_lim = datap["analysis"][self.typean]["mass_fit_lim"]
-        self.p_bin_width = datap["analysis"][self.typean]["bin_width"]
-        self.p_num_bins = int(round((self.p_mass_fit_lim[1] - self.p_mass_fit_lim[0]) / \
-                                    self.p_bin_width))
-        #For rebinning mass and yield histos
-        self.rebins = datap["analysis"][self.typean]["rebin"].copy()
-        if not isinstance(self.rebins[0], list):
-            self.rebins = [self.rebins for _ in range(len(self.lvar2_binmin))]
-        self.ptranges = self.lpt_finbinmin.copy()
-        self.ptranges.append(self.lpt_finbinmax[-1])
-        #For AliHFInvMassFitter
-        self.p_sgnfunc = datap["analysis"][self.typean]["sgnfunc"]
-        self.p_bkgfunc = datap["analysis"][self.typean]["bkgfunc"]
-        self.sig_fmap = {"kGaus": 0, "k2Gaus": 1, "kGausSigmaRatioPar": 2}
-        self.bkg_fmap = {"kExpo": 0, "kLin": 1, "Pol2": 2, "kNoBk": 3, "kPow": 4, "kPowEx": 5}
-        self.p_massmin = datap["analysis"][self.typean]["massmin"]
-        self.p_massmax = datap["analysis"][self.typean]["massmax"]
-        #Extra AliHFInvMassFitter settings
-        self.p_dolike = datap["analysis"][self.typean]["dolikelihood"]
-        self.p_masspeak = datap["analysis"][self.typean]["masspeak"]
-        self.p_sigmaarray = datap["analysis"][self.typean]["sigmaarray"]
-        self.p_exclude_nsigma_sideband = datap["analysis"][self.typean]["exclude_nsigma_sideband"]
-        self.p_nsigma_signal = datap["analysis"][self.typean]["nsigma_signal"]
-        #Options for reflections (e.g. D0)
-        self.p_include_reflection = datap["analysis"][self.typean].get("include_reflection", False)
-        #Options for second peak of Ds
-        self.p_includesecpeaks = datap["analysis"][self.typean].get("includesecpeak", None)
-        self.p_widthsecpeak = datap["analysis"][self.typean].get("widthsecpeak", None)
-        self.p_masssecpeak = datap["analysis"][self.typean].get("masssecpeak", None)
-        self.p_fix_masssecpeaks = datap["analysis"][self.typean].get("fix_masssecpeak", None)
-        self.p_fix_widthsecpeak = datap["analysis"][self.typean].get("fix_widthsecpeak", None)
-        #Some safety for p_fix_masssecpeaks that is checked with [i][j]
-        if self.p_includesecpeaks is not None:
-            if self.p_fix_masssecpeaks is None:
-                self.p_fix_masssecpeaks = [False for ipt in range(self.p_nptbins)]
-            self.p_fix_masssecpeaks = self.p_fix_masssecpeaks.copy()
-            if not isinstance(self.p_fix_masssecpeaks[0], list):
-                self.p_fix_masssecpeaks = [self.p_fix_masssecpeaks \
-                                           for _ in range(len(self.lvar2_binmin))]
-        #Some safety for p_includesecpeaks that is checked with [i][j]
-        if self.p_includesecpeaks is None:
-            self.p_includesecpeaks = [False for ipt in range(self.p_nptbins)]
-        self.p_includesecpeaks = self.p_includesecpeaks.copy()
-        if not isinstance(self.p_includesecpeaks[0], list):
-            self.p_includesecpeaks = [self.p_includesecpeaks for _ in range(len(self.lvar2_binmin))]
 
-        self.min_cv_cut = None
-        self.max_cv_cut = None
+        self.syst_out_dir = "ML_WP_syst"
+        self.processers_mc_syst = None
+        self.processers_data_syst = None
+        self.analyzers_syst = None
 
-        # Flag whether some internals methods have been executed
-        self.done_mass = False
-        self.done_eff = False
-        self.done_fit = False
+        self.p_modelname = self.nominal_processer_mc.p_modelname
 
-    def get_after_burner(self):
-        return SystematicsAfterBurner(self.datap, self.case, self.typean)
+        self.n_trials = 2 * self.p_ncutvar
 
 
-    def define_cutvariation_limits(self):
-        """
-        Cut Variation: Defines the probability cuts based on a max percentage variation (set in DB)
-        Produces N (set in DB) tighter and N looser probability cuts
-        """
+    def __read_nominal_fit_values(self):
 
-        # Check if that has been run already
-        if self.min_cv_cut or self.period is None:
+        if Systematics.NOMINAL_MEANS is not None:
             return
 
-        self.logger.info("Defining systematic cut variations for period: %s", \
-                         self.p_period)
+        fitter = MLFitter(self.nominal_analyzer_merged.case,
+                          self.nominal_analyzer_merged.datap,
+                          self.nominal_analyzer_merged.typean,
+                          self.nominal_analyzer_merged.n_filemass,
+                          self.nominal_analyzer_merged.n_filemass_mc)
+        fitter.load_fits(self.nominal_analyzer_merged.fits_dirname)
 
-        self.min_cv_cut = []
-        self.max_cv_cut = []
-        cent_cv_cut = []
+        ana_n_first_binning = self.nominal_analyzer_merged.p_nptbins
+        ana_n_second_binning = self.nominal_analyzer_merged.p_nbin2
+
+        Systematics.NOMINAL_MEANS = [[None] * ana_n_first_binning \
+                for _ in range(ana_n_second_binning)]
+        Systematics.NOMINAL_SIGMAS = [[None] * ana_n_first_binning \
+                for _ in range(ana_n_second_binning)]
+
+        for ibin1 in range(ana_n_first_binning):
+            for ibin2 in range(ana_n_second_binning):
+                fit = fitter.get_central_fit(ibin1, ibin2)
+                Systematics.NOMINAL_MEANS[ibin2][ibin1] = fit.kernel.GetMean() # pylint: disable=unsubscriptable-object
+                Systematics.NOMINAL_SIGMAS[ibin2][ibin1] = fit.kernel.GetSigma() # pylint: disable=unsubscriptable-object
+
+
+    def __define_cutvariation_limits(self):
+        """obtain ML WP limits (lower/upper) keeping required efficiency variation
+
+        This runs a MultiProcesser and an Analyzer both derived from the nominal
+        Processer and Analyzer class.
+
+        Both are run as long as the boundaries are found.
+
+        Boundaries are searched for in the analysis with all periods merged and are
+        defined for the MB integrated multiplicity bin.
+
+        """
+
+        # Only do this once for all
+        if Systematics.CENT_CV_CUT is not None:
+            return
+
+        # use multiprocesser here, prepare database
+        datap = deepcopy(self.datap)
+
+        results_dirs_periods = [join(d, "tmp_ml_wp_limits") \
+                for d in datap["analysis"][self.typean]["mc"]["results"]]
+        results_dir_all = join(datap["analysis"][self.typean]["mc"]["resultsallp"],
+                               "tmp_ml_wp_limits")
+
+        datap["analysis"][self.typean]["mc"]["results"] = results_dirs_periods
+        datap["analysis"][self.typean]["mc"]["resultsallp"] = results_dir_all
+
+        for rdp in results_dirs_periods:
+            if exists(rdp):
+                continue
+            makedirs(rdp)
+        if not exists(results_dir_all):
+            makedirs(results_dir_all)
+
+        # MultiProcesser to cover all at once
+        multi_processer_effs = MultiProcesser(self.case, self.nominal_processer_mc.__class__, datap,
+                                              self.typean, self.multiprocesser_mc.run_param,
+                                              "mc")
+
+        # construct analyzer for all periods merged and use it for finding ML WP boundaries
+        analyzer_effs = self.nominal_analyzer_merged.__class__(datap, self.case, self.typean, None)
+
+        n_pt_bins = self.nominal_processer_mc.p_nptfinbins
+
+        Systematics.CENT_CV_CUT = self.nominal_processer_mc.lpt_probcutfin
+
+        ana_n_first_binning = analyzer_effs.p_nptbins
+
+        bin_matching = self.nominal_analyzer_merged.bin_matching
+
+        nominal_effs = [None] * ana_n_first_binning
+        for ibin1 in range(ana_n_first_binning):
+            nominal_effs[ibin1], _ = self.nominal_analyzer_merged.get_efficiency(ibin1, 0)
+
+        Systematics.MIN_CV_CUT = [None] * ana_n_first_binning
+        Systematics.MAX_CV_CUT = [None] * ana_n_first_binning
+
         ncutvar_temp = self.p_ncutvar * 2
-        for ipt in range(self.p_nptfinbins):
 
-            bin_id = self.bin_matching[ipt]
-            df_mc_reco = pickle.load(openfile(self.lpt_recodecmerged_mc[bin_id], "rb"))
-            if self.s_evtsel is not None:
-                df_mc_reco = df_mc_reco.query(self.s_evtsel)
-            if self.s_trigger_mc is not None:
-                df_mc_reco = df_mc_reco.query(self.s_trigger_mc)
+        stepsmin = []
+        stepsmax = []
 
-            df_mc_gen = pickle.load(openfile(self.lpt_gendecmerged[bin_id], "rb"))
-            df_mc_gen = df_mc_gen.query(self.s_presel_gen_eff)
 
-            df_mc_reco = seldf_singlevar(df_mc_reco, self.v_var2_binning_gen, \
-                                self.lpt_finbinmin[ipt], self.lpt_finbinmax[ipt])
-            df_mc_gen = seldf_singlevar(df_mc_gen, self.v_var2_binning_gen, \
-                                 self.lpt_finbinmin[ipt], self.lpt_finbinmax[ipt])
+        def found_all_boundaries(boundaries):
+            """helper to check whether all boundaries have been fixed
+            """
+            if None in boundaries:
+                return False
+            return True
 
-            df_mc_reco = seldf_singlevar(df_mc_reco, self.v_var2_binning_gen, \
-                                         self.lvar2_binmin[0], \
-                                         self.lvar2_binmax[0])
-            df_mc_gen = seldf_singlevar(df_mc_gen, self.v_var2_binning_gen, \
-                                        self.lvar2_binmin[0], \
-                                        self.lvar2_binmax[0])
 
-            df_gen_sel_pr = df_mc_gen[df_mc_gen.ismcprompt == 1]
-            df_reco_presel_pr = df_mc_reco[df_mc_reco.ismcprompt == 1]
+        def compute_new_boundaries(wps, boundaries):
+            """helper to compute boundaries if not yet fixed
+            """
+            if found_all_boundaries(boundaries):
+                return
+            wps_strings = ["y_test_prob%s>%s" % (self.p_modelname, wps[ipt]) \
+                    for ipt in range(n_pt_bins)]
+            # update processers and analyzer ML WPs
+            for proc in multi_processer_effs.process_listsample:
+                proc.l_selml = wps_strings
+            analyzer_effs.lpt_probcutfin = wps
 
-            selml_cent = "y_test_prob%s>%s" % (self.p_modelname, self.lpt_probcutfin[bin_id])
-            df_reco_sel_pr = df_reco_presel_pr.query(selml_cent)
-            len_gen_pr = len(df_gen_sel_pr)
-            eff_cent = len(df_reco_sel_pr)/len_gen_pr
+            # Run both
+            multi_processer_effs.multi_efficiency()
+            analyzer_effs.efficiency()
 
-            stepsmin = \
-              (self.lpt_probcutfin[bin_id] - self.p_cutvar_minrange[bin_id]) / ncutvar_temp
-            self.min_cv_cut.append(self.lpt_probcutfin[bin_id])
-            cent_cv_cut.append(self.lpt_probcutfin[bin_id])
-            df_reco_cvmin_pr = df_reco_presel_pr
-            for icv in range(ncutvar_temp):
-                self.min_cv_cut[ipt] = self.p_cutvar_minrange[bin_id] + icv * stepsmin
-                selml_min = "y_test_prob%s>%s" % (self.p_modelname, self.min_cv_cut[ipt])
-                df_reco_cvmin_pr = df_reco_cvmin_pr.query(selml_min)
-                eff_min = len(df_reco_cvmin_pr)/len_gen_pr
-                if eff_cent == 0:
-                    break
-                if eff_min / eff_cent < 1 + self.p_maxperccutvar:
-                    break
+            # Read and compare efficiencies to nominal ones. Add if not yet found
+            for ibin1 in range(ana_n_first_binning):
+                eff_new, _ = analyzer_effs.get_efficiency(ibin1, 0)
+                if abs(eff_new - nominal_effs[ibin1]) / nominal_effs[ibin1] < self.p_maxperccutvar \
+                        and boundaries[ibin1] is None:
+                    boundaries[ibin1] = wps[bin_matching[ibin1]]
 
-            eff_min = len(df_reco_cvmin_pr)/len_gen_pr
 
-            stepsmax = \
-              (self.p_cutvar_maxrange[bin_id] - self.lpt_probcutfin[bin_id]) / ncutvar_temp
-            self.max_cv_cut.append(self.lpt_probcutfin[bin_id])
-            df_reco_cvmax_pr = df_reco_sel_pr
-            for icv in range(ncutvar_temp):
-                self.max_cv_cut[ipt] = self.lpt_probcutfin[bin_id] + icv * stepsmax
-                selml_max = "y_test_prob%s>%s" % (self.p_modelname, self.max_cv_cut[ipt])
-                df_reco_cvmax_pr = df_reco_cvmax_pr.query(selml_max)
-                eff_max = len(df_reco_cvmax_pr)/len_gen_pr
-                if eff_cent == 0:
-                    break
-                if eff_max / eff_cent < 1 - self.p_maxperccutvar:
-                    break
+        # Define stepping up and down from nominal WPs
+        for ipt in range(n_pt_bins):
 
-            eff_max = len(df_reco_cvmax_pr)/len_gen_pr
+            stepsmin.append( \
+              (Systematics.CENT_CV_CUT[ipt] - self.p_cutvar_minrange[ipt]) / ncutvar_temp)
+
+            stepsmax.append( \
+              (self.p_cutvar_maxrange[ipt] - Systematics.CENT_CV_CUT[ipt]) / ncutvar_temp)
+
+        # Attempt to find WP variations up and down
+        for icv in range(ncutvar_temp):
+            if found_all_boundaries(Systematics.MIN_CV_CUT) \
+                    and found_all_boundaries(Systematics.MAX_CV_CUT):
+                break
+
+            wps = [self.p_cutvar_minrange[ipt] + icv * stepsmin[ipt] for ipt in range(n_pt_bins)]
+            compute_new_boundaries(wps, Systematics.MIN_CV_CUT)
+            wps = [self.p_cutvar_maxrange[ipt] - icv * stepsmax[ipt] for ipt in range(n_pt_bins)]
+            compute_new_boundaries(wps, Systematics.MAX_CV_CUT)
 
         print("Limits for cut variation defined, based on eff %-var of: ", self.p_maxperccutvar)
-        print("--Cut variation minimum: ", self.min_cv_cut)
-        print("--Central probability cut: ", cent_cv_cut)
-        print("--Cut variation maximum: ", self.max_cv_cut)
+        print("--Cut variation boundaries minimum: ", Systematics.MIN_CV_CUT)
+        print("--Central probability cut: ", Systematics.CENT_CV_CUT)
+        print("--Cut variation boundaries maximum: ", Systematics.MAX_CV_CUT)
 
 
-    def ml_cutvar_mass(self):
+
+    def __make_working_points(self):
+        Systematics.ml_wps = [[] for _ in range(self.n_trials)]
+        Systematics.ml_wps_strings = [[] for _ in range(self.n_trials)]
+
+        n_pt_bins = self.nominal_processer_mc.p_nptfinbins
+        for ipt in range(n_pt_bins):
+
+            stepsmin = (Systematics.CENT_CV_CUT[ipt] - Systematics.MIN_CV_CUT[ipt]) / self.p_ncutvar
+            stepsmax = (Systematics.MAX_CV_CUT[ipt] - Systematics.CENT_CV_CUT[ipt]) / self.p_ncutvar
+
+            for icv in range(self.p_ncutvar):
+                lower_cut = Systematics.MIN_CV_CUT[ipt] + icv * stepsmin
+                upper_cut = Systematics.CENT_CV_CUT[ipt] + (icv + 1) * stepsmax
+
+                selml_cv_low = "y_test_prob%s>%s" % (self.p_modelname, lower_cut)
+                selml_cv_up = "y_test_prob%s>%s" % (self.p_modelname, upper_cut)
+                Systematics.ml_wps[icv].append(lower_cut)
+                Systematics.ml_wps_strings[icv].append(selml_cv_low)
+                Systematics.ml_wps[self.p_ncutvar + icv].append(upper_cut)
+                Systematics.ml_wps_strings[self.p_ncutvar + icv].append(selml_cv_up)
+
+        print(Systematics.ml_wps)
+        print(Systematics.ml_wps_strings)
+
+
+    def __prepare_trial(self, i_trial):
+
+
+        datap = deepcopy(self.datap)
+        datap["analysis"][self.typean]["mc"]["results"] = \
+                [join(d, self.syst_out_dir, f"trial_{i_trial}") \
+                for d in datap["analysis"][self.typean]["mc"]["results"]]
+        datap["analysis"][self.typean]["mc"]["resultsallp"] = \
+                join(datap["analysis"][self.typean]["mc"]["resultsallp"], \
+                self.syst_out_dir, f"trial_{i_trial}")
+
+        datap["analysis"][self.typean]["data"]["results"] = \
+                [join(d, self.syst_out_dir, f"trial_{i_trial}") \
+                for d in datap["analysis"][self.typean]["data"]["results"]]
+        datap["analysis"][self.typean]["data"]["resultsallp"] = \
+                join(datap["analysis"][self.typean]["data"]["resultsallp"], \
+                self.syst_out_dir, f"trial_{i_trial}")
+
+        for new_dir in \
+                datap["analysis"][self.typean]["mc"]["results"] + \
+                [datap["analysis"][self.typean]["mc"]["resultsallp"]] + \
+                datap["analysis"][self.typean]["data"]["results"] + \
+                [datap["analysis"][self.typean]["data"]["resultsallp"]]:
+            if not exists(new_dir):
+                makedirs(new_dir)
+
+        datap["analysis"][self.typean]["probcuts"] = Systematics.ml_wps[i_trial]
+
+        # For now take PDG mean
+        # However, we could have means and sigmas per pT AND mult, but for that the DB logic
+        # has to be changed
+        datap["analysis"][self.typean]["FixedMean"] = True
+        datap["analysis"][self.typean]["masspeak"] = Systematics.NOMINAL_MEANS
+        datap["analysis"][self.typean]["sigmaarray"] = Systematics.NOMINAL_SIGMAS[0]
+        datap["analysis"][self.typean]["SetFixGaussianSigma"] = \
+                [True] * len(Systematics.NOMINAL_SIGMAS[0])
+        datap["analysis"][self.typean]["SetInitialGaussianSigma"] = \
+                [True] * len(Systematics.NOMINAL_SIGMAS[0])
+        datap["analysis"][self.typean]["SetInitialGaussianMean"] = \
+                [True] * len(Systematics.NOMINAL_SIGMAS[0])
+
+        # Processers
+        self.processers_mc_syst[i_trial] = MultiProcesser(self.case,
+                                                          self.nominal_processer_mc.__class__,
+                                                          datap, self.typean,
+                                                          self.multiprocesser_mc.run_param, "mc")
+        self.processers_data_syst[i_trial] = MultiProcesser(self.case,
+                                                            self.nominal_processer_mc.__class__,
+                                                            datap, self.typean,
+                                                            self.multiprocesser_mc.run_param,
+                                                            "data")
+
+        self.analyzers_syst[i_trial] = self.nominal_analyzer_merged.__class__(datap, self.case,
+                                                                              self.typean, None)
+
+
+    def __ml_cutvar_mass(self, i_trial):
         """
         Cut Variation: Create ROOT file with mass histograms
         Histogram for each variation, for each pT bin, for each 2nd binning bin
@@ -376,73 +331,11 @@ class Systematics(Analyzer):
         Similar as process_histomass_single(self, index) in processor.py
         """
 
-        # Do this only for a single period
-        if self.period is None:
-            return
-
-        # Define limits first
-        self.define_cutvariation_limits()
-
-        myfile = TFile.Open(self.n_filemass_cutvar, "recreate")
-
-        print("Using run selection for mass histo for period", self.p_period)
-        for ipt in range(self.p_nptfinbins):
-            bin_id = self.bin_matching[ipt]
-            df = pickle.load(openfile(self.lpt_recodecmerged_data[bin_id], "rb"))
-
-            stepsmin = (self.lpt_probcutfin[bin_id] - self.min_cv_cut[ipt]) / self.p_ncutvar
-            stepsmax = (self.max_cv_cut[ipt] - self.lpt_probcutfin[bin_id]) / self.p_ncutvar
-            ntrials = 2 * self.p_ncutvar + 1
-            icvmax = 1
-
-            if self.s_evtsel is not None:
-                df = df.query(self.s_evtsel)
-            if self.s_trigger_data is not None:
-                df = df.query(self.s_trigger_data)
-            df = seldf_singlevar(df, self.v_var_binning, \
-                                 self.lpt_finbinmin[ipt], self.lpt_finbinmax[ipt])
-
-            arr_selml_cv = []
-            for icv in range(ntrials):
-                if icv < self.p_ncutvar:
-                    selml_cvval = self.min_cv_cut[ipt] + icv * stepsmin
-                elif icv == self.p_ncutvar:
-                    selml_cvval = self.lpt_probcutfin[bin_id]
-                else:
-                    selml_cvval = self.lpt_probcutfin[bin_id] + icvmax * stepsmax
-                    icvmax = icvmax + 1
-                selml_cv = "y_test_prob%s>%s" % (self.p_modelname, selml_cvval)
-
-                arr_selml_cv.append(selml_cvval)
-                df = df.query(selml_cv)
-
-                for ibin2 in range(len(self.lvar2_binmin)):
-                    suffix = "%s%d_%d_%d_%s%.2f_%.2f" % \
-                             (self.v_var_binning, self.lpt_finbinmin[ipt],
-                              self.lpt_finbinmax[ipt], icv,
-                              self.v_var2_binning, self.lvar2_binmin[ibin2],
-                              self.lvar2_binmax[ibin2])
-                    h_invmass = TH1F("hmass" + suffix, "", self.p_num_bins,
-                                     self.p_mass_fit_lim[0], self.p_mass_fit_lim[1])
-                    h_invmass_weight = TH1F("h_invmass_weight" + suffix, "", self.p_num_bins,
-                                            self.p_mass_fit_lim[0], self.p_mass_fit_lim[1])
-
-                    df_bin = seldf_singlevar(df, self.v_var2_binning,
-                                             self.lvar2_binmin[ibin2], self.lvar2_binmax[ibin2])
-
-                    fill_hist(h_invmass, df_bin.inv_mass)
-
-                    myfile.cd()
-                    h_invmass.Write()
-                    h_invmass_weight.Write()
-
-            print(" Selection variations for [", self.lpt_finbinmin[ipt], "-", \
-                  self.lpt_finbinmax[ipt], "]:  \n   ", arr_selml_cv)
-
-        self.done_mass = True
+        self.processers_mc_syst[i_trial].multi_histomass()
+        self.processers_data_syst[i_trial].multi_histomass()
 
 
-    def ml_cutvar_eff(self):
+    def __ml_cutvar_eff(self, i_trial):
         """
         Cut Variation: Create ROOT file with efficiencies
         Histogram for each variation, for each 2nd binning bin
@@ -450,118 +343,10 @@ class Systematics(Analyzer):
         Similar as process_efficiency_single(self, index) in processor.py
         """
 
-        # Do this only for a single period
-        if self.period is None:
-            return
-
-        # Define limits first
-        self.define_cutvariation_limits()
-
-        myfile = TFile.Open(self.n_fileeff_cutvar, "recreate")
-
-        h_gen_pr = []
-        h_sel_pr = []
-        h_gen_fd = []
-        h_sel_fd = []
-
-        print("Using run selection for eff histo for period", self.p_period)
-        idx = 0
-        for ipt in range(self.p_nptfinbins):
-            bin_id = self.bin_matching[ipt]
-            df = pickle.load(openfile(self.lpt_recodecmerged_mc[bin_id], "rb"))
-
-            if self.s_evtsel is not None:
-                df = df.query(self.s_evtsel)
-            if self.s_trigger_mc is not None:
-                df = df.query(self.s_trigger_mc)
-            df = seldf_singlevar(df, self.v_var_binning, self.lpt_finbinmin[ipt], \
-                                 self.lpt_finbinmax[ipt])
-
-            df_gen = pickle.load(openfile(self.lpt_gendecmerged[bin_id], "rb"))
-            df_gen = df_gen.query(self.s_presel_gen_eff)
-            df_gen = seldf_singlevar(df_gen, self.v_var_binning, self.lpt_finbinmin[ipt], \
-                                     self.lpt_finbinmax[ipt])
-
-            stepsmin = (self.lpt_probcutfin[bin_id] - self.min_cv_cut[ipt]) / self.p_ncutvar
-            stepsmax = (self.max_cv_cut[ipt] - self.lpt_probcutfin[bin_id]) / self.p_ncutvar
-            ntrials = 2 * self.p_ncutvar + 1
-            icvmax = 1
-
-            arr_selml_cv = []
-            idx = 0
-            for icv in range(ntrials):
-                if icv < self.p_ncutvar:
-                    selml_cvval = self.min_cv_cut[ipt] + icv * stepsmin
-                elif icv == self.p_ncutvar:
-                    selml_cvval = self.lpt_probcutfin[bin_id]
-                else:
-                    selml_cvval = self.lpt_probcutfin[bin_id] + icvmax * stepsmax
-                    icvmax = icvmax + 1
-                selml_cv = "y_test_prob%s>%s" % (self.p_modelname, selml_cvval)
-
-                arr_selml_cv.append(selml_cvval)
-                df = df.query(selml_cv)
-
-                for ibin2 in range(len(self.lvar2_binmin)):
-                    stringbin2 = "_%d_%s_%.2f_%.2f" % (icv, \
-                                                self.v_var2_binning_gen, \
-                                                self.lvar2_binmin[ibin2], \
-                                                self.lvar2_binmax[ibin2])
-
-                    if ipt == 0:
-                        n_bins = len(self.lpt_finbinmin)
-                        analysis_bin_lims_temp = self.lpt_finbinmin.copy()
-                        analysis_bin_lims_temp.append(self.lpt_finbinmax[n_bins-1])
-                        analysis_bin_lims = array('f', analysis_bin_lims_temp)
-                        h_gen_pr.append(TH1F("h_gen_pr" + stringbin2, \
-                                             "Prompt Generated in acceptance |y|<0.5", \
-                                             n_bins, analysis_bin_lims))
-                        h_sel_pr.append(TH1F("h_sel_pr" + stringbin2, \
-                                             "Prompt Reco and sel in acc |#eta|<0.8 and sel", \
-                                             n_bins, analysis_bin_lims))
-                        h_gen_fd.append(TH1F("h_gen_fd" + stringbin2, \
-                                             "FD Generated in acceptance |y|<0.5", \
-                                             n_bins, analysis_bin_lims))
-                        h_sel_fd.append(TH1F("h_sel_fd" + stringbin2, \
-                                             "FD Reco and sel in acc |#eta|<0.8 and sel", \
-                                             n_bins, analysis_bin_lims))
-
-                    df_bin = seldf_singlevar(df, self.v_var2_binning_gen, \
-                                             self.lvar2_binmin[ibin2], self.lvar2_binmax[ibin2])
-                    df_gen_bin = seldf_singlevar(df_gen, self.v_var2_binning_gen, \
-                                                 self.lvar2_binmin[ibin2], self.lvar2_binmax[ibin2])
-
-                    df_sel_pr = df_bin[df_bin.ismcprompt == 1]
-                    df_gen_pr = df_gen_bin[df_gen_bin.ismcprompt == 1]
-                    df_sel_fd = df_bin[df_bin.ismcfd == 1]
-                    df_gen_fd = df_gen_bin[df_gen_bin.ismcfd == 1]
-
-                    h_gen_pr[idx].SetBinContent(ipt + 1, len(df_gen_pr))
-                    h_gen_pr[idx].SetBinError(ipt + 1, math.sqrt(len(df_gen_pr)))
-                    h_sel_pr[idx].SetBinContent(ipt + 1, len(df_sel_pr))
-                    h_sel_pr[idx].SetBinError(ipt + 1, math.sqrt(len(df_sel_pr)))
-
-                    h_gen_fd[idx].SetBinContent(ipt + 1, len(df_gen_fd))
-                    h_gen_fd[idx].SetBinError(ipt + 1, math.sqrt(len(df_gen_fd)))
-                    h_sel_fd[idx].SetBinContent(ipt + 1, len(df_sel_fd))
-                    h_sel_fd[idx].SetBinError(ipt + 1, math.sqrt(len(df_sel_fd)))
-                    idx = idx + 1
-
-            print(" Selection variations for [", self.lpt_finbinmin[ipt], "-", \
-                  self.lpt_finbinmax[ipt], "]:  \n   ", arr_selml_cv)
-
-        myfile.cd()
-        for i in range(idx):
-            h_gen_pr[i].Write()
-            h_sel_pr[i].Write()
-            h_gen_fd[i].Write()
-            h_sel_fd[i].Write()
-
-        self.done_eff = True
+        self.processers_mc_syst[i_trial].multi_efficiency()
 
 
-    # pylint: disable=import-outside-toplevel
-    def ml_cutvar_fit(self):
+    def __ml_cutvar_ana(self, i_trial):
         """
         Cut Variation: Fit invariant mass histograms with AliHFInvMassFitter
         If requested, sigma+mean can be fixed to central fit
@@ -569,930 +354,153 @@ class Systematics(Analyzer):
         Similar as fitter(self) in analyzer.py
         """
 
-        # Define limits first
-        if self.period is not None and not self.done_mass:
-            self.logger.fatal("Cannot fit since mass histograms have not been produced yet.")
+        self.analyzers_syst[i_trial].fit()
+        self.analyzers_syst[i_trial].efficiency()
+        self.analyzers_syst[i_trial].makenormyields()
+        self.analyzers_syst[i_trial].plotternormyields()
 
-        tmp_is_root_batch = gROOT.IsBatch()
-        gROOT.SetBatch(True)
-        from ROOT import AliHFInvMassFitter, AliVertexingHFUtils
-        # Enable ROOT batch mode and reset in the end
+    @staticmethod
+    def __style_histograms(histos, style_numbers=None):
+        colours = [kRed, kGreen+2, kBlue, kOrange+2, kViolet-1, kAzure+1, kOrange-7,
+                   kViolet+2, kYellow-3]
+        linestyles = [1, 7, 19]
+        markers_closed = [43, 47, 20, 22, 23]
+        markers_open = [42, 46, 24, 26, 32]
 
-        load_root_style_simple()
+        if not style_numbers:
+            style_numbers = [0] * len(histos)
 
-        lfile = TFile.Open(self.n_filemass_cutvar, "READ")
+        for i, (h, s) in enumerate(zip(histos, style_numbers)):
+            markers = markers_closed if s == 0 else markers_open
+            h.SetLineColor(colours[i % len(colours)])
+            h.SetLineStyle(linestyles[i % len(linestyles)])
+            h.SetMarkerStyle(markers[i % len(markers)])
+            h.SetMarkerColor(colours[i % len(colours)])
 
-        ntrials = 2 * self.p_ncutvar + 1
-        icvmax = 1
 
-        mass_fitter = []
-        ifit = 0
+    @staticmethod
+    def __get_histogram(filepath, name):
+        file_in = TFile.Open(filepath, "READ")
+        histo = file_in.Get(name)
+        histo.SetDirectory(0)
+        return histo
 
-        for icv in range(ntrials):
 
-            fileout_name = make_file_path(self.d_results_cv, self.yields_filename, "root", \
-                                          None, [self.typean, str(icv)])
-            fileout = TFile(fileout_name, "RECREATE")
+    @staticmethod
+    def __adjust_min_max(histos):
+        h_min = min([h.GetMinimum() for h in histos])
+        h_max = max([h.GetMaximum() for h in histos])
 
-            yieldshistos = [TH1F("hyields%d" % (imult), "", self.p_nptfinbins, \
-                            array("d", self.ptranges)) for imult in range(len(self.lvar2_binmin))]
+        delta = h_max - h_min
 
-            if self.p_nptfinbins < 9:
-                nx = 4
-                ny = 2
-                canvy = 533
-            elif self.p_nptfinbins < 13:
-                nx = 4
-                ny = 3
-                canvy = 800
-            else:
-                nx = 5
-                ny = 4
-                canvy = 1200
+        h_min = h_min - 0.1 * delta
+        h_max = h_max + delta
 
-            canvas_data = [TCanvas("canvas_cutvar%d_%d" % (icv, imult), "Data", 1000, canvy) \
-                           for imult in range(len(self.lvar2_binmin))]
+        for h in histos:
+            h.GetYaxis().SetRangeUser(h_min, h_max)
+            h.GetYaxis().SetMaxDigits(3)
 
-            for imult in range(len(self.lvar2_binmin)):
-                canvas_data[imult].Divide(nx, ny)
 
-            for imult in range(len(self.lvar2_binmin)):
+    def __make_single_plot(self, name, ibin2, successful):
 
-                mean_for_data, sigma_for_data = self.load_central_meansigma(imult)
+        # Nominal histogram
+        successful_tmp = copy(successful)
+        successful_tmp.sort()
 
-                for ipt in range(self.p_nptfinbins):
-                    bin_id = self.bin_matching[ipt]
+        filename = f"finalcross{self.case}{self.typean}mult{ibin2}.root"
+        filepath = join(self.nominal_analyzer_merged.d_resultsallpdata, filename)
+        nominal_histo = self.__get_histogram(filepath, name)
+        nominal_histo.SetLineColor(kBlack)
+        nominal_histo.SetMarkerStyle(1)
+        nominal_histo.SetLineWidth(3)
 
-                    suffix = "%s%d_%d_%d_%s%.2f_%.2f" % \
-                             (self.v_var_binning, self.lpt_finbinmin[ipt],
-                              self.lpt_finbinmax[ipt], icv,
-                              self.v_var2_binning, self.lvar2_binmin[imult],
-                              self.lvar2_binmax[imult])
+        histos = []
+        legend_strings = []
+        style_numbers = []
+        for succ in successful_tmp:
+            filename = f"finalcross{self.case}{self.typean}mult{ibin2}.root"
+            filepath = join(self.analyzers_syst[succ].d_resultsallpdata, filename)
+            leg_string = "higher" if succ >= self.p_ncutvar else "lower"
+            style_number = 0 if succ >= self.p_ncutvar else 1
+            legend_strings.append(leg_string)
+            style_numbers.append(style_number)
+            histos.append(self.__get_histogram(filepath, name))
 
-                    stepsmin = (self.lpt_probcutfin[bin_id] - self.min_cv_cut[ipt]) / self.p_ncutvar
-                    stepsmax = (self.max_cv_cut[ipt] - self.lpt_probcutfin[bin_id]) / self.p_ncutvar
-                    ntrials = 2 * self.p_ncutvar + 1
+        for h in histos:
+            h.Divide(nominal_histo)
+        nominal_histo.Divide(nominal_histo)
 
-                    selml_cvval = 0
-                    if icv < self.p_ncutvar:
-                        selml_cvval = self.min_cv_cut[ipt] + icv * stepsmin
-                    elif icv == self.p_ncutvar:
-                        selml_cvval = self.lpt_probcutfin[bin_id]
-                    else:
-                        selml_cvval = self.lpt_probcutfin[bin_id] + icvmax * stepsmax
+        self.__style_histograms(histos, style_numbers)
 
-                    histname = "hmass"
-                    if self.apply_weights is True:
-                        histname = "h_invmass_weight"
-                        self.logger.info("*********** I AM USING WEIGHTED HISTOGRAMS")
+        legend = TLegend(0.15, 0.7, 0.85, 0.89)
+        legend.SetNColumns(4)
+        legend.SetBorderSize(0)
+        legend.SetFillStyle(0)
+        legend.SetTextSize(0.02)
 
-                    h_invmass = lfile.Get(histname + suffix)
-                    h_invmass_rebin_ = AliVertexingHFUtils.RebinHisto(h_invmass, \
-                                                                      self.rebins[imult][ipt], -1)
-                    h_invmass_rebin = TH1F()
-                    h_invmass_rebin_.Copy(h_invmass_rebin)
-                    h_invmass_rebin.SetTitle("%.1f < #it{p}_{T} < %.1f (prob > %.4f)" \
-                                             % (self.lpt_finbinmin[ipt], self.lpt_finbinmax[ipt], \
-                                                selml_cvval))
-                    h_invmass_rebin.GetXaxis().SetTitle("#it{M}_{inv} (GeV/#it{c}^{2})")
-                    h_invmass_rebin.GetYaxis().SetTitle("Entries/(%.0f MeV/#it{c}^{2})" \
-                                                        % (h_invmass_rebin.GetBinWidth(1) * 1000))
-                    h_invmass_rebin.GetYaxis().SetTitleOffset(1.1)
+        histos.insert(0, nominal_histo)
+        legend_strings.insert(0, "nominal")
+        style_numbers.insert(0, 0)
+        for h, l in zip(histos, legend_strings):
+            h.SetTitle("")
+            legend.AddEntry(h, l)
+            h.GetXaxis().SetTitle("#it{p}_{T} [GeV/#it{c}]")
+            h.GetYaxis().SetTitle("WP variation / nominal")
+        self.__adjust_min_max(histos, )
 
-                    mass_fitter.append(AliHFInvMassFitter(h_invmass_rebin, self.p_massmin[ipt],
-                                                          self.p_massmax[ipt],
-                                                          self.bkg_fmap[self.p_bkgfunc[ipt]],
-                                                          self.sig_fmap[self.p_sgnfunc[ipt]]))
 
-                    if self.p_dolike:
-                        mass_fitter[ifit].SetUseLikelihoodFit()
+        canvas = TCanvas("c", "", 800, 800)
+        canvas.cd()
 
-                    mass_fitter[ifit].SetInitialGaussianMean(self.p_masspeak)
-                    mass_fitter[ifit].SetInitialGaussianSigma(self.p_sigmaarray[ipt])
-                    if self.p_fixedmean:
-                        mass_fitter[ifit].SetFixGaussianMean(mean_for_data[ipt])
-                    if self.p_fixedsigma:
-                        mass_fitter[ifit].SetFixGaussianSigma(sigma_for_data[ipt])
+        for h in histos:
+            h.Draw("same")
+        legend.Draw("same")
 
-                    mass_fitter[ifit].SetNSigma4SideBands(self.p_exclude_nsigma_sideband)
-                    mass_fitter[ifit].SetCheckSignalCountsAfterFirstFit(False)
+        save_path = join(self.nominal_analyzer_merged.d_resultsallpdata, self.syst_out_dir,
+                         f"ml_wp_syst_{name}_ibin2_{ibin2}.eps")
+        canvas.SaveAs(save_path)
+        canvas.Close()
 
-                    #Reflections to be included
-                    if self.p_include_reflection:
-                        self.logger.info("Reflections not yet included in cut variation fitter!")
 
-                    if self.p_includesecpeaks[imult][ipt]:
-                        secpeakwidth = self.p_widthsecpeak * sigma_for_data[ipt]
-                        mass_fitter[ifit].IncludeSecondGausPeak(self.p_masssecpeak, \
-                                          self.p_fix_masssecpeaks[imult][ipt], \
-                                          secpeakwidth, \
-                                          self.p_fix_widthsecpeak)
-                    success = mass_fitter[ifit].MassFitter(False)
-
-                    canvas_data[imult].cd(ipt+1)
-                    if success != 1:
-                        mass_fitter[ifit].GetHistoClone().Draw()
-                        self.logger.error("Fit failed for suffix %s", suffix)
-                        ifit = ifit + 1
-                        continue
-                    # Now check for min significance and max chi2
-                    signif = Double()
-                    signif_err = Double()
-                    mass_fitter[ifit].Significance(3., signif, signif_err)
-                    red_chi2 = mass_fitter[ifit].GetReducedChiSquare()
-                    if (self.min_signif_fit >= 0. and signif < self.min_signif_fit) or \
-                            (self.max_red_chi2_fit >= 0. and red_chi2 > self.max_red_chi2_fit):
-                        mass_fitter[ifit].GetHistoClone().Draw()
-                        self.logger.error("Fit failed for suffix %s", suffix)
-                        ifit = ifit + 1
-                        continue
-
-                    mass_fitter[ifit].DrawHere(gPad, self.p_nsigma_signal)
-
-                    # Write fitters to file
-                    fit_root_dir = fileout.mkdir(suffix)
-                    fit_root_dir.WriteObject(mass_fitter[ifit], "fittercutvar")
-
-                    # In case of success == 2, no signal was found, in case of 0, fit failed
-                    rawYield = mass_fitter[ifit].GetRawYield()
-                    rawYieldErr = mass_fitter[ifit].GetRawYieldError()
-                    yieldshistos[imult].SetBinContent(ipt + 1, rawYield)
-                    yieldshistos[imult].SetBinError(ipt + 1, rawYieldErr)
-                    ifit = ifit + 1
-
-                suffix2 = "cutvar%d_%s%.2f_%.2f" % \
-                           (icv, self.v_var2_binning, self.lvar2_binmin[imult], \
-                           self.lvar2_binmax[imult])
-
-                canvas_data[imult].SaveAs(make_file_path(self.d_results_cv, "canvas_FinalData", \
-                                                         "eps", None, suffix2))
-                fileout.cd()
-                yieldshistos[imult].Write()
-
-            fileout.Close()
-            if icv > self.p_ncutvar:
-                icvmax = icvmax + 1
-
-        del mass_fitter[:]
-        # Reset to former mode
-        gROOT.SetBatch(tmp_is_root_batch)
-
-        # Conclude fitting with efficiencies
-        self.ml_cutvar_efficiency_after_fit()
-
-        self.done_fit = True
-
-    def ml_cutvar_efficiency_after_fit(self):
+    def __plot(self, successful):
+        """summary plots
         """
-        Cut Variation: Extract prompt and feeddown efficiencies
-
-        Similar as efficiency(self) in analyzer.py
-        """
-        load_root_style_simple()
-
-        lfileeff = TFile.Open(self.n_fileeff_cutvar, "READ")
-
-        ntrials = 2 * self.p_ncutvar + 1
-        for icv in range(ntrials):
-            fileout_name = make_file_path(self.d_results_cv, self.efficiency_filename, "root", \
-                                          None, [self.typean, str(icv)])
-            fileout = TFile(fileout_name, "RECREATE")
-
-            for imult in range(len(self.lvar2_binmin)):
-
-                stringbin2 = "_%d_%s_%.2f_%.2f" % (icv, self.v_var2_binning_gen, \
-                                                self.lvar2_binmin[imult], \
-                                                self.lvar2_binmax[imult])
-
-                h_gen_pr = lfileeff.Get("h_gen_pr" + stringbin2)
-                h_sel_pr = lfileeff.Get("h_sel_pr" + stringbin2)
-                h_sel_pr.Divide(h_sel_pr, h_gen_pr, 1.0, 1.0, "B")
-
-                h_gen_fd = lfileeff.Get("h_gen_fd" + stringbin2)
-                h_sel_fd = lfileeff.Get("h_sel_fd" + stringbin2)
-                h_sel_fd.Divide(h_sel_fd, h_gen_fd, 1.0, 1.0, "B")
-
-                fileout.cd()
-                h_sel_pr.SetName("eff_mult%d" % imult)
-                h_sel_fd.SetName("eff_fd_mult%d" % imult)
-                h_sel_pr.Write()
-                h_sel_fd.Write()
-
-            fileout.Close()
-
-    # pylint: disable=import-outside-toplevel
-    def cutvariation_makenormyields(self):
-        """
-        Cut Variation: Calculate cross section/corrected yield. NB: Not the full
-        normalisation/correction are applied, so results may differ from central
-
-        Similar as makenormyields(self) in analyzer.py
-        """
-        gROOT.SetBatch(True)
-        load_root_style_simple()
-        gROOT.LoadMacro("HFPtSpectrum.C")
-        from ROOT import HFPtSpectrum, HFPtSpectrum2
-
-        ntrials = 2 * self.p_ncutvar + 1
-        for icv in range(ntrials):
-
-            fileouteff = make_file_path(self.d_results_cv, self.efficiency_filename, \
-                                        "root", None, [self.typean, str(icv)])
-            yield_filename = make_file_path(self.d_results_cv, self.yields_filename, \
-                                            "root", None, [self.typean, str(icv)])
-
-            filecrossmb = ""
-            for imult in range(len(self.lvar2_binmin)):
-                bineff = -1
-                if self.p_bineff is None:
-                    bineff = imult
-                    self.logger.info("Using efficiency for each var2 bin")
-                else:
-                    bineff = self.p_bineff
-                    self.logger.info("Using efficiency always from bin = %f", bineff)
-
-                namehistoeffprompt = "eff_mult%d" % bineff
-                namehistoefffeed = "eff_fd_mult%d" % bineff
-                nameyield = "hyields%d" % imult
-                fileoutcrossmult = make_file_path(self.d_results_cv, self.cross_filename, \
-                                                  "root", None, [self.typean, "cutvar", str(icv), \
-                                                                 "mult", str(imult)])
-                norm = -1
-                norm = self.calculate_norm(self.f_evtnorm, self.triggerbit, \
-                             self.v_var2_binning_gen, self.lvar2_binmin[imult], \
-                             self.lvar2_binmax[imult], self.apply_weights)
-                self.logger.info("Not full normalisation is applied. " \
-                                 "Result may differ from central.")
-                #Keep it simple, don't apply full normalisation
-
-                #Keep it simple, don't correct HM with MB fprompt, but with HM mult-int
-                if self.p_fprompt_from_mb is None or imult == 0 or self.p_fd_method != 2:
-                    HFPtSpectrum(self.p_indexhpt, self.p_inputfonllpred, \
-                     fileouteff, namehistoeffprompt, namehistoefffeed, yield_filename, nameyield, \
-                     fileoutcrossmult, norm, self.p_sigmav0 * 1e12, self.p_fd_method, self.p_cctype)
-                    filecrossmb = fileoutcrossmult
-                else:
-                    self.logger.info("Calculating spectra using fPrompt from mult-int.\n  "\
-                                         "Assuming mult-int is bin 0:   \n%s", filecrossmb)
-                    self.logger.info("HM mult classes take fprompt from HM mult-integrated.\n  " \
-                                     "Result may differ from central where MB mult-int is taken.")
-                    HFPtSpectrum2(filecrossmb, self.p_triggereff[imult], \
-                                  self.p_triggereffunc[imult], fileouteff, \
-                                  namehistoeffprompt, namehistoefffeed, \
-                                  yield_filename, nameyield, fileoutcrossmult, norm, \
-                                  self.p_sigmav0 * 1e12)
-
-            fileoutcrosstot = TFile.Open(make_file_path(self.d_results_cv, self.cross_filename, \
-                                                        "root", None, [self.typean, "cutvar", \
-                                                        str(icv), "multtot"]), "recreate")
-
-            for imult in range(len(self.lvar2_binmin)):
-                fileoutcrossmult = make_file_path(self.d_results_cv, self.cross_filename, \
-                                                  "root", None, [self.typean, "cutvar", str(icv), \
-                                                                 "mult", str(imult)])
-                f_fileoutcrossmult = TFile.Open(fileoutcrossmult)
-                if not f_fileoutcrossmult:
-                    continue
-                hcross = f_fileoutcrossmult.Get("histoSigmaCorr")
-                hcross.SetName("histoSigmaCorr%d" % imult)
-                fileoutcrosstot.cd()
-                hcross.Write()
-                f_fileoutcrossmult.Close()
-            fileoutcrosstot.Close()
-
-
-    def ml_cutvar_makeplots(self, plotname):
-        """
-        Cut Variation: Make final plots.
-        For the moment, value should be assigned by analyser
-        """
-
-        local_min_cv_cut, local_max_cv_cut = (self.min_cv_cut, self.max_cv_cut) \
-                if self.done_mass or self.done_eff or self.done_fit else (None, None)
 
         load_root_style()
 
-        leg = TLegend(.15, .65, .85, .85)
-        leg.SetBorderSize(0)
-        leg.SetFillColor(0)
-        leg.SetFillStyle(0)
-        leg.SetTextFont(42)
-        leg.SetTextSize(0.024)
-        leg.SetNColumns(4)
-        colours = [kBlack, kRed, kGreen+2, kBlue, kOrange+2, kViolet-1, \
-                   kAzure+1, kOrange-7, kViolet+2, kYellow-3]
-
-        ntrials = 2 * self.p_ncutvar + 1
-        for imult in range(len(self.lvar2_binmin)):
-
-            canv = TCanvas("%s%d" % (plotname, imult), '', 400, 400)
-
-            diffratio = 2 * self.p_maxperccutvar
-            if plotname == "histoSigmaCorr":
-                diffratio = self.p_maxperccutvar + 0.15
-            ptmax = self.lpt_finbinmax[-1] + 1
-            canv.cd(1).DrawFrame(0, 1 - diffratio, ptmax, 1 + diffratio, \
-                                 "%s %.2f < %s < %.2f;#it{p}_{T} (GeV/#it{c});Ratio %s" % \
-                                 (self.typean, self.lvar2_binmin[imult], self.v_var2_binning, \
-                                  self.lvar2_binmax[imult], plotname))
-
-            fileoutcrossmultref = make_file_path(self.d_results_cv, self.cross_filename, \
-                                                 "root", None, [self.typean, "cutvar", \
-                                                                str(self.p_ncutvar), \
-                                                                "mult", str(imult)])
-
-            f_fileoutcrossmultref = TFile.Open(fileoutcrossmultref)
-            href = f_fileoutcrossmultref.Get(plotname)
-            imk = 0
-            icol = 0
-            legname = "looser"
-            hcutvar = []
-
-            markers = [20, 21, 22, 23]
-            for icv in range(ntrials):
-                if icv == self.p_ncutvar:
-                    markers = [markers[i] + 4 for i in range(len(markers))]
-                    imk = 0
-                    legname = "tighter"
-                    continue
-                if icol == len(colours) - 1:
-                    imk = imk + 1
-                fileoutcrossmult = make_file_path(self.d_results_cv, self.cross_filename, \
-                                                  "root", None, [self.typean, "cutvar", str(icv), \
-                                                                 "mult", str(imult)])
-                f_fileoutcrossmult = TFile.Open(fileoutcrossmult)
-                hcutvar.append(f_fileoutcrossmult.Get(plotname))
-                hcutvar[icol].SetDirectory(0)
-                hcutvar[icol].SetLineColor(colours[icol % len(colours)])
-                hcutvar[icol].SetMarkerColor(colours[icol % len(colours)])
-                hcutvar[icol].SetMarkerStyle(markers[imk])
-                hcutvar[icol].SetMarkerSize(0.8)
-                hcutvar[icol].Divide(href)
-                hcutvar[icol].Draw("same")
-                if imult == 0:
-                    leg.AddEntry(hcutvar[icol], "Set %d (%s)" % (icv, legname), "LEP")
-                icol = icol + 1
-                f_fileoutcrossmult.Close()
-            leg.Draw()
-            canv.SaveAs("%s/Cutvar_%s_mult%d.eps" % (self.d_results_cv, plotname, imult))
-            f_fileoutcrossmultref.Close()
-
-        if plotname == "histoSigmaCorr":
-            if self.p_nptfinbins < 9:
-                nx = 4
-                ny = 2
-                canvy = 533
-            elif self.p_nptfinbins < 13:
-                nx = 4
-                ny = 3
-                canvy = 800
-            else:
-                nx = 5
-                ny = 4
-                canvy = 1200
-
-            canv = [TCanvas("canvas_corryieldvspt%d_%d" % (icv, imult), "Data", \
-                             1000, canvy) for imult in range(len(self.lvar2_binmin))]
-            arrhistos = [None for ipt in range(self.p_nptfinbins)]
-            for imult in range(len(self.lvar2_binmin)):
-                for ipt in range(self.p_nptfinbins):
-                    arrhistos[ipt] = TH1F("hcorryieldvscut%d%d" % (imult, ipt), \
-                                          "%d < #it{p}_{T} < %d;cut set;Corr. Yield" % \
-                                          (self.lpt_finbinmin[ipt], self.lpt_finbinmax[ipt]),
-                                          ntrials, -0.5, ntrials - 0.5)
-                    arrhistos[ipt].SetDirectory(0)
-
-                for icv in range(ntrials):
-                    fileoutcrossmult = make_file_path(self.d_results_cv, \
-                                                      self.cross_filename, "root", None, \
-                                                      [self.typean, "cutvar", str(icv), \
-                                                       "mult", str(imult)])
-                    f_fileoutcrossmult = TFile.Open(fileoutcrossmult)
-                    hcutvar2 = f_fileoutcrossmult.Get(plotname)
-                    for ipt in range(self.p_nptfinbins):
-                        arrhistos[ipt].SetBinContent(icv + 1, hcutvar2.GetBinContent(ipt + 1))
-                        arrhistos[ipt].SetBinError(icv + 1, hcutvar2.GetBinError(ipt + 1))
-                    f_fileoutcrossmult.Close()
-
-                canv[imult].Divide(nx, ny)
-                for ipt in range(self.p_nptfinbins):
-                    canv[imult].cd(ipt + 1)
-                    arrhistos[ipt].SetLineColor(colours[ipt])
-                    arrhistos[ipt].SetMarkerColor(colours[ipt])
-                    arrhistos[ipt].Draw("ep")
-                canv[imult].SaveAs("%s/Cutvar_CorrYieldvsSet_mult%d.eps" % (self.d_results_cv, \
-                                                                            imult))
-
-            if local_min_cv_cut is not None and local_max_cv_cut is not None:
-
-                probcuts = [None for ipt in range(self.p_nptfinbins)]
-                probarr = [None for icv in range(2 + 2 * ntrials)]
-                for ipt in range(self.p_nptfinbins):
-                    bin_id = self.bin_matching[ipt]
-                    stepsmin = (self.lpt_probcutfin[bin_id] - local_min_cv_cut[ipt]) / \
-                            self.p_ncutvar
-                    stepsmax = (local_max_cv_cut[ipt] - self.lpt_probcutfin[bin_id]) / \
-                            self.p_ncutvar
-
-                    probarr[0] = 0
-                    icvmax = 1
-                    for icv in range(ntrials):
-                        if icv < self.p_ncutvar:
-                            probarr[2 * icv + 1] = local_min_cv_cut[ipt] + (icv - 0.1) * stepsmin
-                            probarr[2 * icv + 2] = local_min_cv_cut[ipt] + (icv + 0.1) * stepsmin
-                        elif icv == self.p_ncutvar:
-                            probarr[2 * icv + 1] = self.lpt_probcutfin[bin_id] - 0.1 * stepsmax
-                            probarr[2 * icv + 2] = self.lpt_probcutfin[bin_id] + 0.1 * stepsmax
-                        else:
-                            probarr[2 * icv + 1] = self.lpt_probcutfin[bin_id] + \
-                                                   (icvmax - 0.1) * stepsmax
-                            probarr[2 * icv + 2] = self.lpt_probcutfin[bin_id] + \
-                                                   (icvmax + 0.1) * stepsmax
-                            icvmax = icvmax + 1
-                    probarr[-1] = 1
-                    probcuts[ipt] = probarr[:]
-
-                canv2 = [TCanvas("canvas_corryieldvsprob%d_%d" % (icv, imult), "Data", \
-                                 1000, canvy) for imult in range(len(self.lvar2_binmin))]
-                arrhistos2 = [None for ipt in range(self.p_nptfinbins)]
-                for imult in range(len(self.lvar2_binmin)):
-                    for ipt in range(self.p_nptfinbins):
-                        arrhistos2[ipt] = TH1F("hcorryieldvsprob%d%d" % (imult, ipt), \
-                                              "%d < #it{p}_{T} < %d;Probability;Corr. Yield" % \
-                                              (self.lpt_finbinmin[ipt], self.lpt_finbinmax[ipt]), \
-                                               len(probcuts[ipt]) - 1, array('f', probcuts[ipt]))
-                        arrhistos2[ipt].SetDirectory(0)
-
-                    icvmax = 1
-                    for icv in range(ntrials):
-                        fileoutcrossmult = make_file_path(self.d_results_cv, \
-                                                          self.cross_filename, "root", None, \
-                                                          [self.typean, "cutvar", str(icv), \
-                                                           "mult", str(imult)])
-                        f_fileoutcrossmult = TFile.Open(fileoutcrossmult)
-                        hcutvar2 = f_fileoutcrossmult.Get(plotname)
-
-                        for ipt in range(self.p_nptfinbins):
-                            bin_id = self.bin_matching[ipt]
-                            stepsmin = (self.lpt_probcutfin[bin_id] - local_min_cv_cut[ipt]) / \
-                                       self.p_ncutvar
-                            stepsmax = (local_max_cv_cut[ipt] - self.lpt_probcutfin[bin_id]) / \
-                                       self.p_ncutvar
-                            selml_cvval = 0
-                            if icv < self.p_ncutvar:
-                                selml_cvval = local_min_cv_cut[ipt] + icv * stepsmin
-                            elif icv == self.p_ncutvar:
-                                selml_cvval = self.lpt_probcutfin[bin_id]
-                            else:
-                                selml_cvval = self.lpt_probcutfin[bin_id] + icvmax * stepsmax
-                            ibin = arrhistos2[ipt].FindBin(selml_cvval)
-                            arrhistos2[ipt].SetBinContent(ibin, hcutvar2.GetBinContent(ipt + 1))
-                            arrhistos2[ipt].SetBinError(ibin, hcutvar2.GetBinError(ipt + 1))
-                        if icv > self.p_ncutvar:
-                            icvmax = icvmax + 1
-                        f_fileoutcrossmult.Close()
-
-                    canv2[imult].Divide(nx, ny)
-                    for ipt in range(self.p_nptfinbins):
-                        canv2[imult].cd(ipt + 1)
-                        arrhistos2[ipt].SetLineColor(colours[ipt])
-                        arrhistos2[ipt].SetLineWidth(1)
-                        arrhistos2[ipt].SetMarkerColor(colours[ipt])
-                        arrhistos2[ipt].Draw("ep")
-                    canv2[imult].SaveAs("%s/Cutvar_CorrYieldvsProb_mult%d.eps" % \
-                                        (self.d_results_cv, imult))
-
-
-    def ml_cutvar_cross(self):
-
-        # Make normalized yields first
-        self.cutvariation_makenormyields()
-        # Then plot for each of these
         for name in ["histoSigmaCorr", "hDirectEffpt", "hFeedDownEffpt", "hRECpt"]:
-            self.ml_cutvar_makeplots(name)
+            for ibin2 in range(self.nominal_analyzer_merged.p_nbin2):
+                self.__make_single_plot(name, ibin2, successful)
 
 
-    def load_central_meansigma(self, imult):
+    def ml_systematics(self):
+        """central method to call for ML WP systematics
         """
-        Cut Variation: Get parameters (mean and sigma) from central fit
-        """
-        func_filename_std = make_file_path(self.d_results, self.yields_filename_std, \
-                                           "root", None, [self.case, self.typean])
 
-        massfile_std = TFile.Open(func_filename_std, "READ")
-        means_histo = massfile_std.Get("hmeanss%d" % (imult))
-        sigmas_histo = massfile_std.Get("hsigmas%d" % (imult))
-
-        mean_for_data = []
-        sigma_for_data = []
-        for ipt in range(self.p_nptfinbins):
-
-            mean_for_data.append(means_histo.GetBinContent(ipt + 1))
-            sigma_for_data.append(sigmas_histo.GetBinContent(ipt + 1))
-
-        massfile_std.Close()
-        return mean_for_data, sigma_for_data
-
-
-    def mcptshape_get_generated(self):
-        """
-        MC pT-shape: Get generated pT spectra from MC to define weights
-        """
-        fileout_name = make_file_path(self.d_results, self.ptspectra_filename, \
-                                      "root", None, [self.typean, self.case])
-        myfile = TFile(fileout_name, "RECREATE")
-
-        for ibin2 in range(len(self.lvar2_binmin)):
-            stringbin2 = "_%s_%.2f_%.2f" % (self.v_var2_binning_gen, \
-                                        self.lvar2_binmin[ibin2], \
-                                        self.lvar2_binmax[ibin2])
-
-            h_gen_pr = TH1F("h_gen_pr" + stringbin2, "Prompt Generated in acceptance |y|<0.5", \
-                            400, 0, 40)
-            h_gen_fd = TH1F("h_gen_fd" + stringbin2, "FD Generated in acceptance |y|<0.5", \
-                            400, 0, 40)
-
-            for ipt in range(self.p_nptfinbins):
-                bin_id = self.bin_matching[ipt]
-
-                df_mc_gen = pickle.load(openfile(self.lpt_gendecmerged[bin_id], "rb"))
-                df_mc_gen = df_mc_gen.query("abs(y_cand) < 0.5")
-
-                df_mc_gen = seldf_singlevar(df_mc_gen, self.v_var_binning, \
-                                     self.lpt_finbinmin[ipt], self.lpt_finbinmax[ipt])
-                df_mc_gen = seldf_singlevar(df_mc_gen, self.v_var2_binning_gen, \
-                                            self.lvar2_binmin[ibin2], self.lvar2_binmax[ibin2])
-
-                df_gen_sel_pr = df_mc_gen[df_mc_gen.ismcprompt == 1]
-                df_gen_sel_fd = df_mc_gen[df_mc_gen.ismcfd == 1]
-
-                fill_hist(h_gen_pr, df_gen_sel_pr.pt_cand)
-                fill_hist(h_gen_fd, df_gen_sel_fd.pt_cand)
-            myfile.cd()
-            h_gen_pr.Write()
-            h_gen_fd.Write()
-        myfile.Close()
-
-
-    def mcptshape_build_efficiencies(self):
-        """
-        MC pT-shape: Create ROOT file with unweighted and weighted efficiencies
-        Histogram for (un)weighted, for each 2nd binning bin
-
-        Similar as process_efficiency_single(self, index) in processor.py
-        """
-        myfile = TFile.Open(self.n_fileeff_ptshape, "recreate")
-
-        print("Using run selection for eff histo for period", self.p_period)
-        for ibin2 in range(len(self.lvar2_binmin)):
-            stringbin2 = "_%s_%.2f_%.2f" % (self.v_var2_binning_gen, \
-                                        self.lvar2_binmin[ibin2], \
-                                        self.lvar2_binmax[ibin2])
-
-            n_bins = len(self.lpt_finbinmin)
-            analysis_bin_lims_temp = self.lpt_finbinmin.copy()
-            analysis_bin_lims_temp.append(self.lpt_finbinmax[n_bins-1])
-            analysis_bin_lims = array('f', analysis_bin_lims_temp)
-
-            h_gen_pr = TH1F("h_gen_pr" + stringbin2, \
-                            "Prompt Generated in acceptance |y|<0.5", \
-                            n_bins, analysis_bin_lims)
-            h_presel_pr = TH1F("h_presel_pr" + stringbin2, \
-                               "Prompt Reco in acc |#eta|<0.8 and sel", \
-                               n_bins, analysis_bin_lims)
-            h_sel_pr = TH1F("h_sel_pr" + stringbin2, \
-                            "Prompt Reco and sel in acc |#eta|<0.8 and sel", \
-                            n_bins, analysis_bin_lims)
-            h_gen_fd = TH1F("h_gen_fd" + stringbin2, \
-                            "FD Generated in acceptance |y|<0.5", \
-                            n_bins, analysis_bin_lims)
-            h_presel_fd = TH1F("h_presel_fd" + stringbin2, \
-                               "FD Reco in acc |#eta|<0.8 and sel", \
-                               n_bins, analysis_bin_lims)
-            h_sel_fd = TH1F("h_sel_fd" + stringbin2, \
-                            "FD Reco and sel in acc |#eta|<0.8 and sel", \
-                            n_bins, analysis_bin_lims)
-
-            bincounter = 0
-            for ipt in range(self.p_nptfinbins):
-                bin_id = self.bin_matching[ipt]
-                selml = "y_test_prob%s>%s" % (self.p_modelname, self.lpt_probcutfin[bin_id])
-
-                df_mc_reco = pickle.load(openfile(self.lpt_recodecmerged_mc[bin_id], "rb"))
-                if self.s_evtsel is not None:
-                    df_mc_reco = df_mc_reco.query(self.s_evtsel)
-                if self.s_trigger_mc is not None:
-                    df_mc_reco = df_mc_reco.query(self.s_trigger_mc)
-
-                df_mc_gen = pickle.load(openfile(self.lpt_gendecmerged[bin_id], "rb"))
-                df_mc_gen = df_mc_gen.query(self.s_presel_gen_eff)
-
-                df_mc_reco = seldf_singlevar(df_mc_reco, self.v_var_binning, \
-                                     self.lpt_finbinmin[ipt], self.lpt_finbinmax[ipt])
-                df_mc_gen = seldf_singlevar(df_mc_gen, self.v_var_binning, \
-                                     self.lpt_finbinmin[ipt], self.lpt_finbinmax[ipt])
-
-                df_mc_reco = seldf_singlevar(df_mc_reco, self.v_var2_binning_gen, \
-                                             self.lvar2_binmin[ibin2], self.lvar2_binmax[ibin2])
-                df_mc_gen = seldf_singlevar(df_mc_gen, self.v_var2_binning_gen, \
-                                            self.lvar2_binmin[ibin2], self.lvar2_binmax[ibin2])
-
-                df_gen_sel_pr = df_mc_gen[df_mc_gen.ismcprompt == 1]
-                df_reco_presel_pr = df_mc_reco[df_mc_reco.ismcprompt == 1]
-                df_reco_sel_pr = None
-                df_reco_sel_pr = df_reco_presel_pr.query(selml)
-
-                df_gen_sel_fd = df_mc_gen[df_mc_gen.ismcfd == 1]
-                df_reco_presel_fd = df_mc_reco[df_mc_reco.ismcfd == 1]
-                df_reco_sel_fd = None
-                df_reco_sel_fd = df_reco_presel_fd.query(selml)
-
-                val = len(df_gen_sel_pr)
-                err = math.sqrt(val)
-                h_gen_pr.SetBinContent(bincounter + 1, val)
-                h_gen_pr.SetBinError(bincounter + 1, err)
-                val = len(df_reco_presel_pr)
-                err = math.sqrt(val)
-                h_presel_pr.SetBinContent(bincounter + 1, val)
-                h_presel_pr.SetBinError(bincounter + 1, err)
-                val = len(df_reco_sel_pr)
-                err = math.sqrt(val)
-                h_sel_pr.SetBinContent(bincounter + 1, val)
-                h_sel_pr.SetBinError(bincounter + 1, err)
-
-                val = len(df_gen_sel_fd)
-                err = math.sqrt(val)
-                h_gen_fd.SetBinContent(bincounter + 1, val)
-                h_gen_fd.SetBinError(bincounter + 1, err)
-                val = len(df_reco_presel_fd)
-                err = math.sqrt(val)
-                h_presel_fd.SetBinContent(bincounter + 1, val)
-                h_presel_fd.SetBinError(bincounter + 1, err)
-                val = len(df_reco_sel_fd)
-                err = math.sqrt(val)
-                h_sel_fd.SetBinContent(bincounter + 1, val)
-                h_sel_fd.SetBinError(bincounter + 1, err)
-
-                bincounter = bincounter + 1
-
-            hw_gen_pr = TH1F("h_gen_pr_weight" + stringbin2, "Prompt Generated in acc |y|<0.5", \
-                             n_bins, analysis_bin_lims)
-            hw_presel_pr = TH1F("h_presel_pr_weight" + stringbin2, \
-                                "Prompt Reco in acc |#eta|<0.8 and sel", \
-                                 n_bins, analysis_bin_lims)
-            hw_sel_pr = TH1F("h_sel_pr_weight" + stringbin2, \
-                             "Prompt Reco and sel in acc |#eta|<0.8 and sel", \
-                             n_bins, analysis_bin_lims)
-            hw_gen_fd = TH1F("h_gen_fd_weight" + stringbin2, "FD Generated in acc |y|<0.5", \
-                             n_bins, analysis_bin_lims)
-            hw_presel_fd = TH1F("h_presel_fd_weight" + stringbin2, \
-                                "FD Reco in acc |#eta|<0.8 and sel", \
-                                n_bins, analysis_bin_lims)
-            hw_sel_fd = TH1F("h_sel_fd_weight" + stringbin2, \
-                             "FD Reco and sel in acc |#eta|<0.8 and sel", \
-                             n_bins, analysis_bin_lims)
-
-            bincounter = 0
-            for ipt in range(self.p_nptfinbins):
-                bin_id = self.bin_matching[ipt]
-                selml = "y_test_prob%s>%s" % (self.p_modelname, self.lpt_probcutfin[bin_id])
-
-                df_mc_reco = pickle.load(openfile(self.lpt_recodecmerged_mc[bin_id], "rb"))
-                if self.s_evtsel is not None:
-                    df_mc_reco = df_mc_reco.query(self.s_evtsel)
-                if self.s_trigger_mc is not None:
-                    df_mc_reco = df_mc_reco.query(self.s_trigger_mc)
-
-                df_mc_gen = pickle.load(openfile(self.lpt_gendecmerged[bin_id], "rb"))
-                df_mc_gen = df_mc_gen.query(self.s_presel_gen_eff)
-
-                df_mc_reco = seldf_singlevar(df_mc_reco, self.v_var_binning, \
-                                     self.lpt_finbinmin[ipt], self.lpt_finbinmax[ipt])
-                df_mc_gen = seldf_singlevar(df_mc_gen, self.v_var_binning, \
-                                     self.lpt_finbinmin[ipt], self.lpt_finbinmax[ipt])
-
-                df_mc_reco = seldf_singlevar(df_mc_reco, self.v_var2_binning_gen, \
-                                             self.lvar2_binmin[ibin2], self.lvar2_binmax[ibin2])
-                df_mc_gen = seldf_singlevar(df_mc_gen, self.v_var2_binning_gen, \
-                                            self.lvar2_binmin[ibin2], self.lvar2_binmax[ibin2])
-
-                df_gen_sel_pr = df_mc_gen[df_mc_gen.ismcprompt == 1]
-                df_reco_presel_pr = df_mc_reco[df_mc_reco.ismcprompt == 1]
-                df_reco_sel_pr = None
-                df_reco_sel_pr = df_reco_presel_pr.query(selml)
-
-                df_gen_sel_fd = df_mc_gen[df_mc_gen.ismcfd == 1]
-                df_reco_presel_fd = df_mc_reco[df_mc_reco.ismcfd == 1]
-                df_reco_sel_fd = None
-                df_reco_sel_fd = df_reco_presel_fd.query(selml)
-
-                array_pt_gencand_gen = df_gen_sel_pr.pt_cand.values
-                array_pt_recocand_reco_presel = df_reco_presel_pr.pt_cand.values
-                array_pt_recocand_reco_sel = df_reco_sel_pr.pt_cand.values
-
-                val, err = self.get_reweighted_count(array_pt_gencand_gen)
-                hw_gen_pr.SetBinContent(bincounter + 1, val)
-                hw_gen_pr.SetBinError(bincounter + 1, err)
-                val, err = self.get_reweighted_count(array_pt_recocand_reco_presel)
-                hw_presel_pr.SetBinContent(bincounter + 1, val)
-                hw_presel_pr.SetBinError(bincounter + 1, err)
-                val, err = self.get_reweighted_count(array_pt_recocand_reco_sel)
-                hw_sel_pr.SetBinContent(bincounter + 1, val)
-                hw_sel_pr.SetBinError(bincounter + 1, err)
-
-                array_pt_gencand_genfd = df_gen_sel_fd.pt_cand.values
-                array_pt_recocand_reco_preselfd = df_reco_presel_fd.pt_cand.values
-                array_pt_recocand_reco_selfd = df_reco_sel_fd.pt_cand.values
-
-                val, err = self.get_reweighted_count(array_pt_gencand_genfd)
-                hw_gen_fd.SetBinContent(bincounter + 1, val)
-                hw_gen_fd.SetBinError(bincounter + 1, err)
-                val, err = self.get_reweighted_count(array_pt_recocand_reco_preselfd)
-                hw_presel_fd.SetBinContent(bincounter + 1, val)
-                hw_presel_fd.SetBinError(bincounter + 1, err)
-                val, err = self.get_reweighted_count(array_pt_recocand_reco_selfd)
-                hw_sel_fd.SetBinContent(bincounter + 1, val)
-                hw_sel_fd.SetBinError(bincounter + 1, err)
-
-                bincounter = bincounter + 1
-
-            myfile.cd()
-            h_gen_pr.Write()
-            h_presel_pr.Write()
-            h_sel_pr.Write()
-            h_gen_fd.Write()
-            h_presel_fd.Write()
-            h_sel_fd.Write()
-            hw_gen_pr.Write()
-            hw_presel_pr.Write()
-            hw_sel_pr.Write()
-            hw_gen_fd.Write()
-            hw_presel_fd.Write()
-            hw_sel_fd.Write()
-        myfile.Close()
-
-    def mcptshape_efficiency(self):
-        """
-        MC pT-shape: Extract prompt and feeddown efficiencies
-        Systematic = difference wrt 1 for ratio unweighted / weighted
-        """
-        load_root_style_simple()
-
-        lfileeff = TFile.Open(self.n_fileeff_ptshape, "READ")
-
-        fileout_name = make_file_path(self.d_results, self.efficiency_filename_pt, \
-                                      "root", None, [self.typean, self.case])
-        fileout = TFile(fileout_name, "RECREATE")
-
-        for imult in range(len(self.lvar2_binmin)):
-
-            stringbin2 = "_%s_%.2f_%.2f" % (self.v_var2_binning_gen, \
-                                           self.lvar2_binmin[imult], \
-                                           self.lvar2_binmax[imult])
-
-            h_gen_pr = lfileeff.Get("h_gen_pr" + stringbin2)
-            h_sel_pr = lfileeff.Get("h_sel_pr" + stringbin2)
-            h_sel_pr.Divide(h_sel_pr, h_gen_pr, 1.0, 1.0, "B")
-
-            h_gen_fd = lfileeff.Get("h_gen_fd" + stringbin2)
-            h_sel_fd = lfileeff.Get("h_sel_fd" + stringbin2)
-            h_sel_fd.Divide(h_sel_fd, h_gen_fd, 1.0, 1.0, "B")
-
-            hw_gen_pr = lfileeff.Get("h_gen_pr_weight" + stringbin2)
-            hw_sel_pr = lfileeff.Get("h_sel_pr_weight" + stringbin2)
-            hw_sel_pr.Divide(hw_sel_pr, hw_gen_pr, 1.0, 1.0, "B")
-
-            hw_gen_fd = lfileeff.Get("h_gen_fd_weight" + stringbin2)
-            hw_sel_fd = lfileeff.Get("h_sel_fd_weight" + stringbin2)
-            hw_sel_fd.Divide(hw_sel_fd, hw_gen_fd, 1.0, 1.0, "B")
-
-            fileout.cd()
-            h_sel_pr.SetName("eff_mult%d" % imult)
-            h_sel_fd.SetName("eff_fd_mult%d" % imult)
-            hw_sel_pr.SetName("eff_weight_mult%d" % imult)
-            hw_sel_fd.SetName("eff_weight_fd_mult%d" % imult)
-            h_sel_pr.Write()
-            h_sel_fd.Write()
-            hw_sel_pr.Write()
-            hw_sel_fd.Write()
-        fileout.Close()
-
-    def mcptshape_makeplots(self):
-        """
-        MC pT shape: Make final plots.
-        For the moment, value should be assigned by analyser
-        """
-        load_root_style()
-
-        leg = TLegend(.15, .65, .85, .85)
-        leg.SetBorderSize(0)
-        leg.SetFillColor(0)
-        leg.SetFillStyle(0)
-        leg.SetTextFont(42)
-        leg.SetTextSize(0.024)
-        colours = [kBlack, kRed]
-        markers = [20, 21]
-
-        fileout_name = make_file_path(self.d_results, self.efficiency_filename_pt, \
-                                      "root", None, [self.typean, self.case])
-
-        f_fileout = TFile.Open(fileout_name)
-
-        hweights = []
-        hnoweights = []
-        hfdweights = []
-        hfdnoweights = []
-        for imult in range(len(self.lvar2_binmin)):
-
-            canv = TCanvas("systmcptshape_%d" % imult, '', 400, 400)
-            plotname = "No weights / Weights"
-            ptmax = self.lpt_finbinmax[-1] + 1
-            canv.cd(1).DrawFrame(0, 0.85, ptmax, 1.15, \
-                                 "%s %.2f < %s < %.2f;#it{p}_{T} (GeV/#it{c});Ratio %s" % \
-                                 (self.typean, self.lvar2_binmin[imult], self.v_var2_binning, \
-                                  self.lvar2_binmax[imult], plotname))
-
-            hweights.append(f_fileout.Get("eff_weight_mult%d" % imult))
-            hweights[imult].SetDirectory(0)
-            hnoweights.append(f_fileout.Get("eff_mult%d" % imult))
-            hnoweights[imult].SetDirectory(0)
-            hfdweights.append(f_fileout.Get("eff_weight_fd_mult%d" % imult))
-            hfdweights[imult].SetDirectory(0)
-            hfdnoweights.append(f_fileout.Get("eff_fd_mult%d" % imult))
-            hfdnoweights[imult].SetDirectory(0)
-
-            hnoweights[imult].Divide(hnoweights[imult], hweights[imult], 1.0, 1.0, "B")
-            hfdnoweights[imult].Divide(hfdnoweights[imult], hfdweights[imult], 1.0, 1.0, "B")
-
-            hnoweights[imult].SetLineColor(colours[0])
-            hnoweights[imult].SetMarkerColor(colours[0])
-            hnoweights[imult].SetMarkerStyle(markers[0])
-            hnoweights[imult].SetMarkerSize(0.8)
-            hnoweights[imult].Draw("same")
-
-            hfdnoweights[imult].SetLineColor(colours[1])
-            hfdnoweights[imult].SetMarkerColor(colours[1])
-            hfdnoweights[imult].SetMarkerStyle(markers[1])
-            hfdnoweights[imult].SetMarkerSize(0.8)
-            hfdnoweights[imult].Draw("same")
-
-            if imult == 0:
-                leg.AddEntry(hnoweights[imult], "Prompt", "LEP")
-                leg.AddEntry(hfdnoweights[imult], "Feed-down", "LEP")
-
-            leg.Draw()
-            canv.SaveAs("%s/MCpTshape_Syst_mult%d.eps" % (self.d_results, imult))
-        f_fileout.Close()
-
-
-    def mcptshape(self):
-
-        # Do only per period
-        if self.period is not None:
-            self.mcptshape_get_generated()
-            self.mcptshape_build_efficiencies()
-
-        # Do for all
-        self.mcptshape_efficiency()
-        self.mcptshape_makeplots()
-
-
-    def get_reweighted_count(self, arraypt):
-        """
-        MC pT-shape: Reweight array of pTs from dataframe based on pT weights
-        """
-        weights = arraypt.copy()
-        binwidth = (self.p_weights_max_pt - self.p_weights_min_pt)/self.p_weights_bins
-        for j in range(weights.shape[0]):
-            pt = arraypt[j]
-            if pt - self.p_weights_min_pt < 0:
-                self.logger.warning("pT_gen < minimum pT of weights!")
-            ptbin_weights = int((pt - self.p_weights_min_pt)/binwidth)
-            #improvement: make linear extrapolation with bins next to it
-            weights[j] = self.p_weights[ptbin_weights]
-        val = sum(weights)
-        err = math.sqrt(val)
-        return val, err
-
-    def calculate_norm(self, filename, trigger, var, multmin, multmax, doweight):
-        """
-        General: Calculates number of events used to normalise
-        NB: Uncorrected for simplicity as systematic variations, see
-        calculate_norm in analyzer.py for full function
-        """
-        fileout = TFile.Open(filename, "read")
-        if not fileout:
-            return -1
-        namehistomulti = None
-        if doweight is True:
-            namehistomulti = "hmultweighted%svs%s" % (trigger, var)
-        else:
-            namehistomulti = "hmult%svs%s" % (trigger, var)
-        hmult = fileout.Get(namehistomulti)
-        if not hmult:
-            self.logger.fatal("MISSING NORMALIZATION MULTIPLICITY")
-        binminv = hmult.GetXaxis().FindBin(multmin)
-        binmaxv = hmult.GetXaxis().FindBin(multmax)
-        norm = hmult.Integral(binminv, binmaxv)
-        fileout.Close()
-        return norm
+        self.processers_mc_syst = [None] * self.n_trials
+        self.processers_data_syst = [None] * self.n_trials
+        self.analyzers_syst = [None] * self.n_trials
+
+        # Define limits first
+        self.__define_cutvariation_limits()
+        self.__make_working_points()
+        # Obtain nominal means and sigmas
+        self.__read_nominal_fit_values()
+
+        # Shuffle --> Doing some larger and smaller variations in case of keyboard interrupt
+        shuffled = list(range(self.n_trials))
+        shuffle(shuffled)
+
+        successful = []
+
+        try:
+            for i in shuffled:
+                self.__prepare_trial(i)
+                self.__ml_cutvar_mass(i)
+                self.__ml_cutvar_eff(i)
+                self.__ml_cutvar_ana(i)
+                successful.append(i)
+        except KeyboardInterrupt:
+            pass
+
+        self.__plot(successful)

--- a/machine_learning_hep/analysis/systematics.py
+++ b/machine_learning_hep/analysis/systematics.py
@@ -553,6 +553,7 @@ class SystematicsMLWP: # pylint: disable=too-few-public-methods, too-many-instan
         if resume:
             for s in shuffled:
                 successful.append(s)
+                self.__prepare_trial(s)
                 self.__add_trial_to_save(s)
             shuffled = [i for i in range(self.n_trials) if i not in shuffled]
 

--- a/machine_learning_hep/analysis/systematics.py
+++ b/machine_learning_hep/analysis/systematics.py
@@ -94,7 +94,7 @@ class Systematics: # pylint: disable=too-few-public-methods
 
     def __read_nominal_fit_values(self):
 
-        if Systematics.NOMINAL_MEANS is not None:
+        if Systematics.NOMINAL_MEANS:
             return
 
         fitter = MLFitter(self.nominal_analyzer_merged.case,
@@ -115,8 +115,8 @@ class Systematics: # pylint: disable=too-few-public-methods
         for ibin1 in range(ana_n_first_binning):
             for ibin2 in range(ana_n_second_binning):
                 fit = fitter.get_central_fit(ibin1, ibin2)
-                Systematics.NOMINAL_MEANS[ibin2][ibin1] = fit.kernel.GetMean() # pylint: disable=unsubscriptable-object
-                Systematics.NOMINAL_SIGMAS[ibin2][ibin1] = fit.kernel.GetSigma() # pylint: disable=unsubscriptable-object
+                Systematics.NOMINAL_MEANS[ibin2][ibin1] = fit.kernel.GetMean()
+                Systematics.NOMINAL_SIGMAS[ibin2][ibin1] = fit.kernel.GetSigma()
 
 
     def __define_cutvariation_limits(self):
@@ -133,7 +133,7 @@ class Systematics: # pylint: disable=too-few-public-methods
         """
 
         # Only do this once for all
-        if Systematics.CENT_CV_CUT is not None:
+        if Systematics.CENT_CV_CUT:
             return
 
         # use multiprocesser here, prepare database

--- a/machine_learning_hep/data/data_prod_20200304/database_ml_parameters_LcpK0spp_0304.yml
+++ b/machine_learning_hep/data/data_prod_20200304/database_ml_parameters_LcpK0spp_0304.yml
@@ -549,7 +549,7 @@ LcpK0spp:
       mc_cut_on_binning2: False
       nbinshisto: 100000
       minvaluehisto: -0.0005
-      maxvaluehisto: 99.9995
+      maxvaluehisto: 100.0005
       triggerbit: INT7
 
       sel_an_binmin: [1,2,4,6,8,12] #list of pt nbins

--- a/machine_learning_hep/data/data_prod_20200304/database_ml_parameters_LcpK0spp_0304.yml
+++ b/machine_learning_hep/data/data_prod_20200304/database_ml_parameters_LcpK0spp_0304.yml
@@ -404,7 +404,7 @@ LcpK0spp:
       FixedMean: false
       SetFixGaussianSigma: [true,true,true,true,true,true]
       # Use value set for "masspeak" for initializing total fit, otherwise what is derived from MC fit is used
-      SetInitialGaussianMean: true
+      SetInitialGaussianMean: false
       # Use values set for "sigmaarray" for initializing total fit (per pT bin),
       # otherwise what is derived from MC fit is used
       SetInitialGaussianSigma: [true, true, true, true, true, true]
@@ -594,7 +594,7 @@ LcpK0spp:
         data: "trigger_hasbit_INT7==1"
         mc: null
       data:
-        runselection: [MBvspt_perc_v0m_2016, null, null]
+        runselection: [null, null, null]
         results: [/data/DerivedResults/LckAnywithJets/vAN-20200824_ROOT6-1/pp_2016_data/490_20200825-1716/resultsMBvspt_perc_v0m,
                   /data/DerivedResults/LckAnywithJets/vAN-20200824_ROOT6-1/pp_2017_data/489_20200825-1716/resultsMBvspt_perc_v0m,
                   /data/DerivedResults/LckAnywithJets/vAN-20200824_ROOT6-1/pp_2018_data/488_20200825-1716/resultsMBvspt_perc_v0m] #list of periods
@@ -641,7 +641,7 @@ LcpK0spp:
       FixedMean: false
       SetFixGaussianSigma: [true,true,true,true,true,true]
       # Use value set for "masspeak" for initializing total fit, otherwise what is derived from MC fit is used
-      SetInitialGaussianMean: true
+      SetInitialGaussianMean: false
       # Use values set for "sigmaarray" for initializing total fit (per pT bin),
       # otherwise what is derived from MC fit is used
       SetInitialGaussianSigma: [false, false, false, false, false, false]
@@ -680,7 +680,7 @@ LcpK0spp:
       ncutvar: 10 #number of looser and tighter variations
       maxperccutvar: 0.25 #max diff in efficiency for loosest/tightest var
       cutvarminrange: [0.30, 0.30, 0.30, 0.30, 0.30, 0.30] #Min starting point for scan
-      cutvarmaxrange: [0.80, 0.80, 0.80, 0.80, 0.80, 0.80] #Max starting point for scan
+      cutvarmaxrange: [0.90, 0.90, 0.90, 0.90, 0.90, 0.90] #Max starting point for scan
       fixedmean: True #Fix mean cutvar histo to central fit
       fixedsigma: True #Fix sigma cutvar histo to central fit
       min_signif_fit: 3.

--- a/machine_learning_hep/data/data_prod_20200304/database_ml_parameters_LcpK0spp_0304_HM_V0.yml
+++ b/machine_learning_hep/data/data_prod_20200304/database_ml_parameters_LcpK0spp_0304_HM_V0.yml
@@ -356,7 +356,7 @@ LcpK0spp:
       var_binning2_gen: perc_v0m
       nbinshisto: 100000
       minvaluehisto: -0.0005
-      maxvaluehisto: 99.9995
+      maxvaluehisto: 100.0005
       triggereff: [1]
       triggereffunc: [0]
       triggerbit: HighMultV0

--- a/machine_learning_hep/data/data_prod_20200304/database_ml_parameters_LcpK0spp_0304_HM_V0.yml
+++ b/machine_learning_hep/data/data_prod_20200304/database_ml_parameters_LcpK0spp_0304_HM_V0.yml
@@ -426,7 +426,7 @@ LcpK0spp:
       FixedMean: false
       SetFixGaussianSigma: [true,true,true,true,true,true]
       # Use value set for "masspeak" for initializing total fit, otherwise what is derived from MC fit is used
-      SetInitialGaussianMean: true
+      SetInitialGaussianMean: False
       # Use values set for "sigmaarray" for initializing total fit (per pT bin),
       # otherwise what is derived from MC fit is used
       SetInitialGaussianSigma: [true, true, true, true, true, true]
@@ -565,7 +565,7 @@ LcpK0spp:
       FixedMean: false
       SetFixGaussianSigma: [true,true,true,true,true,true]
       # Use value set for "masspeak" for initializing total fit, otherwise what is derived from MC fit is used
-      SetInitialGaussianMean: true
+      SetInitialGaussianMean: False
       # Use values set for "sigmaarray" for initializing total fit (per pT bin),
       # otherwise what is derived from MC fit is used
       SetInitialGaussianSigma: [false, false, false, false, false, false]

--- a/machine_learning_hep/data/data_prod_20200417/database_ml_parameters_D0pp_0417.yml
+++ b/machine_learning_hep/data/data_prod_20200417/database_ml_parameters_D0pp_0417.yml
@@ -527,7 +527,7 @@ D0pp:
       FixedMean: False
       SetFixGaussianSigma: [false, false, false, false, false, false]
       # Use value set for "masspeak" for initializing total fit, otherwise what is derived from MC fit is used
-      SetInitialGaussianMean: true
+      SetInitialGaussianMean: false
       # Use values set for "sigmaarray" for initializing total fit (per pT bin),
       # otherwise what is derived from MC fit is used
       SetInitialGaussianSigma: [false, false, false, false, false, false]
@@ -621,7 +621,7 @@ D0pp:
       FixedMean: False
       SetFixGaussianSigma: [false, false, false, false, false, false]
       # Use value set for "masspeak" for initializing total fit, otherwise what is derived from MC fit is used
-      SetInitialGaussianMean: true
+      SetInitialGaussianMean: false
       # Use values set for "sigmaarray" for initializing total fit (per pT bin),
       # otherwise what is derived from MC fit is used
       SetInitialGaussianSigma: [false, false, false, false, false, false]
@@ -761,7 +761,7 @@ D0pp:
       FixedMean: False
       SetFixGaussianSigma: [true, true, true, true, true, true]
       # Use value set for "masspeak" for initializing total fit, otherwise what is derived from MC fit is used
-      SetInitialGaussianMean: true
+      SetInitialGaussianMean: false
       # Use values set for "sigmaarray" for initializing total fit (per pT bin),
       # otherwise what is derived from MC fit is used
       SetInitialGaussianSigma: [false, false, false, false, false, false]

--- a/machine_learning_hep/data/data_prod_20200417/database_ml_parameters_D0pp_0417.yml
+++ b/machine_learning_hep/data/data_prod_20200417/database_ml_parameters_D0pp_0417.yml
@@ -224,7 +224,7 @@ D0pp:
 
     opt:
       isFONLLfromROOT: true
-      filename_fonll: 'data/fonll/D0DplusDstarPredictions_13TeV_y05_all_300416_BDShapeCorrected.root' # file with FONLL predictions
+      filename_fonll: 'data/fonll/old_predictions/D0DplusDstarPredictions_13TeV_y05_all_300416_BDShapeCorrected.root' # file with FONLL predictions
       fonll_particle: 'hD0Kpi'
       fonll_pred: 'max' # edge of the FONLL prediction
       FF: 0.6086 # fragmentation fraction
@@ -272,7 +272,7 @@ D0pp:
     fd_method: 2 #knone=0, kfc=1, kNb=2
     cctype: 1 #kpp7
     sigmav0: 57.8e-3 #NB: multiplied by 1e12 before giving to HFPtSpectrum!
-    inputfonllpred: data/fonll/D0DplusDstarPredictions_13TeV_y05_all_300416_BDShapeCorrected.root
+    inputfonllpred: data/fonll/old_predictions/D0DplusDstarPredictions_13TeV_y05_all_300416_BDShapeCorrected.root
     dir_general_plots: /data/DerivedResults/D0kINTHighMultCALOwithJets/vAN-20200824_ROOT6-1/analysis_plots
 
     jet_zg: &jet_default
@@ -668,7 +668,7 @@ D0pp:
       var_binning2_gen: perc_v0m
       nbinshisto: 100000
       minvaluehisto: -0.0005
-      maxvaluehisto: 99.9995
+      maxvaluehisto: 100.0005
       triggerbit: INT7
       sel_an_binmin: [1,2,4,6,8,12]  # [1,2,4,6,8,12] #list of pt nbins
       sel_an_binmax: [2,4,6,8,12,24]  # [2,4,6,8,12,24] #list of pt nbins

--- a/machine_learning_hep/data/data_prod_20200417/database_ml_parameters_D0pp_0417_HM_V0.yml
+++ b/machine_learning_hep/data/data_prod_20200417/database_ml_parameters_D0pp_0417_HM_V0.yml
@@ -225,7 +225,7 @@ D0pp:
 
     opt:
       isFONLLfromROOT: true
-      filename_fonll: 'data/fonll/D0DplusDstarPredictions_13TeV_y05_all_300416_BDShapeCorrected.root' # file with FONLL predictions
+      filename_fonll: 'data/fonll/old_predictions/D0DplusDstarPredictions_13TeV_y05_all_300416_BDShapeCorrected.root' # file with FONLL predictions
       fonll_particle: 'hD0Kpi'
       fonll_pred: 'max' # edge of the FONLL prediction
       FF: 0.6086 # fragmentation fraction
@@ -273,7 +273,7 @@ D0pp:
     fd_method: 2 #knone=0, kfc=1, kNb=2
     cctype: 1 #kpp7
     sigmav0: 57.8e-3 #NB: multiplied by 1e12 before giving to HFPtSpectrum!
-    inputfonllpred: data/fonll/D0DplusDstarPredictions_13TeV_y05_all_300416_BDShapeCorrected.root
+    inputfonllpred: data/fonll/old_predictions/D0DplusDstarPredictions_13TeV_y05_all_300416_BDShapeCorrected.root
     dir_general_plots: /data/DerivedResults/D0kINTHighMultCALOwithJets/vAN-20200824_ROOT6-1/analysis_plots
 
 
@@ -296,7 +296,7 @@ D0pp:
       var_binning2_gen: perc_v0m
       nbinshisto: 100000
       minvaluehisto: -0.0005
-      maxvaluehisto: 99.9995
+      maxvaluehisto: 100.0005
       # here the trigger efficiency is set to 1. Corrections are implemented in the analysis step
       triggereff: [1.]
       triggereffunc: [0.]

--- a/machine_learning_hep/data/data_prod_20200417/database_ml_parameters_D0pp_0417_HM_V0.yml
+++ b/machine_learning_hep/data/data_prod_20200417/database_ml_parameters_D0pp_0417_HM_V0.yml
@@ -368,7 +368,7 @@ D0pp:
       FixedMean: False
       SetFixGaussianSigma: [true, true, true, true, true, true]
       # Use value set for "masspeak" for initializing total fit, otherwise what is derived from MC fit is used
-      SetInitialGaussianMean: true
+      SetInitialGaussianMean: False
       # Use values set for "sigmaarray" for initializing total fit (per pT bin),
       # otherwise what is derived from MC fit is used
       SetInitialGaussianSigma: [true,true,true,true,true,true]
@@ -462,7 +462,7 @@ D0pp:
       FixedMean: False
       SetFixGaussianSigma: [true, true, true, true, true, true]
       # Use value set for "masspeak" for initializing total fit, otherwise what is derived from MC fit is used
-      SetInitialGaussianMean: true
+      SetInitialGaussianMean: False
       # Use values set for "sigmaarray" for initializing total fit (per pT bin),
       # otherwise what is derived from MC fit is used
       SetInitialGaussianSigma: [true, false, false, false, false, false]

--- a/machine_learning_hep/fitting/fitters.py
+++ b/machine_learning_hep/fitting/fitters.py
@@ -338,6 +338,8 @@ class FitAliHF(FitROOT):
         self.kernel.SetInitialGaussianSigma(self.init_pars["sigma"])
 
         self.kernel.SetNSigma4SideBands(self.init_pars["n_sigma_sideband"])
+        if self.init_pars["fix_mean"]:
+            self.kernel.SetFixGaussianMean(self.init_pars["mean"])
         if self.init_pars["fix_sigma"]:
             self.kernel.SetFixGaussianSigma(self.init_pars["sigma"])
 

--- a/machine_learning_hep/processer.py
+++ b/machine_learning_hep/processer.py
@@ -63,6 +63,7 @@ class Processer: # pylint: disable=too-many-instance-attributes
         self.p_frac_merge = p_frac_merge
         self.p_rd_merge = p_rd_merge
         self.period = p_period
+        self.i_period = i_period
         self.select_children = datap["multi"][mcordata].get("select_children", None)
         if self.select_children:
             # Make sure we have "<child>/" instead if <child> only. Cause in the latter case
@@ -164,11 +165,23 @@ class Processer: # pylint: disable=too-many-instance-attributes
         self.lpt_model = appendmainfoldertolist(self.dirmodel, self.lpt_model)
 
         self.lpt_probcutpre = datap["mlapplication"]["probcutpresel"][self.mcordata]
-        self.lpt_probcutfin = datap["mlapplication"]["probcutoptimal"]
+        self.lpt_probcutfin = datap["analysis"][self.typean].get("probcuts", None)
+
+        # Make it backwards-compatible
+        if not self.lpt_probcutfin:
+            bin_matching = datap["analysis"][self.typean]["binning_matching"]
+            lpt_probcutfin_tmp = datap["mlapplication"]["probcutoptimal"]
+            self.lpt_probcutfin = []
+            for i in range(self.p_nptfinbins):
+                bin_id = bin_matching[i]
+                self.lpt_probcutfin.append(lpt_probcutfin_tmp[bin_id])
 
         if self.mltype != "MultiClassification":
             if self.lpt_probcutfin < self.lpt_probcutpre:
                 print("FATAL error: probability cut final must be tighter!")
+
+        self.l_selml = ["y_test_prob%s>%s" % (self.p_modelname, self.lpt_probcutfin[ipt]) \
+                       for ipt in range(self.p_nptfinbins)]
 
         self.d_pkl_dec = d_pkl_dec
         self.mptfiles_recosk = []

--- a/machine_learning_hep/processer.py
+++ b/machine_learning_hep/processer.py
@@ -40,7 +40,7 @@ class Processer: # pylint: disable=too-many-instance-attributes
 
     # Initializer / Instance Attributes
     # pylint: disable=too-many-statements, too-many-arguments
-    def __init__(self, case, datap, run_param, mcordata, p_maxfiles,
+    def __init__(self, case, datap, run_param, mcordata, p_maxfiles, # pylint: disable=too-many-branches
                  d_root, d_pkl, d_pklsk, d_pkl_ml, p_period, i_period,
                  p_chunksizeunp, p_chunksizeskim, p_maxprocess,
                  p_frac_merge, p_rd_merge, d_pkl_dec, d_pkl_decmerged,

--- a/machine_learning_hep/processerdhadrons.py
+++ b/machine_learning_hep/processerdhadrons.py
@@ -48,8 +48,6 @@ class ProcesserDhadrons(Processer): # pylint: disable=too-many-instance-attribut
         self.p_bin_width = datap["analysis"][self.typean]['bin_width']
         self.p_num_bins = int(round((self.p_mass_fit_lim[1] - self.p_mass_fit_lim[0]) / \
                                     self.p_bin_width))
-        self.l_selml = ["y_test_prob%s>%s" % (self.p_modelname, self.lpt_probcutfin[ipt]) \
-                       for ipt in range(self.p_nptbins)]
         self.s_presel_gen_eff = datap["analysis"][self.typean]['presel_gen_eff']
 
 

--- a/machine_learning_hep/processerdhadrons_jet.py
+++ b/machine_learning_hep/processerdhadrons_jet.py
@@ -165,8 +165,6 @@ class ProcesserDhadrons_jet(Processer): # pylint: disable=invalid-name, too-many
         self.p_bin_width = datap["analysis"][self.typean]["bin_width"]
         self.p_num_bins = int(round((self.p_mass_fit_lim[1] - self.p_mass_fit_lim[0]) / \
                                     self.p_bin_width))
-        self.l_selml = ["y_test_prob%s>%s" % (self.p_modelname, self.lpt_probcutfin[ipt]) \
-                       for ipt in range(self.p_nptbins)]
 
         # first variable (hadron pt)
         self.v_var_binning = datap["var_binning"] # name
@@ -256,7 +254,7 @@ class ProcesserDhadrons_jet(Processer): # pylint: disable=invalid-name, too-many
                 df = pickle.load(openfile(self.mptfiles_recoskmldec[bin_id][index], "rb"))
             df = adjust_nsd(df)
             if self.doml is True:
-                df = df.query(self.l_selml[bin_id])
+                df = df.query(self.l_selml[ipt])
             # custom cuts
             elif self.do_custom_analysis_cuts:
                 # PID cut
@@ -288,7 +286,7 @@ class ProcesserDhadrons_jet(Processer): # pylint: disable=invalid-name, too-many
             for ibin2 in range(self.p_nbin2_reco):
                 suffix = "%s%d_%d_%.2f%s_%.2f_%.2f" % \
                          (self.v_var_binning, self.lpt_finbinmin[ipt],
-                          self.lpt_finbinmax[ipt], self.lpt_probcutfin[bin_id],
+                          self.lpt_finbinmax[ipt], self.lpt_probcutfin[ipt],
                           self.v_var2_binning, self.lvar2_binmin_reco[ibin2],
                           self.lvar2_binmax_reco[ibin2])
                 df_bin = seldf_singlevar(df, self.v_var2_binning,
@@ -452,7 +450,7 @@ class ProcesserDhadrons_jet(Processer): # pylint: disable=invalid-name, too-many
                 df_reco_presel_pr = df_mc_reco[df_mc_reco.ismcprompt == 1]
                 df_reco_sel_pr = None
                 if self.doml is True:
-                    df_reco_sel_pr = df_reco_presel_pr.query(self.l_selml[bin_id])
+                    df_reco_sel_pr = df_reco_presel_pr.query(self.l_selml[ipt])
                 # custom cuts
                 elif self.do_custom_analysis_cuts:
                     df_reco_sel_pr = self.apply_cuts_ptbin(df_reco_presel_pr, ipt)
@@ -469,7 +467,7 @@ class ProcesserDhadrons_jet(Processer): # pylint: disable=invalid-name, too-many
                 df_reco_presel_fd = df_mc_reco[df_mc_reco.ismcfd == 1]
                 df_reco_sel_fd = None
                 if self.doml is True:
-                    df_reco_sel_fd = df_reco_presel_fd.query(self.l_selml[bin_id])
+                    df_reco_sel_fd = df_reco_presel_fd.query(self.l_selml[ipt])
                 # custom cuts
                 elif self.do_custom_analysis_cuts:
                     df_reco_sel_fd = self.apply_cuts_ptbin(df_reco_presel_fd, ipt)
@@ -543,7 +541,7 @@ class ProcesserDhadrons_jet(Processer): # pylint: disable=invalid-name, too-many
                 df_mc_reco = seldf_singlevar(df_mc_reco, self.v_var_binning, \
                     self.lpt_finbinmin[ipt], self.lpt_finbinmax[ipt])
                 if self.doml is True:
-                    df_mc_reco = df_mc_reco.query(self.l_selml[bin_id])
+                    df_mc_reco = df_mc_reco.query(self.l_selml[ipt])
                 # custom cuts
                 elif self.do_custom_analysis_cuts:
                     df_mc_reco = self.apply_cuts_ptbin(df_mc_reco, ipt)

--- a/machine_learning_hep/processerdhadrons_mult.py
+++ b/machine_learning_hep/processerdhadrons_mult.py
@@ -62,16 +62,14 @@ class ProcesserDhadrons_mult(Processer): # pylint: disable=too-many-instance-att
                                     self.p_bin_width))
         if self.mltype == "MultiClassification":
             self.l_selml = []
-            for ipt in range(self.p_nptbins):
+            for ipt in range(self.p_nptfinbins):
+
                 mlsel_multi0 = "y_test_prob" + self.p_modelname + self.multiclass_labels[0] + \
                                " <= " + str(self.lpt_probcutfin[ipt][0])
                 mlsel_multi1 = "y_test_prob" + self.p_modelname + self.multiclass_labels[1] + \
                                " >= " + str(self.lpt_probcutfin[ipt][1])
                 mlsel_multi = mlsel_multi0 + " and " + mlsel_multi1
                 self.l_selml.append(mlsel_multi)
-        else:
-            self.l_selml = ["y_test_prob%s>%s" % (self.p_modelname, self.lpt_probcutfin[ipt]) \
-                           for ipt in range(self.p_nptbins)]
         self.s_presel_gen_eff = datap["analysis"][self.typean]['presel_gen_eff']
         self.lvar2_binmin = datap["analysis"][self.typean]["sel_binmin2"]
         self.lvar2_binmax = datap["analysis"][self.typean]["sel_binmax2"]
@@ -80,7 +78,6 @@ class ProcesserDhadrons_mult(Processer): # pylint: disable=too-many-instance-att
         self.corr_eff_mult = datap["analysis"][self.typean]["corrEffMult"]
         self.mc_cut_on_binning2 = datap["analysis"][self.typean].get("mc_cut_on_binning2", True)
 
-        self.bin_matching = datap["analysis"][self.typean]["binning_matching"]
         #self.sel_final_fineptbins = datap["analysis"][self.typean]["sel_final_fineptbins"]
         self.s_evtsel = datap["analysis"][self.typean]["evtsel"]
         self.s_trigger = datap["analysis"][self.typean]["triggersel"][self.mcordata]
@@ -243,7 +240,7 @@ class ProcesserDhadrons_mult(Processer): # pylint: disable=too-many-instance-att
                 df = selectdfrunlist(df, \
                     self.run_param[self.runlistrigger], "run_number")
             if self.doml is True:
-                df = df.query(self.l_selml[bin_id])
+                df = df.query(self.l_selml[ipt])
             list_df_recodtrig.append(df)
             df = seldf_singlevar(df, self.v_var_binning, \
                                  self.lpt_finbinmin[ipt], self.lpt_finbinmax[ipt])
@@ -255,18 +252,18 @@ class ProcesserDhadrons_mult(Processer): # pylint: disable=too-many-instance-att
                 if self.mltype == "MultiClassification":
                     suffix = "%s%d_%d_%.2f%.2f%s_%.2f_%.2f" % \
                              (self.v_var_binning, self.lpt_finbinmin[ipt],
-                              self.lpt_finbinmax[ipt], self.lpt_probcutfin[bin_id][0],
-                              self.lpt_probcutfin[bin_id][1], self.v_var2_binning,
+                              self.lpt_finbinmax[ipt], self.lpt_probcutfin[ipt][0],
+                              self.lpt_probcutfin[ipt][1], self.v_var2_binning,
                               self.lvar2_binmin[ibin2], self.lvar2_binmax[ibin2])
-                    lpt_probcutfin_temp = 1000 * self.lpt_probcutfin[bin_id][0] + \
-                                          self.lpt_probcutfin[bin_id][1]
+                    lpt_probcutfin_temp = 1000 * self.lpt_probcutfin[ipt][0] + \
+                                          self.lpt_probcutfin[ipt][1]
                 else:
                     suffix = "%s%d_%d_%.2f%s_%.2f_%.2f" % \
                              (self.v_var_binning, self.lpt_finbinmin[ipt],
-                              self.lpt_finbinmax[ipt], self.lpt_probcutfin[bin_id],
+                              self.lpt_finbinmax[ipt], self.lpt_probcutfin[ipt],
                               self.v_var2_binning,
                               self.lvar2_binmin[ibin2], self.lvar2_binmax[ibin2])
-                    lpt_probcutfin_temp = self.lpt_probcutfin[bin_id]
+                    lpt_probcutfin_temp = self.lpt_probcutfin[ipt]
                 curr_dir = myfile.mkdir(f"bin1_{ipt}_bin2_{ibin2}")
                 meta_info = create_meta_info(self.v_var_binning, self.lpt_finbinmin[ipt],
                                              self.lpt_finbinmax[ipt], self.v_var2_binning,
@@ -455,14 +452,14 @@ class ProcesserDhadrons_mult(Processer): # pylint: disable=too-many-instance-att
                 df_reco_presel_pr = df_mc_reco[df_mc_reco.ismcprompt == 1]
                 df_reco_sel_pr = None
                 if self.doml is True:
-                    df_reco_sel_pr = df_reco_presel_pr.query(self.l_selml[bin_id])
+                    df_reco_sel_pr = df_reco_presel_pr.query(self.l_selml[ipt])
                 else:
                     df_reco_sel_pr = df_reco_presel_pr.copy()
                 df_gen_sel_fd = df_mc_gen[df_mc_gen.ismcfd == 1]
                 df_reco_presel_fd = df_mc_reco[df_mc_reco.ismcfd == 1]
                 df_reco_sel_fd = None
                 if self.doml is True:
-                    df_reco_sel_fd = df_reco_presel_fd.query(self.l_selml[bin_id])
+                    df_reco_sel_fd = df_reco_presel_fd.query(self.l_selml[ipt])
                 else:
                     df_reco_sel_fd = df_reco_presel_fd.copy()
 

--- a/machine_learning_hep/processerdhadrons_mult.py
+++ b/machine_learning_hep/processerdhadrons_mult.py
@@ -78,6 +78,7 @@ class ProcesserDhadrons_mult(Processer): # pylint: disable=too-many-instance-att
         self.corr_eff_mult = datap["analysis"][self.typean]["corrEffMult"]
         self.mc_cut_on_binning2 = datap["analysis"][self.typean].get("mc_cut_on_binning2", True)
 
+        self.bin_matching = datap["analysis"][self.typean]["binning_matching"]
         #self.sel_final_fineptbins = datap["analysis"][self.typean]["sel_final_fineptbins"]
         self.s_evtsel = datap["analysis"][self.typean]["evtsel"]
         self.s_trigger = datap["analysis"][self.typean]["triggersel"][self.mcordata]

--- a/machine_learning_hep/steer_analysis.py
+++ b/machine_learning_hep/steer_analysis.py
@@ -136,6 +136,7 @@ def do_entire_analysis(data_config: dict, data_param: dict, data_param_overwrite
     dosyst = data_config["analysis"]["dosyst"]
     do_syst_ml = data_config["systematics"]["cutvar"]["activate"]
     do_syst_ml_only_analysis = data_config["systematics"]["cutvar"]["do_only_analysis"]
+    do_syst_ml_resume = data_config["systematics"]["cutvar"]["resume"]
     doanaperperiod = data_config["analysis"]["doperperiod"]
     typean = data_config["analysis"]["type"]
 
@@ -433,7 +434,7 @@ def do_entire_analysis(data_config: dict, data_param: dict, data_param_overwrite
     ana_mgr.analyze(*analyze_steps)
 
     if do_syst_ml:
-        syst_ml_pt.ml_systematics(do_syst_ml_only_analysis)
+        syst_ml_pt.ml_systematics(do_syst_ml_only_analysis, do_syst_ml_resume)
 
     # Delete per-period results.
     if clean:

--- a/machine_learning_hep/steer_analysis.py
+++ b/machine_learning_hep/steer_analysis.py
@@ -49,7 +49,7 @@ from machine_learning_hep.analysis.analyzer_Dhadrons import AnalyzerDhadrons
 from machine_learning_hep.analysis.analyzerdhadrons_mult import AnalyzerDhadrons_mult
 from machine_learning_hep.analysis.analyzer_jet import AnalyzerJet
 
-from machine_learning_hep.analysis.systematics import Systematics
+from machine_learning_hep.analysis.systematics import SystematicsMLWP
 
 try:
 # FIXME(https://github.com/abseil/abseil-py/issues/99) # pylint: disable=fixme
@@ -134,7 +134,8 @@ def do_entire_analysis(data_config: dict, data_param: dict, data_param_overwrite
     doplotsval = data_config["analysis"]["doplotsval"]
     doplots = data_config["analysis"]["doplots"]
     dosyst = data_config["analysis"]["dosyst"]
-    do_syst_ml = data_config["systematics"]["cutvar"]
+    do_syst_ml = data_config["systematics"]["cutvar"]["activate"]
+    do_syst_ml_only_analysis = data_config["systematics"]["cutvar"]["do_only_analysis"]
     doanaperperiod = data_config["analysis"]["doperperiod"]
     typean = data_config["analysis"]["type"]
 
@@ -283,7 +284,7 @@ def do_entire_analysis(data_config: dict, data_param: dict, data_param_overwrite
 
     proc_class = Processer
     ana_class = Analyzer
-    syst_class = Systematics
+    syst_class = SystematicsMLWP
     if proc_type == "Dhadrons":
         print("Using new feature for Dhadrons")
         proc_class = ProcesserDhadrons
@@ -303,8 +304,8 @@ def do_entire_analysis(data_config: dict, data_param: dict, data_param_overwrite
     ana_mgr = AnalyzerManager(ana_class, data_param[case], case, typean, doanaperperiod)
 
     analyzers = ana_mgr.get_analyzers()
-    # Has to be done always period-by-period
-    syst_ml_pt = syst_class(data_param[case], case, typean, run_param, analyzers,
+    # For ML WP systematics
+    syst_ml_pt = syst_class(data_param[case], case, typean, analyzers,
                             mymultiprocessmc, mymultiprocessdata)
 
     #perform the analysis flow
@@ -432,7 +433,7 @@ def do_entire_analysis(data_config: dict, data_param: dict, data_param_overwrite
     ana_mgr.analyze(*analyze_steps)
 
     if do_syst_ml:
-        syst_ml_pt.ml_systematics()
+        syst_ml_pt.ml_systematics(do_syst_ml_only_analysis)
 
     # Delete per-period results.
     if clean:

--- a/machine_learning_hep/submission/default_ana.yml
+++ b/machine_learning_hep/submission/default_ana.yml
@@ -77,12 +77,7 @@ analysis:
   doplotsval: false # analyzer: plottervalidation
 
 systematics:
-  cutvar:
-    activate: false
-    probvariationmass: false
-    probvariationeff: false
-    probvariationfit: false
-    probvariationcross: false
+  cutvar: false
   mcptshape:
     activate: false
 

--- a/machine_learning_hep/submission/default_ana.yml
+++ b/machine_learning_hep/submission/default_ana.yml
@@ -77,7 +77,9 @@ analysis:
   doplotsval: false # analyzer: plottervalidation
 
 systematics:
-  cutvar: false
+  cutvar:
+      activate: false
+      do_only_analysis: false # This can be done anytime when mass and efficiency histograms have been produced already for a number of trials
   mcptshape:
     activate: false
 

--- a/machine_learning_hep/submission/default_ana.yml
+++ b/machine_learning_hep/submission/default_ana.yml
@@ -80,6 +80,7 @@ systematics:
   cutvar:
       activate: false
       do_only_analysis: false # This can be done anytime when mass and efficiency histograms have been produced already for a number of trials
+      resume: false # already done mass and efficiency histograms will not be done again, continue with left trials
   mcptshape:
     activate: false
 

--- a/machine_learning_hep/submission/default_analyzer.yml
+++ b/machine_learning_hep/submission/default_analyzer.yml
@@ -77,11 +77,6 @@ analysis:
   doplotsval: false # analyzer: plottervalidation
 
 systematics:
-  cutvar:
-    activate: false
-    probvariationmass: false
-    probvariationeff: false
-    probvariationfit: false
-    probvariationcross: false
+  cutvar: false
   mcptshape:
     activate: false

--- a/machine_learning_hep/submission/default_analyzer.yml
+++ b/machine_learning_hep/submission/default_analyzer.yml
@@ -80,5 +80,6 @@ systematics:
   cutvar:
       activate: false
       do_only_analysis: false # This can be done anytime when mass and efficiency histograms have been produced already for a number of trials
+      resume: false # already done mass and efficiency histograms will not be done again, continue with left trials
   mcptshape:
     activate: false

--- a/machine_learning_hep/submission/default_analyzer.yml
+++ b/machine_learning_hep/submission/default_analyzer.yml
@@ -77,6 +77,8 @@ analysis:
   doplotsval: false # analyzer: plottervalidation
 
 systematics:
-  cutvar: false
+  cutvar:
+      activate: false
+      do_only_analysis: false # This can be done anytime when mass and efficiency histograms have been produced already for a number of trials
   mcptshape:
     activate: false

--- a/machine_learning_hep/submission/default_apply.yml
+++ b/machine_learning_hep/submission/default_apply.yml
@@ -77,12 +77,7 @@ analysis:
   doplotsval: false # analyzer: plottervalidation
 
 systematics:
-  cutvar:
-    activate: false
-    probvariationmass: false
-    probvariationeff: false
-    probvariationfit: false
-    probvariationcross: false
+  cutvar: false
   mcptshape:
     activate: false
 

--- a/machine_learning_hep/submission/default_apply.yml
+++ b/machine_learning_hep/submission/default_apply.yml
@@ -77,7 +77,9 @@ analysis:
   doplotsval: false # analyzer: plottervalidation
 
 systematics:
-  cutvar: false
+  cutvar:
+      activate: false
+      do_only_analysis: false # This can be done anytime when mass and efficiency histograms have been produced already for a number of trials
   mcptshape:
     activate: false
 

--- a/machine_learning_hep/submission/default_apply.yml
+++ b/machine_learning_hep/submission/default_apply.yml
@@ -80,6 +80,7 @@ systematics:
   cutvar:
       activate: false
       do_only_analysis: false # This can be done anytime when mass and efficiency histograms have been produced already for a number of trials
+      resume: false # already done mass and efficiency histograms will not be done again, continue with left trials
   mcptshape:
     activate: false
 

--- a/machine_learning_hep/submission/default_complete.yml
+++ b/machine_learning_hep/submission/default_complete.yml
@@ -78,11 +78,6 @@ analysis:
   doplotsval: false # analyzer: plottervalidation
 
 systematics:
-  cutvar:
-    activate: false
-    probvariationmass: false
-    probvariationeff: false
-    probvariationfit: false
-    probvariationcross: false
+  cutvar: false
   mcptshape:
     activate: false

--- a/machine_learning_hep/submission/default_complete.yml
+++ b/machine_learning_hep/submission/default_complete.yml
@@ -78,6 +78,8 @@ analysis:
   doplotsval: false # analyzer: plottervalidation
 
 systematics:
-  cutvar: false
+  cutvar:
+      activate: false
+      do_only_analysis: false # This can be done anytime when mass and efficiency histograms have been produced already for a number of trials
   mcptshape:
     activate: false

--- a/machine_learning_hep/submission/default_complete.yml
+++ b/machine_learning_hep/submission/default_complete.yml
@@ -81,5 +81,6 @@ systematics:
   cutvar:
       activate: false
       do_only_analysis: false # This can be done anytime when mass and efficiency histograms have been produced already for a number of trials
+      resume: false # already done mass and efficiency histograms will not be done again, continue with left trials
   mcptshape:
     activate: false

--- a/machine_learning_hep/submission/default_pre.yml
+++ b/machine_learning_hep/submission/default_pre.yml
@@ -77,12 +77,7 @@ analysis:
   doplotsval: false # analyzer: plottervalidation
 
 systematics:
-  cutvar:
-    activate: false
-    probvariationmass: false
-    probvariationeff: false
-    probvariationfit: false
-    probvariationcross: false
+  cutvar: false
   mcptshape:
     activate: false
 

--- a/machine_learning_hep/submission/default_pre.yml
+++ b/machine_learning_hep/submission/default_pre.yml
@@ -77,7 +77,9 @@ analysis:
   doplotsval: false # analyzer: plottervalidation
 
 systematics:
-  cutvar: false
+  cutvar:
+      activate: false
+      do_only_analysis: false # This can be done anytime when mass and efficiency histograms have been produced already for a number of trials
   mcptshape:
     activate: false
 

--- a/machine_learning_hep/submission/default_pre.yml
+++ b/machine_learning_hep/submission/default_pre.yml
@@ -80,6 +80,7 @@ systematics:
   cutvar:
       activate: false
       do_only_analysis: false # This can be done anytime when mass and efficiency histograms have been produced already for a number of trials
+      resume: false # already done mass and efficiency histograms will not be done again, continue with left trials
   mcptshape:
     activate: false
 

--- a/machine_learning_hep/submission/default_systematics.yml
+++ b/machine_learning_hep/submission/default_systematics.yml
@@ -77,11 +77,6 @@ analysis:
   doplotsval: false # analyzer: plottervalidation
 
 systematics:
-  cutvar:
-    activate: false
-    probvariationmass: false
-    probvariationeff: false
-    probvariationfit: false
-    probvariationcross: false
+  cutvar: false
   mcptshape:
     activate: false

--- a/machine_learning_hep/submission/default_systematics.yml
+++ b/machine_learning_hep/submission/default_systematics.yml
@@ -80,5 +80,6 @@ systematics:
   cutvar:
       activate: false
       do_only_analysis: false # This can be done anytime when mass and efficiency histograms have been produced already for a number of trials
+      resume: false # already done mass and efficiency histograms will not be done again, continue with left trials
   mcptshape:
     activate: false

--- a/machine_learning_hep/submission/default_systematics.yml
+++ b/machine_learning_hep/submission/default_systematics.yml
@@ -77,6 +77,8 @@ analysis:
   doplotsval: false # analyzer: plottervalidation
 
 systematics:
-  cutvar: false
+  cutvar:
+      activate: false
+      do_only_analysis: false # This can be done anytime when mass and efficiency histograms have been produced already for a number of trials
   mcptshape:
     activate: false

--- a/machine_learning_hep/submission/default_train.yml
+++ b/machine_learning_hep/submission/default_train.yml
@@ -76,12 +76,7 @@ analysis:
   doplotsval: false # analyzer: plottervalidation
 
 systematics:
-  cutvar:
-    activate: false
-    probvariationmass: false
-    probvariationeff: false
-    probvariationfit: false
-    probvariationcross: false
+  cutvar: false
   mcptshape:
     activate: false
 

--- a/machine_learning_hep/submission/default_train.yml
+++ b/machine_learning_hep/submission/default_train.yml
@@ -79,6 +79,7 @@ systematics:
   cutvar:
       activate: false
       do_only_analysis: false # This can be done anytime when mass and efficiency histograms have been produced already for a number of trials
+      resume: false # already done mass and efficiency histograms will not be done again, continue with left trials
   mcptshape:
     activate: false
 

--- a/machine_learning_hep/submission/default_train.yml
+++ b/machine_learning_hep/submission/default_train.yml
@@ -76,7 +76,9 @@ analysis:
   doplotsval: false # analyzer: plottervalidation
 
 systematics:
-  cutvar: false
+  cutvar:
+      activate: false
+      do_only_analysis: false # This can be done anytime when mass and efficiency histograms have been produced already for a number of trials
   mcptshape:
     activate: false
 


### PR DESCRIPTION
* introduce the possibility to define probability cut per pT analysis
  bin. If nothing specified in analysis section fallback to default and
  take global best cuts (aka "probcutoptimal").

* fitter/helper can now actually fix mean ("FixedMean")
  Lc and D0 DBs have been updated accordingly

* ML systematics
  * runs with MultiProcesser and Analyzer which is used for nominal
    results --> changes there are implicitly taken into account
  * runs trial-by-trial
    * trials are shuffled to have a mixture of ML WP up/down variations
    * keyboard interrupt is caught --> successful trials up to this
      point are summarised and plotted
      (press Ctrl-C only once and wait!)