### PR TITLE
Update D0, Lc DBs

### DIFF
--- a/machine_learning_hep/data/data_prod_20200304/database_ml_parameters_LcpK0spp_0304.yml
+++ b/machine_learning_hep/data/data_prod_20200304/database_ml_parameters_LcpK0spp_0304.yml
@@ -404,7 +404,7 @@ LcpK0spp:
       FixedMean: false
       SetFixGaussianSigma: [true,true,true,true,true,true]
       # Use value set for "masspeak" for initializing total fit, otherwise what is derived from MC fit is used
-      SetInitialGaussianMean: true
+      SetInitialGaussianMean: false
       # Use values set for "sigmaarray" for initializing total fit (per pT bin),
       # otherwise what is derived from MC fit is used
       SetInitialGaussianSigma: [true, true, true, true, true, true]
@@ -549,7 +549,7 @@ LcpK0spp:
       mc_cut_on_binning2: False
       nbinshisto: 100000
       minvaluehisto: -0.0005
-      maxvaluehisto: 99.9995
+      maxvaluehisto: 100.0005
       triggerbit: INT7
 
       sel_an_binmin: [1,2,4,6,8,12] #list of pt nbins
@@ -594,7 +594,7 @@ LcpK0spp:
         data: "trigger_hasbit_INT7==1"
         mc: null
       data:
-        runselection: [MBvspt_perc_v0m_2016, null, null]
+        runselection: [null, null, null]
         results: [/data/DerivedResults/LckAnywithJets/vAN-20200824_ROOT6-1/pp_2016_data/490_20200825-1716/resultsMBvspt_perc_v0m,
                   /data/DerivedResults/LckAnywithJets/vAN-20200824_ROOT6-1/pp_2017_data/489_20200825-1716/resultsMBvspt_perc_v0m,
                   /data/DerivedResults/LckAnywithJets/vAN-20200824_ROOT6-1/pp_2018_data/488_20200825-1716/resultsMBvspt_perc_v0m] #list of periods
@@ -641,7 +641,7 @@ LcpK0spp:
       FixedMean: false
       SetFixGaussianSigma: [true,true,true,true,true,true]
       # Use value set for "masspeak" for initializing total fit, otherwise what is derived from MC fit is used
-      SetInitialGaussianMean: true
+      SetInitialGaussianMean: false
       # Use values set for "sigmaarray" for initializing total fit (per pT bin),
       # otherwise what is derived from MC fit is used
       SetInitialGaussianSigma: [false, false, false, false, false, false]
@@ -680,7 +680,7 @@ LcpK0spp:
       ncutvar: 10 #number of looser and tighter variations
       maxperccutvar: 0.25 #max diff in efficiency for loosest/tightest var
       cutvarminrange: [0.30, 0.30, 0.30, 0.30, 0.30, 0.30] #Min starting point for scan
-      cutvarmaxrange: [0.80, 0.80, 0.80, 0.80, 0.80, 0.80] #Max starting point for scan
+      cutvarmaxrange: [0.90, 0.90, 0.90, 0.90, 0.90, 0.90] #Max starting point for scan
       fixedmean: True #Fix mean cutvar histo to central fit
       fixedsigma: True #Fix sigma cutvar histo to central fit
       min_signif_fit: 3.

--- a/machine_learning_hep/data/data_prod_20200304/database_ml_parameters_LcpK0spp_0304_HM_V0.yml
+++ b/machine_learning_hep/data/data_prod_20200304/database_ml_parameters_LcpK0spp_0304_HM_V0.yml
@@ -249,21 +249,21 @@ LcpK0spp:
       fracmerge: [1.0,1.0,1.0]  #list of periods
       seedmerge: [12,12,12] #list of periods
       period: [LHC16pp,LHC17pp,LHC18pp] #list of periods
-      select_children: [["child_9"], ["child_10"], ["child_11"]] # select children explicitly corresponding to each year
+      select_children: [["child_1"], ["child_2"], ["child_3"]] # select children explicitly corresponding to each year
       unmerged_tree_dir: [/data/TTree/MCpp13TeV_HM_Dedicated/vAN-20200824_ROOT6-1/pp_sim/492_20200901-1528/merged,
                           /data/TTree/MCpp13TeV_HM_Dedicated/vAN-20200824_ROOT6-1/pp_sim/492_20200901-1528/merged,
                           /data/TTree/MCpp13TeV_HM_Dedicated/vAN-20200824_ROOT6-1/pp_sim/492_20200901-1528/merged] #list of periods
-      pkl: [/data/Derived/LckINTHighMultCALOwithJets/vAN-20200824_ROOT6-1/pp_2016_mc_prodHMV0MpK0s/492_20200901-1528/pkl,
-            /data/Derived/LckINTHighMultCALOwithJets/vAN-20200824_ROOT6-1/pp_2017_mc_prodHMV0MpK0s/492_20200901-1528/pkl,
-            /data/Derived/LckINTHighMultCALOwithJets/vAN-20200824_ROOT6-1/pp_2018_mc_prodHMV0MpK0s/492_20200901-1528/pkl] #list of periods
-      pkl_skimmed: [/data/Derived/LckINTHighMultCALOwithJets/vAN-20200824_ROOT6-1/pp_2016_mc_prodHMV0MpK0s/492_20200901-1528/pklsk,
-                    /data/Derived/LckINTHighMultCALOwithJets/vAN-20200824_ROOT6-1/pp_2017_mc_prodHMV0MpK0s/492_20200901-1528/pklsk,
-                    /data/Derived/LckINTHighMultCALOwithJets/vAN-20200824_ROOT6-1/pp_2018_mc_prodHMV0MpK0s/492_20200901-1528/pklsk] #list of periods
-      pkl_skimmed_merge_for_ml: [/data/Derived/LckINTHighMultCALOwithJets/vAN-20200824_ROOT6-1/pp_2016_mc_prodHMV0MpK0s/492_20200901-1528/pklskml,
-                                 /data/Derived/LckINTHighMultCALOwithJets/vAN-20200824_ROOT6-1/pp_2017_mc_prodHMV0MpK0s/492_20200901-1528/pklskml,
-                                 /data/Derived/LckINTHighMultCALOwithJets/vAN-20200824_ROOT6-1/pp_2018_mc_prodHMV0MpK0s/492_20200901-1528/pklskml] #list of periods
-      pkl_skimmed_merge_for_ml_all: /data/Derived/LckINTHighMultCALOwithJets/vAN-20200824_ROOT6-1/pp_mc_prodHMV0MpK0s_mltot
-      pkl_evtcounter_all: /data/Derived/LckINTHighMultCALOwithJets/vAN-20200824_ROOT6-1/pp_mc_prodHMV0MpK0s_evttot
+      pkl: [/data/Derived/LckINTHighMultCALOwithJets/vAN-20200824_ROOT6-1/pp_2016_mc_prodHMV0MD2H/492_20200901-1528/pkl,
+            /data/Derived/LckINTHighMultCALOwithJets/vAN-20200824_ROOT6-1/pp_2017_mc_prodHMV0MD2H/492_20200901-1528/pkl,
+            /data/Derived/LckINTHighMultCALOwithJets/vAN-20200824_ROOT6-1/pp_2018_mc_prodHMV0MD2H/492_20200901-1528/pkl] #list of periods
+      pkl_skimmed: [/data/Derived/LckINTHighMultCALOwithJets/vAN-20200824_ROOT6-1/pp_2016_mc_prodHMV0MD2H/492_20200901-1528/pklsk,
+                    /data/Derived/LckINTHighMultCALOwithJets/vAN-20200824_ROOT6-1/pp_2017_mc_prodHMV0MD2H/492_20200901-1528/pklsk,
+                    /data/Derived/LckINTHighMultCALOwithJets/vAN-20200824_ROOT6-1/pp_2018_mc_prodHMV0MD2H/492_20200901-1528/pklsk] #list of periods
+      pkl_skimmed_merge_for_ml: [/data/Derived/LckINTHighMultCALOwithJets/vAN-20200824_ROOT6-1/pp_2016_mc_prodHMV0MD2H/492_20200901-1528/pklskml,
+                                 /data/Derived/LckINTHighMultCALOwithJets/vAN-20200824_ROOT6-1/pp_2017_mc_prodHMV0MD2H/492_20200901-1528/pklskml,
+                                 /data/Derived/LckINTHighMultCALOwithJets/vAN-20200824_ROOT6-1/pp_2018_mc_prodHMV0MD2H/492_20200901-1528/pklskml] #list of periods
+      pkl_skimmed_merge_for_ml_all: /data/Derived/LckINTHighMultCALOwithJets/vAN-20200824_ROOT6-1/pp_mc_prodHMV0MD2H_mltot
+      pkl_evtcounter_all: /data/Derived/LckINTHighMultCALOwithJets/vAN-20200824_ROOT6-1/pp_mc_prodHMV0MD2H_evttot
       mcreweights: [../Analyses/ALICE_D2H_vs_mult_pp13/reweighting/prodD2H_16,
                     ../Analyses/ALICE_D2H_vs_mult_pp13/reweighting/prodD2H_17,
                     ../Analyses/ALICE_D2H_vs_mult_pp13/reweighting/prodD2H_18] #list of periods
@@ -291,7 +291,7 @@ LcpK0spp:
 
     opt:
       isFONLLfromROOT: true
-      filename_fonll: 'data/fonll/D0DplusDstarPredictions_13TeV_y05_all_300416_BDShapeCorrected.root' # 'data/fonll/fo_pp_d0meson_5TeV_y0p5.csv' file with FONLL predictions
+      filename_fonll: 'data/fonll/DmesonLcPredictions_13TeV_y05_FFptDepLHCb_BRpythia8.root'  #'data/fonll/D0DplusDstarPredictions_13TeV_y05_all_300416_BDShapeCorrected.root'
       fonll_particle: 'hLcK0sp'
       fonll_pred: 'max' # edge of the FONLL prediction
       FF: 0.1281 # fragmentation fraction
@@ -339,7 +339,7 @@ LcpK0spp:
     fd_method: 2 #knone=0, kfc=1, kNb=2
     cctype: 1 #kpp7
     sigmav0: 57.8e-3 #NB: multiplied by 1e12 before giving to HFPtSpectrum!
-    inputfonllpred: data/fonll/D0DplusDstarPredictions_13TeV_y05_all_300416_BDShapeCorrected.root
+    inputfonllpred: data/fonll/DmesonLcPredictions_13TeV_y05_FFptDepLHCb_BRpythia8.root
     dir_general_plots: /data/DerivedResults/LckAnywithJets_sub/vAN-20200304_ROOT6-1/analysis_plots
 
     V0vspt_perc_v0m:
@@ -356,7 +356,7 @@ LcpK0spp:
       var_binning2_gen: perc_v0m
       nbinshisto: 100000
       minvaluehisto: -0.0005
-      maxvaluehisto: 99.9995
+      maxvaluehisto: 100.0005
       triggereff: [1]
       triggereffunc: [0]
       triggerbit: HighMultV0
@@ -426,7 +426,7 @@ LcpK0spp:
       FixedMean: false
       SetFixGaussianSigma: [true,true,true,true,true,true]
       # Use value set for "masspeak" for initializing total fit, otherwise what is derived from MC fit is used
-      SetInitialGaussianMean: true
+      SetInitialGaussianMean: False
       # Use values set for "sigmaarray" for initializing total fit (per pT bin),
       # otherwise what is derived from MC fit is used
       SetInitialGaussianSigma: [true, true, true, true, true, true]
@@ -565,7 +565,7 @@ LcpK0spp:
       FixedMean: false
       SetFixGaussianSigma: [true,true,true,true,true,true]
       # Use value set for "masspeak" for initializing total fit, otherwise what is derived from MC fit is used
-      SetInitialGaussianMean: true
+      SetInitialGaussianMean: False
       # Use values set for "sigmaarray" for initializing total fit (per pT bin),
       # otherwise what is derived from MC fit is used
       SetInitialGaussianSigma: [false, false, false, false, false, false]

--- a/machine_learning_hep/data/data_prod_20200417/database_ml_parameters_D0pp_0417.yml
+++ b/machine_learning_hep/data/data_prod_20200417/database_ml_parameters_D0pp_0417.yml
@@ -224,7 +224,7 @@ D0pp:
 
     opt:
       isFONLLfromROOT: true
-      filename_fonll: 'data/fonll/D0DplusDstarPredictions_13TeV_y05_all_300416_BDShapeCorrected.root' # file with FONLL predictions
+      filename_fonll: data/fonll/DmesonLcPredictions_13TeV_y05_FFee_BRpythia8.root
       fonll_particle: 'hD0Kpi'
       fonll_pred: 'max' # edge of the FONLL prediction
       FF: 0.6086 # fragmentation fraction
@@ -272,7 +272,7 @@ D0pp:
     fd_method: 2 #knone=0, kfc=1, kNb=2
     cctype: 1 #kpp7
     sigmav0: 57.8e-3 #NB: multiplied by 1e12 before giving to HFPtSpectrum!
-    inputfonllpred: data/fonll/D0DplusDstarPredictions_13TeV_y05_all_300416_BDShapeCorrected.root
+    inputfonllpred: data/fonll/DmesonLcPredictions_13TeV_y05_FFee_BRpythia8.root
     dir_general_plots: /data/DerivedResults/D0kINTHighMultCALOwithJets/vAN-20200824_ROOT6-1/analysis_plots
 
     jet_zg: &jet_default
@@ -527,7 +527,7 @@ D0pp:
       FixedMean: False
       SetFixGaussianSigma: [false, false, false, false, false, false]
       # Use value set for "masspeak" for initializing total fit, otherwise what is derived from MC fit is used
-      SetInitialGaussianMean: true
+      SetInitialGaussianMean: false
       # Use values set for "sigmaarray" for initializing total fit (per pT bin),
       # otherwise what is derived from MC fit is used
       SetInitialGaussianSigma: [false, false, false, false, false, false]
@@ -621,7 +621,7 @@ D0pp:
       FixedMean: False
       SetFixGaussianSigma: [false, false, false, false, false, false]
       # Use value set for "masspeak" for initializing total fit, otherwise what is derived from MC fit is used
-      SetInitialGaussianMean: true
+      SetInitialGaussianMean: false
       # Use values set for "sigmaarray" for initializing total fit (per pT bin),
       # otherwise what is derived from MC fit is used
       SetInitialGaussianSigma: [false, false, false, false, false, false]
@@ -668,7 +668,7 @@ D0pp:
       var_binning2_gen: perc_v0m
       nbinshisto: 100000
       minvaluehisto: -0.0005
-      maxvaluehisto: 99.9995
+      maxvaluehisto: 100.0005
       triggerbit: INT7
       sel_an_binmin: [1,2,4,6,8,12]  # [1,2,4,6,8,12] #list of pt nbins
       sel_an_binmax: [2,4,6,8,12,24]  # [2,4,6,8,12,24] #list of pt nbins
@@ -761,7 +761,7 @@ D0pp:
       FixedMean: False
       SetFixGaussianSigma: [true, true, true, true, true, true]
       # Use value set for "masspeak" for initializing total fit, otherwise what is derived from MC fit is used
-      SetInitialGaussianMean: true
+      SetInitialGaussianMean: false
       # Use values set for "sigmaarray" for initializing total fit (per pT bin),
       # otherwise what is derived from MC fit is used
       SetInitialGaussianSigma: [false, false, false, false, false, false]

--- a/machine_learning_hep/data/data_prod_20200417/database_ml_parameters_D0pp_0417_HM_V0.yml
+++ b/machine_learning_hep/data/data_prod_20200417/database_ml_parameters_D0pp_0417_HM_V0.yml
@@ -225,7 +225,7 @@ D0pp:
 
     opt:
       isFONLLfromROOT: true
-      filename_fonll: 'data/fonll/D0DplusDstarPredictions_13TeV_y05_all_300416_BDShapeCorrected.root' # file with FONLL predictions
+      filename_fonll: data/fonll/DmesonLcPredictions_13TeV_y05_FFee_BRpythia8.root
       fonll_particle: 'hD0Kpi'
       fonll_pred: 'max' # edge of the FONLL prediction
       FF: 0.6086 # fragmentation fraction
@@ -273,7 +273,7 @@ D0pp:
     fd_method: 2 #knone=0, kfc=1, kNb=2
     cctype: 1 #kpp7
     sigmav0: 57.8e-3 #NB: multiplied by 1e12 before giving to HFPtSpectrum!
-    inputfonllpred: data/fonll/D0DplusDstarPredictions_13TeV_y05_all_300416_BDShapeCorrected.root
+    inputfonllpred: data/fonll/DmesonLcPredictions_13TeV_y05_FFee_BRpythia8.root
     dir_general_plots: /data/DerivedResults/D0kINTHighMultCALOwithJets/vAN-20200824_ROOT6-1/analysis_plots
 
 
@@ -296,7 +296,7 @@ D0pp:
       var_binning2_gen: perc_v0m
       nbinshisto: 100000
       minvaluehisto: -0.0005
-      maxvaluehisto: 99.9995
+      maxvaluehisto: 100.0005
       # here the trigger efficiency is set to 1. Corrections are implemented in the analysis step
       triggereff: [1.]
       triggereffunc: [0.]
@@ -368,7 +368,7 @@ D0pp:
       FixedMean: False
       SetFixGaussianSigma: [true, true, true, true, true, true]
       # Use value set for "masspeak" for initializing total fit, otherwise what is derived from MC fit is used
-      SetInitialGaussianMean: true
+      SetInitialGaussianMean: False
       # Use values set for "sigmaarray" for initializing total fit (per pT bin),
       # otherwise what is derived from MC fit is used
       SetInitialGaussianSigma: [true,true,true,true,true,true]
@@ -462,7 +462,7 @@ D0pp:
       FixedMean: False
       SetFixGaussianSigma: [true, true, true, true, true, true]
       # Use value set for "masspeak" for initializing total fit, otherwise what is derived from MC fit is used
-      SetInitialGaussianMean: true
+      SetInitialGaussianMean: False
       # Use values set for "sigmaarray" for initializing total fit (per pT bin),
       # otherwise what is derived from MC fit is used
       SetInitialGaussianSigma: [true, false, false, false, false, false]


### PR DESCRIPTION
* binning adjustment for perc_v0m analysis to include value of 100.
  otherwise the number of selected events is not estimated correctly
  when this percentile value is included

* use HM V0 inclusive (aka D2H) MC for Lc in 0.-0.1

* remove run selection for 2016 MB in perc_v0m analysis

* update FONLL file where not yet done

* SetInitialGaussianMean to False in perc_v0m already. This will be used
  by the fitter in the future

