### PR TITLE
Update fitters

### DIFF
--- a/machine_learning_hep/fitting/fitters.py
+++ b/machine_learning_hep/fitting/fitters.py
@@ -338,6 +338,8 @@ class FitAliHF(FitROOT):
         self.kernel.SetInitialGaussianSigma(self.init_pars["sigma"])
 
         self.kernel.SetNSigma4SideBands(self.init_pars["n_sigma_sideband"])
+        if self.init_pars["fix_mean"]:
+            self.kernel.SetFixGaussianMean(self.init_pars["mean"])
         if self.init_pars["fix_sigma"]:
             self.kernel.SetFixGaussianSigma(self.init_pars["sigma"])
 


### PR DESCRIPTION
* already reading ML WPs from analysis section rather than from
  mlapplication section. Falling back to latter if former fails

* mean can actually be fixed now --> FixedMean is read from analysis
  section in DBs

* SetInitialGaussianMean in the analysis section of the DBs has a
  meaning now. If set, the masspeak value from the DB analysis section
  is taken for fit initialisation. It can be given as
    - a scalar value: used for all pT bins in all mult. bins
    - a list of length of pT bins: used per pT across all mult. bins
    - a list of mult and pT, hence a list of lists. the top list has
      n_mult_bins sub-lists of length n_pT_bins