### PR TITLE
Small tidying up

### DIFF
--- a/machine_learning_hep/analysis/systematics.py
+++ b/machine_learning_hep/analysis/systematics.py
@@ -89,12 +89,19 @@ class SystematicsMLWP: # pylint: disable=too-few-public-methods, too-many-instan
         if self.nominal_means:
             return
 
-        fitter = MLFitter(self.nominal_analyzer_merged.case,
-                          self.nominal_analyzer_merged.datap,
-                          self.nominal_analyzer_merged.typean,
-                          self.nominal_analyzer_merged.n_filemass,
-                          self.nominal_analyzer_merged.n_filemass_mc)
-        fitter.load_fits(self.nominal_analyzer_merged.fits_dirname)
+        # An analyzer has it only if the fitting procedure was done
+        # so if the nominal analyzer was run in the same process,
+        # we can just obtain everything from it already
+        fitter = self.nominal_analyzer_merged.fitter
+
+        if fitter is None:
+
+            fitter = MLFitter(self.nominal_analyzer_merged.case,
+                              self.nominal_analyzer_merged.datap,
+                              self.nominal_analyzer_merged.typean,
+                              self.nominal_analyzer_merged.n_filemass,
+                              self.nominal_analyzer_merged.n_filemass_mc)
+            fitter.load_fits(self.nominal_analyzer_merged.fits_dirname)
 
         ana_n_first_binning = self.nominal_analyzer_merged.p_nptbins
         ana_n_second_binning = self.nominal_analyzer_merged.p_nbin2

--- a/machine_learning_hep/fitting/fitters.py
+++ b/machine_learning_hep/fitting/fitters.py
@@ -115,7 +115,8 @@ class FitBase: # pylint: disable=too-many-instance-attributes
         #self.logger.debug("Following default parameters are used")
         #for p in pars_not_changed:
             #print(p)
-
+        if self.success:
+            return True
         return self.init_kernel()
 
 

--- a/machine_learning_hep/fitting/helpers.py
+++ b/machine_learning_hep/fitting/helpers.py
@@ -307,6 +307,7 @@ class MLFitParsFactory: # pylint: disable=too-many-instance-attributes, too-many
             histo_name = "h_invmass_weight" if self.apply_weights else "hmass"
             histo_data = file_data.Get(histo_name + suffix)
             histo_data.SetDirectory(0)
+            file_data.Close()
 
         if not (get_mc or get_reflections):
             return histo_data, None, None
@@ -320,6 +321,7 @@ class MLFitParsFactory: # pylint: disable=too-many-instance-attributes, too-many
         if get_reflections:
             histo_reflections = file_mc.Get("hmass_refl" + suffix)
             histo_reflections.SetDirectory(0)
+        file_mc.Close()
 
         return histo_data, histo_mc, histo_reflections
 

--- a/machine_learning_hep/fitting/utils.py
+++ b/machine_learning_hep/fitting/utils.py
@@ -45,6 +45,7 @@ def save_fit(fit, save_dir, annotations=None):
         if root_object:
             root_object.Write(name)
     fit.kernel.Write("kernel")
+    root_file.Close()
 
     yaml_path = join(save_dir, "init_pars.yaml")
     dump_yaml_from_dict(fit.init_pars, yaml_path)
@@ -96,10 +97,11 @@ def load_fit(save_dir):
         obj = k.ReadObj()
         obj.SetDirectory(0)
         root_objects[k.GetName()] = obj
+    root_file.Close()
 
     fit.set_root_objects(root_objects)
-    fit.init_fit()
     fit.success = meta_info["success"]
+    fit.init_fit()
 
     if "annotations" not in meta_info:
         return fit


### PR DESCRIPTION
* close ROOT files after usage in fitting, helpers and utils

* don't re-initialise a fitter kernel when fit is loaded from disk

* obtain fitter from nominal analyzer if available in ML syst