### PR TITLE
Ds vs mult analysis: Small fixes and extra features

### DIFF
--- a/machine_learning_hep/analysis/analyzerdhadrons_mult.py
+++ b/machine_learning_hep/analysis/analyzerdhadrons_mult.py
@@ -58,6 +58,10 @@ class AnalyzerDhadrons_mult(Analyzer): # pylint: disable=invalid-name
         self.triggerbit = datap["analysis"][self.typean]["triggerbit"]
         self.p_nbin2 = len(self.lvar2_binmin)
 
+        self.do_inel0 = datap["analysis"][self.typean].get("apply_inel0_sel", \
+                                  [None for _ in range(len(self.lvar2_binmin))])
+        self.inel0_var = datap["analysis"][self.typean].get("inel0_var", "n_tracklets")
+
         self.d_resultsallpmc = datap["analysis"][typean]["mc"]["results"][period] \
                 if period is not None else datap["analysis"][typean]["mc"]["resultsallp"]
         self.d_resultsallpdata = datap["analysis"][typean]["data"]["results"][period] \
@@ -497,6 +501,15 @@ class AnalyzerDhadrons_mult(Analyzer): # pylint: disable=invalid-name
             norm = self.calculate_norm(hsel, hnovtx, hvtxout,
                                        self.lvar2_binmin[imult],
                                        self.lvar2_binmax[imult])
+            if self.do_inel0[imult] is not None:
+                labeltrigger_inel0 = "hbit%svs%s_ibin2_%d" % (self.triggerbit, self.inel0_var, \
+                                                              imult)
+                if self.apply_weights is True:
+                    labeltrigger_inel0 = labeltrigger_inel0 + "_weight"
+                hsel_inel0 = filemass.Get("sel_%s" % labeltrigger_inel0)
+                hnovtx_inel0 = filemass.Get("novtx_%s" % labeltrigger_inel0)
+                hvtxout_inel0 = filemass.Get("vtxout_%s" % labeltrigger_inel0)
+                norm = self.calculate_norm(hsel_inel0, hnovtx_inel0, hvtxout_inel0, 1, 999)
             histonorm.SetBinContent(imult + 1, norm)
             # pylint: disable=logging-not-lazy
             self.logger.warning("Number of events %d for mult bin %d" % (norm, imult))

--- a/machine_learning_hep/analysis/systematics.py
+++ b/machine_learning_hep/analysis/systematics.py
@@ -491,6 +491,14 @@ class SystematicsMLWP: # pylint: disable=too-few-public-methods, too-many-instan
         save_path = join(self.nominal_analyzer_merged.d_resultsallpdata, self.syst_out_dir,
                          f"ml_wp_syst_{name}_ibin2_{ibin2}.eps")
         canvas.SaveAs(save_path)
+        save_path = join(self.nominal_analyzer_merged.d_resultsallpdata, self.syst_out_dir,
+                         f"ml_wp_syst_{name}_ibin2_{ibin2}.root")
+        file_out = TFile.Open(save_path, "RECREATE")
+        file_out.cd()
+        for i, h in enumerate(histos):
+            h.Write("%s%d" % (h.GetName(), i))
+        canvas.Write()
+        file_out.Close()
         canvas.Close()
 
     def __make_summary_plot(self, name, ibin2, successful):
@@ -536,6 +544,14 @@ class SystematicsMLWP: # pylint: disable=too-few-public-methods, too-many-instan
         save_path = join(self.nominal_analyzer_merged.d_resultsallpdata, self.syst_out_dir,
                          f"ml_wp_syst_{name}_vs_MLcut_ibin2_{ibin2}.eps")
         canvas.SaveAs(save_path)
+        save_path = join(self.nominal_analyzer_merged.d_resultsallpdata, self.syst_out_dir,
+                         f"ml_wp_syst_{name}_vs_MLcut_ibin2_{ibin2}.root")
+        file_out = TFile.Open(save_path, "RECREATE")
+        file_out.cd()
+        for i, graph in enumerate(gr):
+            graph.Write("%s%d" % (graph.GetName(), i))
+        canvas.Write()
+        file_out.Close()
         canvas.Close()
 
     def __plot(self, successful):

--- a/machine_learning_hep/data/data_Dspp/database_ml_parameters_Dspp.yml
+++ b/machine_learning_hep/data/data_Dspp/database_ml_parameters_Dspp.yml
@@ -405,7 +405,7 @@ Dspp:
       nbinshisto: 100001
       minvaluehisto: -0.0005
       maxvaluehisto: 100.0005
-      triggereff: [1,0.921,0.890,0.997,1]
+      triggereff: [1,0.920,0.897,0.998,1]
       triggereffunc: [0,0,0,0,0]    #To be added/checked if interesting
       triggerbit: INT7
       event_cand_validation: False

--- a/machine_learning_hep/data/data_Dspp/database_ml_parameters_Dspp.yml
+++ b/machine_learning_hep/data/data_Dspp/database_ml_parameters_Dspp.yml
@@ -415,11 +415,10 @@ Dspp:
       include_reflection: False
       presel_gen_eff: "abs(y_cand) < 0.5 and abs(z_vtx_gen) < 10"
       evtsel: is_ev_rej==0
-      #INEL>0 requirement. Takes a long time, do this once and copy masshistograms when rerunning is better (disable for cut variation)
-      #A different implementation will be pushed to master, then this has to be changed
-      evtsel_array: [null, "n_tracklets_corr > 0", "n_tracklets_corr > 0", "n_tracklets_corr > 0", "n_tracklets_corr > 0"]
-      #evtsel_array: [null, "n_tracklets > 0", "n_tracklets > 0", "n_tracklets > 0", "n_tracklets > 0"] #negligible differencce with n_tracklets_corr
       mc_cut_on_binning2: False
+      #INEL>0 requirement. Takes a long time, do this once and copy masshistograms when rerunning is better (disable for cut variation)
+      apply_inel0_sel: [false, true, true, true, true]
+      inel0_var: n_tracklets_corr
 
       event_weighting_mc:
         LHC16pp_Ds:

--- a/machine_learning_hep/data/data_Dspp/database_ml_parameters_Dspp_HMSPD.yml
+++ b/machine_learning_hep/data/data_Dspp/database_ml_parameters_Dspp_HMSPD.yml
@@ -121,8 +121,8 @@ Dspp:
                                  /mnt/temp/OngoingAnalysis_D2HvsMult/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_data/504_20200911-2312/pklskml] #list of periods
       pkl_skimmed_merge_for_ml_all: /mnt/temp/OngoingAnalysis_D2HvsMult/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_data/pp_data_mltot
       pkl_evtcounter_all: /mnt/temp/OngoingAnalysis_D2HvsMult/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_data/pp_data_evttot
-      mcreweights: [/home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/data_2016_train504,  
-                    /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/data_2017_train504,  
+      mcreweights: [/home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/data_2018_train504,  
+                    /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/data_2018_train504,  
                     /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/data_2018_train504] #list of periods
     mc:
       nprocessesparallel: 50
@@ -131,25 +131,25 @@ Dspp:
       chunksizeskim: [1000,1000,1000] #list of periods
       fracmerge: [1.0,1.0,1.0] #list of periods
       seedmerge: [12,12,12] #list of periods
-      period: [LHC16pp_Ds, LHC17pp_Ds, LHC18pp_Ds] #list of periods
-      select_children: [["child_11"], ["child_12"], ["child_13"]] # select children explicitly
-      unmerged_tree_dir: [/data/TTree/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim/505_20200911-2319/merged,
-                          /data/TTree/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim/505_20200911-2319/merged,
-                          /data/TTree/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim/505_20200911-2319/merged] #list of periods
-      pkl: [/data/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim_Ds/505_20200911-2319/pkl,
-            /data/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim_Ds/505_20200911-2319/pkl,
-            /data/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim_Ds/505_20200911-2319/pkl] #list of periods
-      pkl_skimmed: [/data/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim_Ds/505_20200911-2319/pklsk,
-                    /data/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim_Ds/505_20200911-2319/pklsk,
-                    /data/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim_Ds/505_20200911-2319/pklsk] #list of periods
-      pkl_skimmed_merge_for_ml: [/data/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim_Ds/505_20200911-2319/pklskml,
-                                 /data/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim_Ds/505_20200911-2319/pklskml,
-                                 /data/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim_Ds/505_20200911-2319/pklskml] #list of periods
-      pkl_skimmed_merge_for_ml_all: /data/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim_Ds/pp_mc_prodD2H_mltot
-      pkl_evtcounter_all: /data/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim_Ds/pp_mrc_prodD2H_evttot
-      mcreweights: [/home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodDs_2016_train505,
-                    /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodDs_2017_train505,
-                    /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodDs_2018_train505]
+      period: [LHC16pp_D2HHM, LHC17pp_D2HHM, LHC18pp_D2HHM] #list of periods
+      select_children: [["child_0"], ["child_0"], ["child_4"]] # select children explicitly
+      unmerged_tree_dir: [/mnt/temp/OngoingAnalysis_D2HvsMult/TTree/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim/506_20200911-2319/merged,
+                          /mnt/temp/OngoingAnalysis_D2HvsMult/TTree/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim/506_20200911-2319/merged,
+                          /mnt/temp/OngoingAnalysis_D2HvsMult/TTree/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim/506_20200911-2319/merged] #list of periods
+      pkl: [/mnt/temp/OngoingAnalysis_D2HvsMult/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim_D2HHM/506_20200911-2319/pkl,
+            /mnt/temp/OngoingAnalysis_D2HvsMult/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim_D2HHM/506_20200911-2319/pkl,
+            /mnt/temp/OngoingAnalysis_D2HvsMult/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim_D2HHM/506_20200911-2319/pkl] #list of periods
+      pkl_skimmed: [/mnt/temp/OngoingAnalysis_D2HvsMult/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim_D2HHM/506_20200911-2319/pklsk,
+                    /mnt/temp/OngoingAnalysis_D2HvsMult/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim_D2HHM/506_20200911-2319/pklsk,
+                    /mnt/temp/OngoingAnalysis_D2HvsMult/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim_D2HHM/506_20200911-2319/pklsk] #list of periods
+      pkl_skimmed_merge_for_ml: [/mnt/temp/OngoingAnalysis_D2HvsMult/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim_D2HHM/506_20200911-2319/pklskml,
+                                 /mnt/temp/OngoingAnalysis_D2HvsMult/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim_D2HHM/506_20200911-2319/pklskml,
+                                 /mnt/temp/OngoingAnalysis_D2HvsMult/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim_D2HHM/506_20200911-2319/pklskml] #list of periods
+      pkl_skimmed_merge_for_ml_all: /mnt/temp/OngoingAnalysis_D2HvsMult/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim_D2HHM/pp_mc_prodD2H_mltot
+      pkl_evtcounter_all: /mnt/temp/OngoingAnalysis_D2HvsMult/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim_D2HHM/pp_mrc_prodD2H_evttot
+      mcreweights: [/home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodD2HHM_2018_train506,
+                    /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodD2HHM_2018_train506,
+                    /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodD2HHM_2018_train506]
 
   ml:
     evtsel: is_ev_rej==0
@@ -201,12 +201,12 @@ Dspp:
                               /data/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_2017_data/504_20200911-2312/skpkldecmerged,
                               /data/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_2018_data/504_20200911-2312/skpkldecmerged] #list of periods
     mc:
-      pkl_skimmed_dec: [/data/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_2016_sim_Ds/505_20200911-2319/skpkldec,
-                        /data/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_2017_sim_Ds/505_20200911-2319/skpkldec,
-                        /data/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_2018_sim_Ds/505_20200911-2319/skpkldec] #list of periods
-      pkl_skimmed_decmerged: [/data/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_2016_sim_Ds/505_20200911-2319/skpkldecmerged,
-                              /data/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_2017_sim_Ds/505_20200911-2319/skpkldecmerged,
-                              /data/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_2018_sim_Ds/505_20200911-2319/skpkldecmerged] #list of periods
+      pkl_skimmed_dec: [/data/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_2016_sim_D2HHM/506_20200911-2319/skpkldec,
+                        /data/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_2017_sim_D2HHM/506_20200911-2319/skpkldec,
+                        /data/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_2018_sim_D2HHM/506_20200911-2319/skpkldec] #list of periods
+      pkl_skimmed_decmerged: [/data/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_2016_sim_D2HHM/506_20200911-2319/skpkldecmerged,
+                              /data/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_2017_sim_D2HHM/506_20200911-2319/skpkldecmerged,
+                              /data/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_2018_sim_D2HHM/506_20200911-2319/skpkldecmerged] #list of periods
     modelname: xgboost
     modelsperptbin: [Model_pT_1_2.model,
                      Model_pT_2_4.model,
@@ -232,16 +232,179 @@ Dspp:
     # MULTIPLICITY ANALYSES #
     #                       #
     #########################
+    SPDvspt_ntrkl:
+      proc_type: Dhadrons_mult
+      useperiod: [0, 0, 1]
+      plotbin: [0,0,0,0,0,1]
+      usesinglebineff: null
+      fprompt_from_mb: true
+      corresp_mb_typean: MBvspt_ntrkl
+      #corrEffMult: [false, true, true, true, true, true]
+      corrEffMult: [false, false, true, true, true, true]
+      #corrEffMult: [false, false, false, false, false, false]
+      sel_binmin2: [0,1,1,10,30,60] #list of var2 splittng nbins
+      sel_binmax2: [9999,9999,9,29,59,99] #list of var2 splitting nbins
+      var_binning2: n_tracklets_corr_sub
+      var_binning2_gen: n_tracklets_corr
+      nbinshisto: 200
+      minvaluehisto: -0.5
+      maxvaluehisto: 199.5
+      # here the trigger efficiency is set to 1. Corrections are implemented in the analysis step
+      triggereff: [1.,1.,1.,1.,1.,1.]
+      triggereffunc: [0.,0.,0.,0.,0.,0.]
+      triggerbit: HighMultSPD
+      isNbx2: False    #Estimate the feeddown systematic with Nb and Nbx2 method convolution
+      event_cand_validation: False #True, only False when need to speed up and weights already defined
+      sel_an_binmin: [1,2,4,6,8,12] #list of pt nbins
+      sel_an_binmax: [2,4,6,8,12,24] #list of pt nbins
+      binning_matching: [0,1,2,3,4,5] #list of pt nbins
+      include_reflection: False
+      presel_gen_eff: "abs(y_cand) < 0.5 and abs(z_vtx_gen) < 10"
+      evtsel: is_ev_rej==0
+
+      event_weighting_mc:
+        LHC16pp_D2HHM:
+          #Not there, but just to be safe (copy paste from 2018)
+          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodD2HHM_2018_train506/weights_n_tracklets_HM_Ds_data.root
+            histo_name: n_tracklets_0_LHC18pp_weights
+            according_to: n_tracklets
+          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodD2HHM_2018_train506/weights_n_tracklets_HM_Ds_data.root
+            histo_name: n_tracklets_0_LHC18pp_weights
+            according_to: n_tracklets
+          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodD2HHM_2018_train506/weights_n_tracklets_HM_Ds_data.root
+            histo_name: n_tracklets_0_LHC18pp_weights
+            according_to: n_tracklets
+          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodD2HHM_2018_train506/weights_n_tracklets_HM_Ds_data.root
+            histo_name: n_tracklets_0_LHC18pp_weights
+            according_to: n_tracklets
+          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodD2HHM_2018_train506/weights_n_tracklets_HM_Ds_data.root
+            histo_name: n_tracklets_0_LHC18pp_weights
+            according_to: n_tracklets
+          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodD2HHM_2018_train506/weights_n_tracklets_HM_Ds_data.root
+            histo_name: n_tracklets_0_LHC18pp_weights
+            according_to: n_tracklets
+        LHC17pp_D2HHM:
+          #Not there, but just to be safe (copy paste from 2018)
+          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodD2HHM_2018_train506/weights_n_tracklets_HM_Ds_data.root
+            histo_name: n_tracklets_0_LHC18pp_weights
+            according_to: n_tracklets
+          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodD2HHM_2018_train506/weights_n_tracklets_HM_Ds_data.root
+            histo_name: n_tracklets_0_LHC18pp_weights
+            according_to: n_tracklets
+          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodD2HHM_2018_train506/weights_n_tracklets_HM_Ds_data.root
+            histo_name: n_tracklets_0_LHC18pp_weights
+            according_to: n_tracklets
+          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodD2HHM_2018_train506/weights_n_tracklets_HM_Ds_data.root
+            histo_name: n_tracklets_0_LHC18pp_weights
+            according_to: n_tracklets
+          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodD2HHM_2018_train506/weights_n_tracklets_HM_Ds_data.root
+            histo_name: n_tracklets_0_LHC18pp_weights
+            according_to: n_tracklets
+          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodD2HHM_2018_train506/weights_n_tracklets_HM_Ds_data.root
+            histo_name: n_tracklets_0_LHC18pp_weights
+            according_to: n_tracklets
+        LHC18pp_D2HHM:
+          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodD2HHM_2018_train506/weights_n_tracklets_HM_Ds_data.root
+            histo_name: n_tracklets_0_LHC18pp_weights
+            according_to: n_tracklets
+          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodD2HHM_2018_train506/weights_n_tracklets_HM_Ds_data.root
+            histo_name: n_tracklets_0_LHC18pp_weights
+            according_to: n_tracklets
+          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodD2HHM_2018_train506/weights_n_tracklets_HM_Ds_data.root
+            histo_name: n_tracklets_0_LHC18pp_weights
+            according_to: n_tracklets
+          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodD2HHM_2018_train506/weights_n_tracklets_HM_Ds_data.root
+            histo_name: n_tracklets_0_LHC18pp_weights
+            according_to: n_tracklets
+          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodD2HHM_2018_train506/weights_n_tracklets_HM_Ds_data.root
+            histo_name: n_tracklets_0_LHC18pp_weights
+            according_to: n_tracklets
+          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodD2HHM_2018_train506/weights_n_tracklets_HM_Ds_data.root
+            histo_name: n_tracklets_0_LHC18pp_weights
+            according_to: n_tracklets
+
+      triggersel:
+        data: "trigger_hasbit_HighMultSPD==1"
+        mc: null
+        usetriggcorrfunc: False
+        #Needs improvement, look at implementation in workbranch_Ds
+
+      data:
+        runselection: [null, null, HighMultSPD2018]
+        results: [/data/DerivedResults/DsppvsMult/vAN-20200910_ROOT6-1/pp_2016_data/504_20200911-2312/resultsSPDvspt_ntrkl_final191020,
+                  /data/DerivedResults/DsppvsMult/vAN-20200910_ROOT6-1/pp_2017_data/504_20200911-2312/resultsSPDvspt_ntrkl_final191020,
+                  /data/DerivedResults/DsppvsMult/vAN-20200910_ROOT6-1/pp_2018_data/504_20200911-2312/resultsSPDvspt_ntrkl_final191020] #list of periods
+        resultsallp: /data/DerivedResults/DsppvsMult/vAN-20200910_ROOT6-1/pp_data/resultsSPDvspt_ntrkl_final191020
+      mc:
+        runselection: [null, null, HighMultSPD2018]
+        results: [/data/DerivedResults/DsppvsMult/vAN-20200910_ROOT6-1/pp_2016_sim_D2HHM/506_20200911-2319/resultsSPDvspt_ntrkl_final191020,
+                  /data/DerivedResults/DsppvsMult/vAN-20200910_ROOT6-1/pp_2017_sim_D2HHM/506_20200911-2319/resultsSPDvspt_ntrkl_final191020,
+                  /data/DerivedResults/DsppvsMult/vAN-20200910_ROOT6-1/pp_2018_sim_D2HHM/506_20200911-2319/resultsSPDvspt_ntrkl_final191020] #list of periods
+        resultsallp: /data/DerivedResults/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim_D2HHM/resultsSPDvspt_ntrkl_final191020
+
+      # The global mass limits
+      mass_fit_lim: [1.69, 2.21] # histogram range of the invariant mass distribution [GeV/c^2]
+      bin_width: 0.001 # bin width of the invariant mass histogram
+      # To initialize the individual fits in pT bins
+      # Decide whether to take the sigma from MC or data for individual fits
+      init_fits_from: [mc, data, data, data, data, data] # data or mc
+      sgnfunc: [kGaus,kGaus,kGaus,kGaus,kGaus,kGaus]
+      bkgfunc: [kExpo,Pol2,kExpo,kExpo,kExpo,kExpo]
+      masspeak: 1.969
+      massmin: [1.75, 1.78, 1.75, 1.75, 1.75, 1.75]
+      massmax: [2.15, 2.12, 2.15, 2.15, 2.15, 2.15]
+      rebin: [[6,6,6,6,6,6], [6,6,6,6,6,6],[6,6,6,6,6,6], [6,6,6,6,6,6],[6,6,6,6,6,6], [6,6,6,6,6,6]]
+      includesecpeak: [[true, true, true, true, true, true], [true, true, true, true, true, true],[true, true, true, true, true, true], [true, true, true, true, true, true],[true, true, true, true, true, true], [true, true, true, true, true, true]]
+      masssecpeak: 1.869
+      fix_masssecpeak: [[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false]]
+      #Fraction Dplus/Ds (taken from pp5TeV as we don't store it in TTrees)
+      widthsecpeak: 0.91
+      fix_widthsecpeak: true
+      # Fix mean and/or sigma
+      FixedMean: False
+      SetFixGaussianSigma: [true, true, true, true, true, true]
+      # Use value set for "masspeak" for initializing total fit, otherwise what is derived from MC fit is used
+      SetInitialGaussianMean: true
+      # Use values set for "sigmaarray" for initializing total fit (per pT bin),
+      # otherwise what is derived from MC fit is used
+      SetInitialGaussianSigma: [false, false, false, false, false, false]
+      # Max percentage deviation in sigma (from init) to be considered as a good fit
+      MaxPercSigmaDeviation: 0.5
+      # Number of initial signal sigmas around the mean to be excluded for side-band fit
+      exclude_nsigma_sideband: 4
+      # Sigma around mean where signal is integrated after total fit has been done
+      nsigma_signal: 3
+      dolikelihood: false
+      sigmaarray: [0.011,0.011,0.012,0.014,0.016,0.02]
+      FixedSigma: false
+      fitcase: Ds
+      latexnamehadron: "D_{s}^{+}"
+      latexbin2var: "n_{trkl}"
+      nevents: null
+      dodoublecross: false
+
+      systematics:
+        # For now don't do these things per pT bin
+        max_chisquare_ndf: 2.
+        rebin: [-1,0,1]
+        massmin: [1.69, 1.72, 1.75, 1.78, 1.81]
+        massmax: [2.09, 2.09, 2.12, 2.15, 2.18, 2.21]
+        bincount_sigma: [3.,5.]
+        bkg_funcs: [kExpo, Pol2] #[kExpo, Pol2, Pol1]
+        # Whether to include the free sigma option in the derivation of raw yield uncertainty in given pT bin
+        consider_free_sigma: [False, True, True, True, True, True]
+
     MBvspt_ntrkl:
+      #Doesn't work in this database due to MB and HM MCs. Run in MBvspt database and make sure directories are the same
       proc_type: Dhadrons_mult
       useperiod: [1,1,1]
       plotbin: [1,1,1,1,1,0]
       usesinglebineff: null
       fprompt_from_mb: true
       corresp_mb_typean: null
-      corrEffMult: [false,false,true,true,true,true] #Strategy for preliminary and paper proposal
-      #corrEffMult: [false,true,true,true,true,true] #Weighting also 1-999, strategy to be decided
-      #corrEffMult: [false, false, false, false, false, false] #Just for checking the weights
+      #corrEffMult: [false,true,true,true,true,true]
+      corrEffMult: [false,false,true,true,true,true]
+      #corrEffMult: [false,false,false,false,false,false]
       sel_binmin2: [0,1,1,10,30,60] #list of var2 splittng nbins
       sel_binmax2: [9999,9999,9,29,59,99] #list of var2 splitting nbins
       var_binning2: n_tracklets_corr_sub
@@ -331,9 +494,9 @@ Dspp:
         resultsallp: /data/DerivedResults/DsppvsMult/vAN-20200910_ROOT6-1/pp_data/resultsMBvspt_ntrkl_final191020
       mc:
         runselection: [null, null, null]
-        results: [/data/DerivedResults/DsppvsMult/vAN-20200910_ROOT6-1/pp_2016_sim_Ds/505_20200911-2319/resultsMBvspt_ntrkl_final191020,
-                  /data/DerivedResults/DsppvsMult/vAN-20200910_ROOT6-1/pp_2017_sim_Ds/505_20200911-2319/resultsMBvspt_ntrkl_final191020,
-                  /data/DerivedResults/DsppvsMult/vAN-20200910_ROOT6-1/pp_2018_sim_Ds/505_20200911-2319/resultsMBvspt_ntrkl_final191020] #list of periods
+        results: [/data/DerivedResults/DsppvsMult/vAN-20200910_ROOT6-1/pp_2016_sim_Ds/506_20200911-2319/resultsMBvspt_ntrkl_final191020,
+                  /data/DerivedResults/DsppvsMult/vAN-20200910_ROOT6-1/pp_2017_sim_Ds/506_20200911-2319/resultsMBvspt_ntrkl_final191020,
+                  /data/DerivedResults/DsppvsMult/vAN-20200910_ROOT6-1/pp_2018_sim_Ds/506_20200911-2319/resultsMBvspt_ntrkl_final191020] #list of periods
         resultsallp: /data/DerivedResults/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim_Ds/resultsMBvspt_ntrkl_final191020
 
       # The global mass limits
@@ -343,7 +506,7 @@ Dspp:
       # Decide whether to take the sigma from MC or data for individual fits
       init_fits_from: [mc, data, data, data, data, data] # data or mc
       sgnfunc: [kGaus,kGaus,kGaus,kGaus,kGaus,kGaus]
-      bkgfunc: [Pol2,Pol2,kExpo,kExpo,kExpo,kExpo]
+      bkgfunc: [kExpo,Pol2,kExpo,kExpo,kExpo,kExpo]
       masspeak: 1.969
       massmin: [1.75, 1.78, 1.75, 1.75, 1.75, 1.75]
       massmax: [2.15, 2.12, 2.15, 2.15, 2.15, 2.15]
@@ -386,166 +549,15 @@ Dspp:
         bincount_sigma: [3.,5.]
         bkg_funcs: [kExpo, Pol2] #[kExpo, Pol2, Pol1]
         # Whether to include the free sigma option in the derivation of raw yield uncertainty in given pT bin
-        consider_free_sigma: [False, True, True, True, True, True] #[True, True, True, True, True, True]
-
-    MBvspt_perc_v0m:
-      proc_type: Dhadrons_mult
-      useperiod: [1,1,1]
-      plotbin: [1,1,1,1,1]
-      usesinglebineff: null
-      fprompt_from_mb: true
-      corresp_mb_typean: null
-      #corrEffMult: [false, false, true, true, true] #Strategy for preliminary and paper proposal
-      corrEffMult: [false, true, true, true, true] #Weighting also 1-999, strategy to be decided
-      #corrEffMult: [false, false, false, false, false] #Just for checking the weights
-      sel_binmin2: [0,  0,  30, 0.1,0]
-      sel_binmax2: [101,100,100,30, 0.1] #101 just to have a different histoname
-      var_binning2: perc_v0m
-      var_binning2_gen: perc_v0m
-      nbinshisto: 100001
-      minvaluehisto: -0.0005
-      maxvaluehisto: 100.0005
-      triggereff: [1,0.921,0.890,0.997,1]
-      triggereffunc: [0,0,0,0,0]    #To be added/checked if interesting
-      triggerbit: INT7
-      event_cand_validation: False
-      sel_an_binmin: [1,2,4,6,8,12]  #list of pt nbins
-      sel_an_binmax: [2,4,6,8,12,24]  #list of pt nbins
-      binning_matching: [0,1,2,3,4,5]  #list of pt nbins
-      include_reflection: False
-      presel_gen_eff: "abs(y_cand) < 0.5 and abs(z_vtx_gen) < 10"
-      evtsel: is_ev_rej==0
-      #INEL>0 requirement. Takes a long time, do this once and copy masshistograms when rerunning is better (disable for cut variation)
-      #A different implementation will be pushed to master, then this has to be changed
-      evtsel_array: [null, "n_tracklets_corr > 0", "n_tracklets_corr > 0", "n_tracklets_corr > 0", "n_tracklets_corr > 0"]
-      #evtsel_array: [null, "n_tracklets > 0", "n_tracklets > 0", "n_tracklets > 0", "n_tracklets > 0"] #negligible differencce with n_tracklets_corr
-      mc_cut_on_binning2: False
-
-      event_weighting_mc:
-        LHC16pp_Ds:
-          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodDs_2016_train505/weights_n_tracklets_for_perc_v0m_MB_Ds_data.root
-            histo_name: n_tracklets_0_LHC16pp_weights
-            according_to: n_tracklets
-          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodDs_2016_train505/weights_n_tracklets_for_perc_v0m_MB_Ds_data.root
-            histo_name: n_tracklets_0_LHC16pp_weights
-            according_to: n_tracklets
-          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodDs_2016_train505/weights_n_tracklets_for_perc_v0m_MB_Ds_data.root
-            histo_name: n_tracklets_1_LHC16pp_weights
-            according_to: n_tracklets
-          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodDs_2016_train505/weights_n_tracklets_for_perc_v0m_MB_Ds_data.root
-            histo_name: n_tracklets_2_LHC16pp_weights
-            according_to: n_tracklets
-          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodDs_2016_train505/weights_n_tracklets_for_perc_v0m_MB_Ds_data.root
-            histo_name: n_tracklets_0_LHC16pp_weights
-            according_to: n_tracklets
-        LHC17pp_Ds:
-          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodDs_2017_train505/weights_n_tracklets_for_perc_v0m_MB_Ds_data.root
-            histo_name: n_tracklets_0_LHC17pp_weights
-            according_to: n_tracklets
-          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodDs_2017_train505/weights_n_tracklets_for_perc_v0m_MB_Ds_data.root
-            histo_name: n_tracklets_0_LHC17pp_weights
-            according_to: n_tracklets
-          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodDs_2017_train505/weights_n_tracklets_for_perc_v0m_MB_Ds_data.root
-            histo_name: n_tracklets_1_LHC17pp_weights
-            according_to: n_tracklets
-          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodDs_2017_train505/weights_n_tracklets_for_perc_v0m_MB_Ds_data.root
-            histo_name: n_tracklets_2_LHC17pp_weights
-            according_to: n_tracklets
-          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodDs_2017_train505/weights_n_tracklets_for_perc_v0m_MB_Ds_data.root
-            histo_name: n_tracklets_0_LHC17pp_weights
-            according_to: n_tracklets
-        LHC18pp_Ds:
-          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodDs_2018_train505/weights_n_tracklets_for_perc_v0m_MB_Ds_data.root
-            histo_name: n_tracklets_0_LHC18pp_weights
-            according_to: n_tracklets
-          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodDs_2018_train505/weights_n_tracklets_for_perc_v0m_MB_Ds_data.root
-            histo_name: n_tracklets_0_LHC18pp_weights
-            according_to: n_tracklets
-          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodDs_2018_train505/weights_n_tracklets_for_perc_v0m_MB_Ds_data.root
-            histo_name: n_tracklets_1_LHC18pp_weights
-            according_to: n_tracklets
-          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodDs_2018_train505/weights_n_tracklets_for_perc_v0m_MB_Ds_data.root
-            histo_name: n_tracklets_2_LHC18pp_weights
-            according_to: n_tracklets
-          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodDs_2018_train505/weights_n_tracklets_for_perc_v0m_MB_Ds_data.root
-            histo_name: n_tracklets_0_LHC18pp_weights
-            according_to: n_tracklets
-
-      triggersel:
-        data: "trigger_hasbit_INT7==1"
-        mc: null
-
-      data:
-        runselection: [null, null, null]
-        results: [/data/DerivedResults/DsppvsMult/vAN-20200910_ROOT6-1/pp_2016_data/504_20200911-2312/resultsMBvspt_perc_v0m_final191020,
-                  /data/DerivedResults/DsppvsMult/vAN-20200910_ROOT6-1/pp_2017_data/504_20200911-2312/resultsMBvspt_perc_v0m_final191020,
-                  /data/DerivedResults/DsppvsMult/vAN-20200910_ROOT6-1/pp_2018_data/504_20200911-2312/resultsMBvspt_perc_v0m_final191020] #list of periods
-        resultsallp: /data/DerivedResults/DsppvsMult/vAN-20200910_ROOT6-1/pp_data/resultsMBvspt_perc_v0m_final191020
-      mc:
-        runselection: [null, null, null]
-        results: [/data/DerivedResults/DsppvsMult/vAN-20200910_ROOT6-1/pp_2016_sim_D2H/505_20200911-2319/resultsMBvspt_perc_v0m_final191020,
-                  /data/DerivedResults/DsppvsMult/vAN-20200910_ROOT6-1/pp_2017_sim_D2H/505_20200911-2319/resultsMBvspt_perc_v0m_final191020,
-                  /data/DerivedResults/DsppvsMult/vAN-20200910_ROOT6-1/pp_2018_sim_D2H/505_20200911-2319/resultsMBvspt_perc_v0m_final191020] #list of periods
-        resultsallp: /data/DerivedResults/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim_D2H/resultsMBvspt_perc_v0m_final191020
-
-      # The global mass limits
-      mass_fit_lim: [1.69, 2.21] # histogram range of the invariant mass distribution [GeV/c^2]
-      bin_width: 0.001 # bin width of the invariant mass histogram
-      # To initialize the individual fits in pT bins
-      # Decide whether to take the sigma from MC or data for individual fits
-      init_fits_from: [mc, data, data, data, data, data] # data or mc
-      sgnfunc: [kGaus,kGaus,kGaus,kGaus,kGaus,kGaus]
-      bkgfunc: [Pol2,Pol2,kExpo,kExpo,kExpo,kExpo]
-      masspeak: 1.969
-      massmin: [1.75, 1.78, 1.75, 1.75, 1.75, 1.75]
-      massmax: [2.15, 2.12, 2.15, 2.15, 2.15, 2.15]
-      rebin: [[6,6,6,6,6,6], [6,6,6,6,6,6], [6,6,6,6,6,6], [6,6,6,6,6,6], [6,6,6,6,6,6]]
-      includesecpeak: [[true, true, true, true, true, true], [true, true, true, true, true, true], [true, true, true, true, true, true], [true, true, true, true, true, true], [true, true, true, true, true, true]]
-      masssecpeak: 1.869
-      fix_masssecpeak: [[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false]]
-      #Fraction Dplus/Ds (taken from pp5TeV as we don't store it in TTrees)
-      widthsecpeak: 0.91
-      fix_widthsecpeak: true
-      # Fix mean and/or sigma
-      FixedMean: False
-      SetFixGaussianSigma: [true, true, true, true, true, true]
-      # Use value set for "masspeak" for initializing total fit, otherwise what is derived from MC fit is used
-      SetInitialGaussianMean: true
-      # Use values set for "sigmaarray" for initializing total fit (per pT bin),
-      # otherwise what is derived from MC fit is used
-      SetInitialGaussianSigma: [false, false, false, false, false, false]
-      # Max percentage deviation in sigma (from init) to be considered as a good fit
-      MaxPercSigmaDeviation: 0.5
-      # Number of initial signal sigmas around the mean to be excluded for side-band fit
-      exclude_nsigma_sideband: 4
-      # Sigma around mean where signal is integrated after total fit has been done
-      nsigma_signal: 3
-      dolikelihood: false
-      sigmaarray: [0.011,0.011,0.012,0.014,0.016,0.02]
-      FixedSigma: false
-      fitcase: Ds
-      latexnamehadron: "D_{s}^{+}"
-      latexbin2var: "V0M_{perc}"
-      nevents: null
-      dodoublecross: false
-
-      systematics:
-        # For now don't do these things per pT bin
-        max_chisquare_ndf: 2.
-        rebin: [-1,0,1]
-        massmin: [1.69, 1.72, 1.75, 1.78, 1.81]
-        massmax: [2.09,2.09, 2.12, 2.15, 2.18, 2.21]
-        bincount_sigma: [3.,5.]
-        bkg_funcs: [kExpo, Pol2] #[kExpo, Pol2, Pol1]
-        # Whether to include the free sigma option in the derivation of raw yield uncertainty in given pT bin
-        consider_free_sigma: [True, True, True, True, True, True]
+        consider_free_sigma: [False, True, True, True, True, True]
 
   systematics:
     probvariation:
+      #Doesn't work yet for HM, since it needs to get fprompt from MB
       useperiod: [0,0,1] #period from where to define prob cuts
       ncutvar: 10 #number of looser and tighter variations
       maxperccutvar: 0.25 #max diff in efficiency for loosest/tightest var
-      #For multiclassificcatio, use low - high value convention, not looser-tighter
+      #For multiclassification, use low - high value convention, not looser-tighter
       cutvarminrange: [[0.002, 0.001], [0.005, 0.001], [0.005, 0.001], [0.005, 0.001], [0.005, 0.001], [0.005, 0.001]]
       cutvarmaxrange: [[0.02, 0.8], [0.07, 0.8], [0.07, 0.8], [0.30, 0.8], [0.20, 0.8], [0.8, 0.8]]
       fixedmean: True #Fix mean cutvar histo to central fit

--- a/machine_learning_hep/data/data_Dspp/database_ml_parameters_Dspp_HMV0M.yml
+++ b/machine_learning_hep/data/data_Dspp/database_ml_parameters_Dspp_HMV0M.yml
@@ -249,7 +249,7 @@ Dspp:
       nbinshisto: 100001
       minvaluehisto: -0.0005
       maxvaluehisto: 100.0005
-      triggereff: [1,0.921,0.890,0.997,1]
+      triggereff: [1,0.920,0.897,0.998,1]
       triggereffunc: [0,0,0,0,0]    #To be added/checked if interesting
       triggerbit: HighMultV0
       isNbx2: False    #Estimate the feeddown systematic with Nb and Nbx2 method convolution
@@ -403,7 +403,7 @@ Dspp:
       nbinshisto: 100001
       minvaluehisto: -0.0005
       maxvaluehisto: 100.0005
-      triggereff: [1,0.921,0.890,0.997,1]
+      triggereff: [1,0.920,0.897,0.998,1]
       triggereffunc: [0,0,0,0,0]    #To be added/checked if interesting
       triggerbit: INT7
       event_cand_validation: False

--- a/machine_learning_hep/data/data_Dspp/database_ml_parameters_Dspp_HMV0M.yml
+++ b/machine_learning_hep/data/data_Dspp/database_ml_parameters_Dspp_HMV0M.yml
@@ -121,8 +121,8 @@ Dspp:
                                  /mnt/temp/OngoingAnalysis_D2HvsMult/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_data/504_20200911-2312/pklskml] #list of periods
       pkl_skimmed_merge_for_ml_all: /mnt/temp/OngoingAnalysis_D2HvsMult/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_data/pp_data_mltot
       pkl_evtcounter_all: /mnt/temp/OngoingAnalysis_D2HvsMult/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_data/pp_data_evttot
-      mcreweights: [/home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/data_2016_train504,  
-                    /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/data_2017_train504,  
+      mcreweights: [/home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/data_2018_train504,  
+                    /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/data_2018_train504,  
                     /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/data_2018_train504] #list of periods
     mc:
       nprocessesparallel: 50
@@ -131,25 +131,25 @@ Dspp:
       chunksizeskim: [1000,1000,1000] #list of periods
       fracmerge: [1.0,1.0,1.0] #list of periods
       seedmerge: [12,12,12] #list of periods
-      period: [LHC16pp_Ds, LHC17pp_Ds, LHC18pp_Ds] #list of periods
-      select_children: [["child_11"], ["child_12"], ["child_13"]] # select children explicitly
-      unmerged_tree_dir: [/data/TTree/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim/505_20200911-2319/merged,
-                          /data/TTree/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim/505_20200911-2319/merged,
-                          /data/TTree/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim/505_20200911-2319/merged] #list of periods
-      pkl: [/data/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim_Ds/505_20200911-2319/pkl,
-            /data/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim_Ds/505_20200911-2319/pkl,
-            /data/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim_Ds/505_20200911-2319/pkl] #list of periods
-      pkl_skimmed: [/data/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim_Ds/505_20200911-2319/pklsk,
-                    /data/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim_Ds/505_20200911-2319/pklsk,
-                    /data/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim_Ds/505_20200911-2319/pklsk] #list of periods
-      pkl_skimmed_merge_for_ml: [/data/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim_Ds/505_20200911-2319/pklskml,
-                                 /data/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim_Ds/505_20200911-2319/pklskml,
-                                 /data/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim_Ds/505_20200911-2319/pklskml] #list of periods
-      pkl_skimmed_merge_for_ml_all: /data/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim_Ds/pp_mc_prodD2H_mltot
-      pkl_evtcounter_all: /data/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim_Ds/pp_mrc_prodD2H_evttot
-      mcreweights: [/home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodDs_2016_train505,
-                    /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodDs_2017_train505,
-                    /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodDs_2018_train505]
+      period: [LHC16pp_D2HHM, LHC17pp_D2HHM, LHC18pp_D2HHM] #list of periods
+      select_children: [["child_1"], ["child_2"], ["child_3"]] # select children explicitly
+      unmerged_tree_dir: [/mnt/temp/OngoingAnalysis_D2HvsMult/TTree/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim/506_20200911-2319/merged,
+                          /mnt/temp/OngoingAnalysis_D2HvsMult/TTree/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim/506_20200911-2319/merged,
+                          /mnt/temp/OngoingAnalysis_D2HvsMult/TTree/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim/506_20200911-2319/merged] #list of periods
+      pkl: [/mnt/temp/OngoingAnalysis_D2HvsMult/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim_D2HHMV0/506_20200911-2319/pkl,
+            /mnt/temp/OngoingAnalysis_D2HvsMult/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim_D2HHMV0/506_20200911-2319/pkl,
+            /mnt/temp/OngoingAnalysis_D2HvsMult/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim_D2HHMV0/506_20200911-2319/pkl] #list of periods
+      pkl_skimmed: [/mnt/temp/OngoingAnalysis_D2HvsMult/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim_D2HHMV0/506_20200911-2319/pklsk,
+                    /mnt/temp/OngoingAnalysis_D2HvsMult/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim_D2HHMV0/506_20200911-2319/pklsk,
+                    /mnt/temp/OngoingAnalysis_D2HvsMult/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim_D2HHMV0/506_20200911-2319/pklsk] #list of periods
+      pkl_skimmed_merge_for_ml: [/mnt/temp/OngoingAnalysis_D2HvsMult/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim_D2HHMV0/506_20200911-2319/pklskml,
+                                 /mnt/temp/OngoingAnalysis_D2HvsMult/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim_D2HHMV0/506_20200911-2319/pklskml,
+                                 /mnt/temp/OngoingAnalysis_D2HvsMult/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim_D2HHMV0/506_20200911-2319/pklskml] #list of periods
+      pkl_skimmed_merge_for_ml_all: /mnt/temp/OngoingAnalysis_D2HvsMult/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim_D2HHMV0/pp_mc_prodD2H_mltot
+      pkl_evtcounter_all: /mnt/temp/OngoingAnalysis_D2HvsMult/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim_D2HHMV0/pp_mrc_prodD2H_evttot
+      mcreweights: [/home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodD2HHMV0_2016_train506,
+                    /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodD2HHMV0_2017_train506,
+                    /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodD2HHMV0_2018_train506]
 
   ml:
     evtsel: is_ev_rej==0
@@ -201,12 +201,12 @@ Dspp:
                               /data/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_2017_data/504_20200911-2312/skpkldecmerged,
                               /data/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_2018_data/504_20200911-2312/skpkldecmerged] #list of periods
     mc:
-      pkl_skimmed_dec: [/data/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_2016_sim_Ds/505_20200911-2319/skpkldec,
-                        /data/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_2017_sim_Ds/505_20200911-2319/skpkldec,
-                        /data/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_2018_sim_Ds/505_20200911-2319/skpkldec] #list of periods
-      pkl_skimmed_decmerged: [/data/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_2016_sim_Ds/505_20200911-2319/skpkldecmerged,
-                              /data/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_2017_sim_Ds/505_20200911-2319/skpkldecmerged,
-                              /data/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_2018_sim_Ds/505_20200911-2319/skpkldecmerged] #list of periods
+      pkl_skimmed_dec: [/data/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_2016_sim_D2HHMV0/506_20200911-2319/skpkldec,
+                        /data/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_2017_sim_D2HHMV0/506_20200911-2319/skpkldec,
+                        /data/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_2018_sim_D2HHMV0/506_20200911-2319/skpkldec] #list of periods
+      pkl_skimmed_decmerged: [/data/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_2016_sim_D2HHMV0/506_20200911-2319/skpkldecmerged,
+                              /data/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_2017_sim_D2HHMV0/506_20200911-2319/skpkldecmerged,
+                              /data/Derived/DsppvsMult/vAN-20200910_ROOT6-1/pp_2018_sim_D2HHMV0/506_20200911-2319/skpkldecmerged] #list of periods
     modelname: xgboost
     modelsperptbin: [Model_pT_1_2.model,
                      Model_pT_2_4.model,
@@ -232,109 +232,106 @@ Dspp:
     # MULTIPLICITY ANALYSES #
     #                       #
     #########################
-    MBvspt_ntrkl:
+    V0vspt_perc_v0m:
       proc_type: Dhadrons_mult
-      useperiod: [1,1,1]
-      plotbin: [1,1,1,1,1,0]
+      useperiod: [1, 1, 1]
+      plotbin: [0,0,0,0,1]
       usesinglebineff: null
       fprompt_from_mb: true
-      corresp_mb_typean: null
-      corrEffMult: [false,false,true,true,true,true] #Strategy for preliminary and paper proposal
-      #corrEffMult: [false,true,true,true,true,true] #Weighting also 1-999, strategy to be decided
-      #corrEffMult: [false, false, false, false, false, false] #Just for checking the weights
-      sel_binmin2: [0,1,1,10,30,60] #list of var2 splittng nbins
-      sel_binmax2: [9999,9999,9,29,59,99] #list of var2 splitting nbins
-      var_binning2: n_tracklets_corr_sub
-      var_binning2_gen: n_tracklets_corr
-      nbinshisto: 200
-      minvaluehisto: -0.5
-      maxvaluehisto: 199.5
-      triggereff: [1,0.92,0.862,1,1,1]
-      triggereffunc: [0,0.003,0.018,0,0,0]
-      triggerbit: INT7
-      event_cand_validation: False
+      corresp_mb_typean: MBvspt_perc_v0m
+      #corrEffMult: [false, true, true, true, true]
+      corrEffMult: [false, false, true, true, true]
+      #corrEffMult: [false, false, false, false, false]
+      sel_binmin2: [0,  0,  30, 0.1,0] #list of var2 splittng nbins
+      sel_binmax2: [101,100,100,30, 0.1] #list of var2 splitting nbins
+      var_binning2: perc_v0m
+      var_binning2_gen: perc_v0m
+      nbinshisto: 100001
+      minvaluehisto: -0.0005
+      maxvaluehisto: 100.0005
+      triggereff: [1,0.921,0.890,0.997,1]
+      triggereffunc: [0,0,0,0,0]    #To be added/checked if interesting
+      triggerbit: HighMultV0
+      isNbx2: False    #Estimate the feeddown systematic with Nb and Nbx2 method convolution
+      event_cand_validation: False #True, only False when need to speed up and weights already defined
       sel_an_binmin: [1,2,4,6,8,12] #list of pt nbins
       sel_an_binmax: [2,4,6,8,12,24] #list of pt nbins
       binning_matching: [0,1,2,3,4,5] #list of pt nbins
       include_reflection: False
       presel_gen_eff: "abs(y_cand) < 0.5 and abs(z_vtx_gen) < 10"
       evtsel: is_ev_rej==0
+      #INEL>0 requirement. Takes a long time, do this once and copy masshistograms
+      #Effect for HMV0M bin is <0.1%, so not needed per se when in rush
+      evtsel_array: [null, "n_tracklets_corr > 0", "n_tracklets_corr > 0", "n_tracklets_corr > 0", "n_tracklets_corr > 0"]
+      #evtsel_array: [null, "n_tracklets > 0", "n_tracklets > 0", "n_tracklets > 0", "n_tracklets > 0"] #negligible differencce with n_tracklets_corr
+      mc_cut_on_binning2: False
 
       event_weighting_mc:
-        LHC16pp_Ds:
-          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodDs_2016_train505/weights_n_tracklets_MB_Ds_data.root
+        LHC16pp_D2HHM:
+          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodDs_2016_train505/weights_n_tracklets_for_perc_v0m_MB_Ds_data.root
             histo_name: n_tracklets_0_LHC16pp_weights
             according_to: n_tracklets
-          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodDs_2016_train505/weights_n_tracklets_MB_Ds_data.root
+          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodDs_2016_train505/weights_n_tracklets_for_perc_v0m_MB_Ds_data.root
             histo_name: n_tracklets_0_LHC16pp_weights
             according_to: n_tracklets
-          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodDs_2016_train505/weights_n_tracklets_MB_Ds_data.root
-            histo_name: n_tracklets_0_LHC16pp_weights
+          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodDs_2016_train505/weights_n_tracklets_for_perc_v0m_MB_Ds_data.root
+            histo_name: n_tracklets_1_LHC16pp_weights
             according_to: n_tracklets
-          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodDs_2016_train505/weights_n_tracklets_MB_Ds_data.root
-            histo_name: n_tracklets_0_LHC16pp_weights
+          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodDs_2016_train505/weights_n_tracklets_for_perc_v0m_MB_Ds_data.root
+            histo_name: n_tracklets_2_LHC16pp_weights
             according_to: n_tracklets
-          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodDs_2016_train505/weights_n_tracklets_MB_Ds_data.root
-            histo_name: n_tracklets_0_LHC16pp_weights
+          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodD2HHMV0_2016_train506/weights_n_tracklets_for_perc_v0m_HM_Ds_data.root
+            histo_name: n_tracklets_3_LHC16pp_weights
             according_to: n_tracklets
-          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodDs_2016_train505/weights_n_tracklets_MB_Ds_data.root
-            histo_name: n_tracklets_0_LHC16pp_weights
-            according_to: n_tracklets
-        LHC17pp_Ds:
-          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodDs_2017_train505/weights_n_tracklets_MB_Ds_data.root
+        LHC17pp_D2HHM:
+          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodDs_2017_train505/weights_n_tracklets_for_perc_v0m_MB_Ds_data.root
             histo_name: n_tracklets_0_LHC17pp_weights
             according_to: n_tracklets
-          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodDs_2017_train505/weights_n_tracklets_MB_Ds_data.root
+          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodDs_2017_train505/weights_n_tracklets_for_perc_v0m_MB_Ds_data.root
             histo_name: n_tracklets_0_LHC17pp_weights
             according_to: n_tracklets
-          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodDs_2017_train505/weights_n_tracklets_MB_Ds_data.root
-            histo_name: n_tracklets_0_LHC17pp_weights
+          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodDs_2017_train505/weights_n_tracklets_for_perc_v0m_MB_Ds_data.root
+            histo_name: n_tracklets_1_LHC17pp_weights
             according_to: n_tracklets
-          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodDs_2017_train505/weights_n_tracklets_MB_Ds_data.root
-            histo_name: n_tracklets_0_LHC17pp_weights
+          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodDs_2017_train505/weights_n_tracklets_for_perc_v0m_MB_Ds_data.root
+            histo_name: n_tracklets_2_LHC17pp_weights
             according_to: n_tracklets
-          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodDs_2017_train505/weights_n_tracklets_MB_Ds_data.root
-            histo_name: n_tracklets_0_LHC17pp_weights
+          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodD2HHMV0_2017_train506/weights_n_tracklets_for_perc_v0m_HM_Ds_data.root
+            histo_name: n_tracklets_3_LHC17pp_weights
             according_to: n_tracklets
-          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodDs_2017_train505/weights_n_tracklets_MB_Ds_data.root
-            histo_name: n_tracklets_0_LHC17pp_weights
-            according_to: n_tracklets
-        LHC18pp_Ds:
-          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodDs_2018_train505/weights_n_tracklets_MB_Ds_data.root
+        LHC18pp_D2HHM:
+          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodDs_2018_train505/weights_n_tracklets_for_perc_v0m_MB_Ds_data.root
             histo_name: n_tracklets_0_LHC18pp_weights
             according_to: n_tracklets
-          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodDs_2018_train505/weights_n_tracklets_MB_Ds_data.root
+          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodDs_2018_train505/weights_n_tracklets_for_perc_v0m_MB_Ds_data.root
             histo_name: n_tracklets_0_LHC18pp_weights
             according_to: n_tracklets
-          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodDs_2018_train505/weights_n_tracklets_MB_Ds_data.root
-            histo_name: n_tracklets_0_LHC18pp_weights
+          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodDs_2018_train505/weights_n_tracklets_for_perc_v0m_MB_Ds_data.root
+            histo_name: n_tracklets_1_LHC18pp_weights
             according_to: n_tracklets
-          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodDs_2018_train505/weights_n_tracklets_MB_Ds_data.root
-            histo_name: n_tracklets_0_LHC18pp_weights
+          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodDs_2018_train505/weights_n_tracklets_for_perc_v0m_MB_Ds_data.root
+            histo_name: n_tracklets_2_LHC18pp_weights
             according_to: n_tracklets
-          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodDs_2018_train505/weights_n_tracklets_MB_Ds_data.root
-            histo_name: n_tracklets_0_LHC18pp_weights
-            according_to: n_tracklets
-          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodDs_2018_train505/weights_n_tracklets_MB_Ds_data.root
-            histo_name: n_tracklets_0_LHC18pp_weights
+          - filepath: /home/lvermunt/MachineLearningHEP_Ds/MachineLearningHEP/Analyses/ALICE_D2H_vs_mult_pp13/reweighting/production504/prodD2HHMV0_2018_train506/weights_n_tracklets_for_perc_v0m_HM_Ds_data.root
+            histo_name: n_tracklets_3_LHC18pp_weights
             according_to: n_tracklets
 
       triggersel:
-        data: "trigger_hasbit_INT7==1"
+        data: "trigger_hasbit_HighMultV0==1"
         mc: null
 
       data:
-        runselection: [null, null, null]
-        results: [/data/DerivedResults/DsppvsMult/vAN-20200910_ROOT6-1/pp_2016_data/504_20200911-2312/resultsMBvspt_ntrkl_final191020,
-                  /data/DerivedResults/DsppvsMult/vAN-20200910_ROOT6-1/pp_2017_data/504_20200911-2312/resultsMBvspt_ntrkl_final191020,
-                  /data/DerivedResults/DsppvsMult/vAN-20200910_ROOT6-1/pp_2018_data/504_20200911-2312/resultsMBvspt_ntrkl_final191020] #list of periods
-        resultsallp: /data/DerivedResults/DsppvsMult/vAN-20200910_ROOT6-1/pp_data/resultsMBvspt_ntrkl_final191020
+        runselection: [V0vspt_perc_v0m_2016, null, null]
+        results: [/data/DerivedResults/DsppvsMult/vAN-20200910_ROOT6-1/pp_2016_data/504_20200911-2312/resultsV0vspt_perc_v0m_final191020,
+                  /data/DerivedResults/DsppvsMult/vAN-20200910_ROOT6-1/pp_2017_data/504_20200911-2312/resultsV0vspt_perc_v0m_final191020,
+                  /data/DerivedResults/DsppvsMult/vAN-20200910_ROOT6-1/pp_2018_data/504_20200911-2312/resultsV0vspt_perc_v0m_final191020] #list of periods
+        resultsallp: /data/DerivedResults/DsppvsMult/vAN-20200910_ROOT6-1/pp_data/resultsV0vspt_perc_v0m_final191020
       mc:
-        runselection: [null, null, null]
-        results: [/data/DerivedResults/DsppvsMult/vAN-20200910_ROOT6-1/pp_2016_sim_Ds/505_20200911-2319/resultsMBvspt_ntrkl_final191020,
-                  /data/DerivedResults/DsppvsMult/vAN-20200910_ROOT6-1/pp_2017_sim_Ds/505_20200911-2319/resultsMBvspt_ntrkl_final191020,
-                  /data/DerivedResults/DsppvsMult/vAN-20200910_ROOT6-1/pp_2018_sim_Ds/505_20200911-2319/resultsMBvspt_ntrkl_final191020] #list of periods
-        resultsallp: /data/DerivedResults/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim_Ds/resultsMBvspt_ntrkl_final191020
+        runselection: [V0vspt_perc_v0m_2016, null, null]
+        results: [/data/DerivedResults/DsppvsMult/vAN-20200910_ROOT6-1/pp_2016_sim_D2HHMV0/506_20200911-2319/resultsV0vspt_perc_v0m_final191020,
+                  /data/DerivedResults/DsppvsMult/vAN-20200910_ROOT6-1/pp_2017_sim_D2HHMV0/506_20200911-2319/resultsV0vspt_perc_v0m_final191020,
+                  /data/DerivedResults/DsppvsMult/vAN-20200910_ROOT6-1/pp_2018_sim_D2HHMV0/506_20200911-2319/resultsV0vspt_perc_v0m_final191020] #list of periods
+        resultsallp: /data/DerivedResults/DsppvsMult/vAN-20200910_ROOT6-1/pp_sim_D2HHMV0/resultsV0vspt_perc_v0m_final191020
 
       # The global mass limits
       mass_fit_lim: [1.69, 2.21] # histogram range of the invariant mass distribution [GeV/c^2]
@@ -347,10 +344,10 @@ Dspp:
       masspeak: 1.969
       massmin: [1.75, 1.78, 1.75, 1.75, 1.75, 1.75]
       massmax: [2.15, 2.12, 2.15, 2.15, 2.15, 2.15]
-      rebin: [[6,6,6,6,6,6], [6,6,6,6,6,6], [6,6,6,6,6,6], [6,6,6,6,6,6], [6,6,6,6,6,6], [6,6,6,6,6,6]]
-      includesecpeak: [[true, true, true, true, true, true], [true, true, true, true, true, true], [true, true, true, true, true, true], [true, true, true, true, true, true], [true, true, true, true, true, true], [true, true, true, true, true, true]]
+      rebin: [[6,6,6,6,6,6], [6,6,6,6,6,6],[6,6,6,6,6,6], [6,6,6,6,6,6],[6,6,6,6,6,6]]
+      includesecpeak: [[true, true, true, true, true, true], [true, true, true, true, true, true],[true, true, true, true, true, true], [true, true, true, true, true, true],[true, true, true, true, true, true]]
       masssecpeak: 1.869
-      fix_masssecpeak: [[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false]]
+      fix_masssecpeak: [[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false],[false, false, false, false, false, false]]
       #Fraction Dplus/Ds (taken from pp5TeV as we don't store it in TTrees)
       widthsecpeak: 0.91
       fix_widthsecpeak: true
@@ -373,7 +370,7 @@ Dspp:
       FixedSigma: false
       fitcase: Ds
       latexnamehadron: "D_{s}^{+}"
-      latexbin2var: "n_{trkl}"
+      latexbin2var: "V0M_{perc}"
       nevents: null
       dodoublecross: false
 
@@ -386,20 +383,21 @@ Dspp:
         bincount_sigma: [3.,5.]
         bkg_funcs: [kExpo, Pol2] #[kExpo, Pol2, Pol1]
         # Whether to include the free sigma option in the derivation of raw yield uncertainty in given pT bin
-        consider_free_sigma: [False, True, True, True, True, True] #[True, True, True, True, True, True]
+        consider_free_sigma: [True, True, True, True, True, True] #[False, True, True, True, True, True]
 
     MBvspt_perc_v0m:
+      #Doesn't work in this database due to MB and HM MCs. Run in MBvspt database and make sure directories are the same
       proc_type: Dhadrons_mult
       useperiod: [1,1,1]
-      plotbin: [1,1,1,1,1]
+      plotbin: [1,1,1,1,0]
       usesinglebineff: null
       fprompt_from_mb: true
       corresp_mb_typean: null
-      #corrEffMult: [false, false, true, true, true] #Strategy for preliminary and paper proposal
-      corrEffMult: [false, true, true, true, true] #Weighting also 1-999, strategy to be decided
-      #corrEffMult: [false, false, false, false, false] #Just for checking the weights
-      sel_binmin2: [0,  0,  30, 0.1,0]
-      sel_binmax2: [101,100,100,30, 0.1] #101 just to have a different histoname
+      #corrEffMult: [false, true, true, true, true]
+      corrEffMult: [false, false, true, true, true]
+      #corrEffMult: [false, false, false, false, false]
+      sel_binmin2: [0,  0,  30, 0.1,0] #list of var2 splittng nbins
+      sel_binmax2: [101,100,100,30, 0.1] #list of var2 splitting nbins
       var_binning2: perc_v0m
       var_binning2_gen: perc_v0m
       nbinshisto: 100001
@@ -415,8 +413,7 @@ Dspp:
       include_reflection: False
       presel_gen_eff: "abs(y_cand) < 0.5 and abs(z_vtx_gen) < 10"
       evtsel: is_ev_rej==0
-      #INEL>0 requirement. Takes a long time, do this once and copy masshistograms when rerunning is better (disable for cut variation)
-      #A different implementation will be pushed to master, then this has to be changed
+      #INEL>0: Takes a long time, do this once and copy masshistograms
       evtsel_array: [null, "n_tracklets_corr > 0", "n_tracklets_corr > 0", "n_tracklets_corr > 0", "n_tracklets_corr > 0"]
       #evtsel_array: [null, "n_tracklets > 0", "n_tracklets > 0", "n_tracklets > 0", "n_tracklets > 0"] #negligible differencce with n_tracklets_corr
       mc_cut_on_binning2: False
@@ -534,7 +531,7 @@ Dspp:
         max_chisquare_ndf: 2.
         rebin: [-1,0,1]
         massmin: [1.69, 1.72, 1.75, 1.78, 1.81]
-        massmax: [2.09,2.09, 2.12, 2.15, 2.18, 2.21]
+        massmax: [2.09, 2.09, 2.12, 2.15, 2.18, 2.21]
         bincount_sigma: [3.,5.]
         bkg_funcs: [kExpo, Pol2] #[kExpo, Pol2, Pol1]
         # Whether to include the free sigma option in the derivation of raw yield uncertainty in given pT bin
@@ -545,13 +542,12 @@ Dspp:
       useperiod: [0,0,1] #period from where to define prob cuts
       ncutvar: 10 #number of looser and tighter variations
       maxperccutvar: 0.25 #max diff in efficiency for loosest/tightest var
-      #For multiclassificcatio, use low - high value convention, not looser-tighter
+      #For multiclassification use low - high value convention, not looser-tighter
       cutvarminrange: [[0.002, 0.001], [0.005, 0.001], [0.005, 0.001], [0.005, 0.001], [0.005, 0.001], [0.005, 0.001]]
       cutvarmaxrange: [[0.02, 0.8], [0.07, 0.8], [0.07, 0.8], [0.30, 0.8], [0.20, 0.8], [0.8, 0.8]]
       fixedmean: True #Fix mean cutvar histo to central fit
       fixedsigma: True #Fix sigma cutvar histo to central fit
     mcptshape:
-      #Outdated, should be added again in package
       #FONLL / generated LHC19h4c1
       weights: [1.000000]
       #From SetPtWeightsFromFONLL13overLHC17c3a12 in AliPhysics

--- a/machine_learning_hep/data/data_Dspp/database_ml_parameters_Dspp_HMV0M.yml
+++ b/machine_learning_hep/data/data_Dspp/database_ml_parameters_Dspp_HMV0M.yml
@@ -260,11 +260,10 @@ Dspp:
       include_reflection: False
       presel_gen_eff: "abs(y_cand) < 0.5 and abs(z_vtx_gen) < 10"
       evtsel: is_ev_rej==0
-      #INEL>0 requirement. Takes a long time, do this once and copy masshistograms
-      #Effect for HMV0M bin is <0.1%, so not needed per se when in rush
-      evtsel_array: [null, "n_tracklets_corr > 0", "n_tracklets_corr > 0", "n_tracklets_corr > 0", "n_tracklets_corr > 0"]
-      #evtsel_array: [null, "n_tracklets > 0", "n_tracklets > 0", "n_tracklets > 0", "n_tracklets > 0"] #negligible differencce with n_tracklets_corr
       mc_cut_on_binning2: False
+      #INEL>0 requirement. Takes a long time, do this once and copy masshistograms when rerunning is better (disable for cut variation)
+      apply_inel0_sel: [false, true, true, true, true]
+      inel0_var: n_tracklets_corr
 
       event_weighting_mc:
         LHC16pp_D2HHM:
@@ -413,10 +412,10 @@ Dspp:
       include_reflection: False
       presel_gen_eff: "abs(y_cand) < 0.5 and abs(z_vtx_gen) < 10"
       evtsel: is_ev_rej==0
-      #INEL>0: Takes a long time, do this once and copy masshistograms
-      evtsel_array: [null, "n_tracklets_corr > 0", "n_tracklets_corr > 0", "n_tracklets_corr > 0", "n_tracklets_corr > 0"]
-      #evtsel_array: [null, "n_tracklets > 0", "n_tracklets > 0", "n_tracklets > 0", "n_tracklets > 0"] #negligible differencce with n_tracklets_corr
       mc_cut_on_binning2: False
+      #INEL>0 requirement. Takes a long time, do this once and copy masshistograms when rerunning is better (disable for cut variation)
+      apply_inel0_sel: [false, true, true, true, true]
+      inel0_var: n_tracklets_corr
 
       event_weighting_mc:
         LHC16pp_Ds:

--- a/machine_learning_hep/data/data_prod_20200304/database_ml_parameters_D0pp_0304.yml
+++ b/machine_learning_hep/data/data_prod_20200304/database_ml_parameters_D0pp_0304.yml
@@ -680,6 +680,11 @@ D0pp:
       include_reflection: True
       presel_gen_eff: "abs(y_cand) < 0.5 and abs(z_vtx_gen) < 10"
       evtsel: is_ev_rej==0
+      mc_cut_on_binning2: False
+      #INEL>0 requirement. Takes a long time, do this once and copy masshistograms when rerunning is better (disable for cut variation)
+      apply_inel0_sel: [false, true, true, true, true]
+      inel0_var: n_tracklets_corr
+
       triggersel:
         data: "trigger_hasbit_INT7==1"
         mc: null

--- a/machine_learning_hep/data/data_prod_20200304/database_ml_parameters_LcpK0spp_0304.yml
+++ b/machine_learning_hep/data/data_prod_20200304/database_ml_parameters_LcpK0spp_0304.yml
@@ -557,6 +557,9 @@ LcpK0spp:
       binning_matching: [0,1,2,3,4,5] #list of pt nbins
       presel_gen_eff: "abs(y_cand) < 0.5 and abs(z_vtx_gen) < 10"
       evtsel: is_ev_rej==0
+      #INEL>0 requirement. Takes a long time, do this once and copy masshistograms when rerunning is better (disable for cut variation)
+      apply_inel0_sel: [false, true, true, true, true]
+      inel0_var: n_tracklets_corr
 
       event_weighting_mc:
         LHC16pp:

--- a/machine_learning_hep/data/data_prod_20200304/database_ml_parameters_LcpK0spp_0304_HM_V0.yml
+++ b/machine_learning_hep/data/data_prod_20200304/database_ml_parameters_LcpK0spp_0304_HM_V0.yml
@@ -368,6 +368,9 @@ LcpK0spp:
       presel_gen_eff: "abs(y_cand) < 0.5 and abs(z_vtx_gen) < 10"
       evtsel: is_ev_rej==0
       mc_cut_on_binning2: False
+      #INEL>0 requirement. Takes a long time, do this once and copy masshistograms when rerunning is better (disable for cut variation)
+      apply_inel0_sel: [false, true, true, true, true]
+      inel0_var: n_tracklets_corr
 
       event_weighting_mc:
         LHC16pp:
@@ -489,6 +492,10 @@ LcpK0spp:
       binning_matching: [0,1,2,3,4,5] #list of pt nbins
       presel_gen_eff: "abs(y_cand) < 0.5 and abs(z_vtx_gen) < 10"
       evtsel: is_ev_rej==0
+      mc_cut_on_binning2: False
+      #INEL>0 requirement. Takes a long time, do this once and copy masshistograms when rerunning is better (disable for cut variation)
+      apply_inel0_sel: [false, true, true, true, true]
+      inel0_var: n_tracklets_corr
 
       event_weighting_mc:
         LHC16pp:

--- a/machine_learning_hep/data/data_prod_20200417/database_ml_parameters_D0pp_0417.yml
+++ b/machine_learning_hep/data/data_prod_20200417/database_ml_parameters_D0pp_0417.yml
@@ -677,7 +677,10 @@ D0pp:
       presel_gen_eff: "abs(y_cand) < 0.5 and abs(z_vtx_gen) < 10"
       evtsel: is_ev_rej==0
       mc_cut_on_binning2: False
-
+      #INEL>0 requirement. Takes a long time, do this once and copy masshistograms when rerunning is better (disable for cut variation)
+      apply_inel0_sel: [false, true, true, true, true]
+      inel0_var: n_tracklets_corr
+      
       event_weighting_mc:
         LHC16pp:
           - filepath: data/event_weighting_mc/weights_n_tracklets_MB_D0_data.root

--- a/machine_learning_hep/data/data_prod_20200417/database_ml_parameters_D0pp_0417_HM_V0.yml
+++ b/machine_learning_hep/data/data_prod_20200417/database_ml_parameters_D0pp_0417_HM_V0.yml
@@ -310,6 +310,9 @@ D0pp:
       presel_gen_eff: "abs(y_cand) < 0.5 and abs(z_vtx_gen) < 10"
       evtsel: is_ev_rej==0
       mc_cut_on_binning2: False
+      #INEL>0 requirement. Takes a long time, do this once and copy masshistograms when rerunning is better (disable for cut variation)
+      apply_inel0_sel: [false, true, true, true, true]
+      inel0_var: n_tracklets_corr
 
       event_weighting_mc:
         LHC16pp:
@@ -423,6 +426,11 @@ D0pp:
       include_reflection: True
       presel_gen_eff: "abs(y_cand) < 0.5 and abs(z_vtx_gen) < 10"
       evtsel: is_ev_rej==0
+      mc_cut_on_binning2: False
+      #INEL>0 requirement. Takes a long time, do this once and copy masshistograms when rerunning is better (disable for cut variation)
+      apply_inel0_sel: [false, true, true, true, true]
+      inel0_var: n_tracklets_corr
+      
       triggersel:
         data: "trigger_hasbit_INT7==1"
         mc: null

--- a/machine_learning_hep/fitting/helpers.py
+++ b/machine_learning_hep/fitting/helpers.py
@@ -470,6 +470,12 @@ class MLFitter: # pylint: disable=too-many-instance-attributes
                     histo_reflections=pars["histograms"]["reflections"])
             self.init_central_fits_from[(ibin1, ibin2)] = pars["init_from"]
             self.lock_override_init[(ibin1, ibin2)] = pars["lock_override_init"]
+
+        #Weights only make sense in HM bin, not in mult. integrated where we initialise.
+        #If weights are used, the initialised width doesn't make sense anymore
+        apply_weights_temp = self.pars_factory.apply_weights
+        self.pars_factory.apply_weights = False
+        for ibin1, ibin2, pars in self.pars_factory.yield_fit_pars():
             if ibin1 in pre_fits_bins1:
                 continue
 
@@ -483,6 +489,7 @@ class MLFitter: # pylint: disable=too-many-instance-attributes
                     histo=pars["histograms"]["data"], \
                     histo_mc=pars["histograms"]["mc"], \
                     histo_reflections=pars["histograms"]["reflections"])
+        self.pars_factory.apply_weights = apply_weights_temp
         self.is_initialized_fits = True
 
 

--- a/machine_learning_hep/processer.py
+++ b/machine_learning_hep/processer.py
@@ -284,8 +284,10 @@ class Processer: # pylint: disable=too-many-instance-attributes
         isselacc = selectfidacc(dfreco.pt_cand.values, dfreco.y_cand.values)
         dfreco = dfreco[np.array(isselacc, dtype=bool)]
         arraysub = [0 for ival in range(len(dfreco))]
+        n_tracklets = dfreco["n_tracklets"].values
         n_tracklets_corr = dfreco["n_tracklets_corr"].values
         n_tracklets_corr_shm = dfreco["n_tracklets_corr_shm"].values
+        n_tracklets_sub = None
         n_tracklets_corr_sub = None
         n_tracklets_corr_shm_sub = None
         for iprong in range(self.nprongs):
@@ -296,9 +298,11 @@ class Processer: # pylint: disable=too-many-instance-attributes
             ntrackletsthisprong = [1 if spdhits_thisprong[index] == 3 else 0 \
                                    for index in range(len(dfreco))]
             arraysub = np.add(ntrackletsthisprong, arraysub)
+        n_tracklets_sub = np.subtract(n_tracklets, arraysub)
         n_tracklets_corr_sub = np.subtract(n_tracklets_corr, arraysub)
         n_tracklets_corr_shm_sub = np.subtract(n_tracklets_corr_shm, arraysub)
 
+        dfreco["n_tracklets_sub"] = n_tracklets_sub
         dfreco["n_tracklets_corr_sub"] = n_tracklets_corr_sub
         dfreco["n_tracklets_corr_shm_sub"] = n_tracklets_corr_shm_sub
         if self.b_trackcuts is not None:


### PR DESCRIPTION
* Save histograms and canvas in root file in ML cut variation, so layout can be changed offline
* Fix for initialisation of widths for HMSPD case. The trigger weights were applied to 0-999, which makes the fit fail
* Databases for MB, HMSPD and HMV0M Ds analyses for paper proposal
* Add possibility to do INEL>0 selection
* Bug fix for efficiency when `is_ev_rej == 0` was not yet applied when unpacking (was not required for generated df)
* Calculate and store `n_tracklets_sub` as well (before only `n_tracklets_corr_sub`)