### PR TITLE
Major ML update

### DIFF
--- a/machine_learning_hep/analysis/analyzerdhadrons_mult.py
+++ b/machine_learning_hep/analysis/analyzerdhadrons_mult.py
@@ -451,7 +451,7 @@ class AnalyzerDhadrons_mult(Analyzer): # pylint: disable=invalid-name
         norm = -1
         if n_sel + n_vtxout > 0:
             norm = (n_sel + n_novtx) - n_novtx * n_vtxout / (n_sel + n_vtxout)
-        return norm
+        return n_sel, norm
 
     def makenormyields(self): # pylint: disable=import-outside-toplevel, too-many-branches
         gROOT.SetBatch(True)
@@ -503,17 +503,18 @@ class AnalyzerDhadrons_mult(Analyzer): # pylint: disable=invalid-name
                 hsel_inel0 = filemass.Get("sel_%s" % labeltrigger_inel0)
                 hnovtx_inel0 = filemass.Get("novtx_%s" % labeltrigger_inel0)
                 hvtxout_inel0 = filemass.Get("vtxout_%s" % labeltrigger_inel0)
-                norm = self.calculate_norm(hsel_inel0, hnovtx_inel0, hvtxout_inel0, 1, 999)
+                n_sel, norm = self.calculate_norm(hsel_inel0, hnovtx_inel0, hvtxout_inel0, 1, 999)
             else:
                 hsel = filemass.Get("sel_%s" % labeltrigger)
                 hnovtx = filemass.Get("novtx_%s" % labeltrigger)
                 hvtxout = filemass.Get("vtxout_%s" % labeltrigger)
-                norm = self.calculate_norm(hsel, hnovtx, hvtxout,
-                                           self.lvar2_binmin[imult],
-                                           self.lvar2_binmax[imult])
+                n_sel, norm = self.calculate_norm(hsel, hnovtx, hvtxout,
+                                                  self.lvar2_binmin[imult],
+                                                  self.lvar2_binmax[imult])
             histonorm.SetBinContent(imult + 1, norm)
             # pylint: disable=logging-not-lazy
-            self.logger.warning("Number of events %d for mult bin %d" % (norm, imult))
+            self.logger.warning("Number of events %d for mult bin %d" % (n_sel, imult))
+            self.logger.warning("Number of zvtx-corr events %d for mult bin %d" % (norm, imult))
             filecrossmb = None
             if self.p_fprompt_from_mb is True and self.p_fd_method == 2:
                 if self.p_corrmb_typean is not None:

--- a/machine_learning_hep/data/data_prod_20210223/database_ml_parameters_LcpK0spp.yml
+++ b/machine_learning_hep/data/data_prod_20210223/database_ml_parameters_LcpK0spp.yml
@@ -81,6 +81,19 @@ LcpK0spp:
                    imp_par_prong0, imp_par_prong1, imp_par_prong2, inv_mass_K0s, nsigTOF_Pr_0, nsigTPC_Pr_0, cos_t_star],
                    [dca_K0s, imp_par_K0s, d_len_K0s, armenteros_K0s, ctau_K0s, cos_p_K0s,
                    imp_par_prong0, imp_par_prong1, imp_par_prong2, inv_mass_K0s, nsigTOF_Pr_0, nsigTPC_Pr_0, cos_t_star]]
+    # Choose some selected variables for which distributions and correlations should be computed and plotted during ML
+    var_selected: [[dca_K0s, imp_par_K0s, d_len_K0s, armenteros_K0s, ctau_K0s, cos_p_K0s,
+                   imp_par_prong0, imp_par_prong1, imp_par_prong2, inv_mass_K0s, nsigTOF_Pr_0, nsigTPC_Pr_0, inv_mass],
+                   [dca_K0s, imp_par_K0s, d_len_K0s, armenteros_K0s, ctau_K0s, cos_p_K0s,
+                   imp_par_prong0, imp_par_prong1, imp_par_prong2, inv_mass_K0s, nsigTOF_Pr_0, nsigTPC_Pr_0, inv_mass],
+                   [dca_K0s, imp_par_K0s, d_len_K0s, armenteros_K0s, ctau_K0s, cos_p_K0s,
+                   imp_par_prong0, imp_par_prong1, imp_par_prong2, inv_mass_K0s, nsigTOF_Pr_0, nsigTPC_Pr_0, cos_t_star, inv_mass],
+                   [dca_K0s, imp_par_K0s, d_len_K0s, armenteros_K0s, ctau_K0s, cos_p_K0s,
+                   imp_par_prong0, imp_par_prong1, imp_par_prong2, inv_mass_K0s, nsigTOF_Pr_0, nsigTPC_Pr_0, cos_t_star, inv_mass],
+                   [dca_K0s, imp_par_K0s, d_len_K0s, armenteros_K0s, ctau_K0s, cos_p_K0s,
+                   imp_par_prong0, imp_par_prong1, imp_par_prong2, inv_mass_K0s, nsigTOF_Pr_0, nsigTPC_Pr_0, cos_t_star, inv_mass],
+                   [dca_K0s, imp_par_K0s, d_len_K0s, armenteros_K0s, ctau_K0s, cos_p_K0s,
+                   imp_par_prong0, imp_par_prong1, imp_par_prong2, inv_mass_K0s, nsigTOF_Pr_0, nsigTPC_Pr_0, cos_t_star, inv_mass]]
     var_boundaries: [cos_t_star, pt_cand]
     var_correlation:
       - [cos_t_star]
@@ -104,95 +117,93 @@ LcpK0spp:
 
     plot_options:
       prob_cut_scan:
-        cos_t_star:
-          xlim:
-            - -1
-            - 1
         pt_K0s:
-          xlim:
-            - 0
-            - 1
+          xlim: [0, 1]
         pt_prong0:
-          xlim:
-            - 0
-            - 1
+          xlim: [0, 1]
         pt_prong1:
-          xlim:
-            - 0
-            - 1
+          xlim: [0, 1]
         pt_prong2:
-          xlim:
-            - 0
-            - 1
-        nsigTOF_Pr_0:
-          xlim:
-            - -4
-            - 4
+          xlim: [0, 1]
         armenteros_K0s:
-          xlim:
-            - 0
-            - 2
-        signd0:
-          xlim:
-            - 0
-            - 0.3
+          xlim: [0, 10000]
+          xlabel: "\\mathrm{arm}"
         nsigTPC_Pr_0:
-          xlim:
-            - -4
-            - 4
-      eff_cut_scan:
-        cos_t_star:
-          xlim:
-            - -1
-            - 1
-        pt_K0s:
-          xlim:
-            - 0
-            - 1
-        pt_prong0:
-          xlim:
-            - 0
-            - 1
-        pt_prong1:
-          xlim:
-            - 0
-            - 1
-        pt_prong2:
-          xlim:
-            - 0
-            - 1
-        inv_mass_K0s:
-          xlim:
-            - 0.
-            - 0.04
-        armenteros_K0s:
-          xlim:
-            - 0
-            - 2
-        signd0:
-          xlim:
-            - 0
-            - 0.3
+          xlim: [-10, 10]
+          xlabel: "n\\sigma_\\mathrm{TPC}(p)"
         nsigTOF_Pr_0:
-          xlim:
-            - 0
-            - 1000
-        nsigTPC_Pr_0:
-          xlim:
-            - 0
-            - 4
+          xlim: [-100, 100]
+          xlabel: "n\\sigma_\\mathrm{TOF}(p)"
         imp_par_prong0:
-          xlim:
-            - 0
-            - 0.3
+          xlim: [-3, 3]
+          xlabel: "b_p"
+        imp_par_prong1:
+          xlim: [0, 60]
+          xlabel: "b_{\\pi^+}"
+        imp_par_prong2:
+          xlim: [0, 60]
+          xlabel: "b_{\\pi^-}"
         imp_par_K0s:
-          xlim:
-            - 0
-            - 1.
+          xlim: [-2, 2]
+          xlabel: "b_{V^0}"
         dca_K0s:
-          xlim:
-            - 0
-            - 1.
+            xlim: [0, 0.8]
+            xlabel: "\\mathrm{DCA}(\\pi^+,\\pi^-)"
+        inv_mass_K0s:
+            xlim: [0.45, 0.55]
+            xlabel: "m_\\mathrm{inv}(V^0)"
+        ctau_K0s:
+            xlim: [0, 150]
+            xlabel: "c\\tau(V^0)"
+        d_len_K0s:
+            xlim: [0, 300]
+            xlabel: "d_\\mathrm{len}(V^0)"
+        cos_p_K0s:
+            xlim: [0.997, 1]
+            xlabel: "\\cos\\theta_\\mathrm{point}(V^0)"
+        cos_t_star:
+            xlim: [-1, 1]
+            xlabel: "\\cos\\theta^\\star"
+        inv_mass:
+            xlim: [1.9,2.5]
+            xlabel: "m_\\mathrm{inv}(\\mathrm{\\Lambda}^+_\\mathrm{c})"
+
+      eff_cut_scan:
+        pt_K0s:
+          xlim: [0, 1]
+        pt_prong0:
+          xlim: [0, 1]
+        pt_prong1:
+          xlim: [0, 1]
+        pt_prong2:
+          xlim: [0, 1]
+        armenteros_K0s:
+          xlim: [0, 10000]
+        nsigTPC_Pr_0:
+          xlim: [-100, 100]
+        nsigTOF_Pr_0:
+          xlim: [-100, 100]
+        imp_par_prong0:
+            xlim: [-3, 3]
+        imp_par_prong1:
+            xlim: [-60, 60]
+        imp_par_prong2:
+            xlim: [-60, 60]
+        imp_par_K0s:
+            xlim: [-2, 2]
+        dca_K0s:
+            xlim: [0, 1.5]
+        inv_mass_K0s:
+            xlim: [0.45, 0.55]
+        ctau_K0s:
+            xlim: [0, 150]
+        d_len_K0s:
+            xlim: [0, 300]
+        cos_p_K0s:
+            xlim: [-1, 1]
+        cos_t_star:
+            xlim: [-1, 1]
+
 
   files_names:
     namefile_unmerged_tree: AnalysisResults.root
@@ -219,7 +230,10 @@ LcpK0spp:
       maxfiles: [-1,-1,-1] #list of periods
       chunksizeunp: [100,100,100] #list of periods
       chunksizeskim: [100,100,100] #list of periods
-      fracmerge: [0.1, 0.1, 0.1]  #list of periods
+      fracmerge:
+        - [0.02, 0.03, 0.1, 0.4, 0.52, 0.8]  #list of periods
+        - [0.02, 0.03, 0.1, 0.4, 0.52, 0.8]  #list of periods
+        - [0.02, 0.03, 0.1, 0.4, 0.52, 0.8]  #list of periods
       seedmerge: [12,12,12] #list of periods
       period: [LHC16pp,LHC17pp,LHC18pp] #list of periods
       unmerged_tree_dir: [/data/TTree/D0DsLckINT7HighMultCalo_withJets/vAN-20210223_ROOT6-1/pp_data/593_20210223-2051/merged,
@@ -282,6 +296,10 @@ LcpK0spp:
     test_frac: 0.2
     binmin: [1,2,4,6,8,12] #list of nbins
     binmax: [2,4,6,8,12,24] #list of nbins
+    mask_values:
+      - name: nsigTOF_Pr_0
+        query: "nsigTOF_Pr_0 <= -999"
+        value: Null
     mltype: BinaryClassification
     ncorescrossval: 10
     mlplot: /data/Derived/LckINT7HighMultCalo_withJets/vAN-20210223_ROOT6-1/mlplot # to be removed

--- a/machine_learning_hep/mlperformance.py
+++ b/machine_learning_hep/mlperformance.py
@@ -318,14 +318,15 @@ def roc_train_test(names, classifiers, x_train, y_train, x_test, y_test, suffix,
         roc_auc_test = auc(fpr_test, tpr_test)
         train_line = plt.plot(fpr_train, tpr_train, lw=3, alpha=0.4,
                               label=f'ROC {name} - Train set (AUC = {roc_auc_train:.4f})')
-        plt.plot(fpr_test, tpr_test, lw=3, alpha=0.8, c=train_line[0].get_color(),
+        plt.plot(fpr_test, tpr_test, lw=3, ls="-.", alpha=0.8, c=train_line[0].get_color(),
                  label=f'ROC {name} - Test set (AUC = {roc_auc_test:.4f})')
 
     plt.xlim([-0.05, 1.05])
     plt.ylim([-0.05, 1.05])
-    plt.xlabel('False Positive Rate', fontsize=20)
-    plt.ylabel('True Positive Rate', fontsize=20)
-    plt.legend(loc='lower right', prop={'size': 18})
+    plt.xlabel('False Positive Rate', fontsize=30)
+    plt.ylabel('True Positive Rate', fontsize=30)
+    plt.legend(loc='lower right', prop={'size': 25})
+    plt.tick_params(labelsize=20)
     plot_name = f'{folder}/ROCtraintest{suffix}.png'
     fig.savefig(plot_name)
     plot_name = plot_name.replace('png', 'pickle')

--- a/machine_learning_hep/steer_analysis.py
+++ b/machine_learning_hep/steer_analysis.py
@@ -201,10 +201,6 @@ def do_entire_analysis(data_config: dict, data_param: dict, data_param_overwrite
     if domergingperiodsdata is True:
         counter = counter + checkdir(dirpklmltotdata)
 
-    if doml is True:
-        counter = counter + checkdir(mlout)
-        counter = counter + checkdir(mlplot)
-
     if docontinueapplymc is False:
         if doapplymc is True:
             counter = counter + checkdirlist(dirpklskdecmc)
@@ -348,7 +344,7 @@ def do_entire_analysis(data_config: dict, data_param: dict, data_param_overwrite
         for binmin, binmax in zip(binminarray, binmaxarray):
             myopt = Optimiser(data_param[case], case, typean,
                               data_model[mltype], binmin, binmax,
-                              raahp[index], training_vars[index])
+                              raahp[index], training_vars[index], index)
             if docorrelation is True:
                 myopt.do_corr()
             if dotraining is True:

--- a/machine_learning_hep/templates_xgboost.py
+++ b/machine_learning_hep/templates_xgboost.py
@@ -30,16 +30,18 @@ def xgboost_classifier(model_config): # pylint: disable=W0613
 
 
 def xgboost_classifier_bayesian_space():
-    return {"max_depth": scope.int(hp.quniform("x_max_depth", 1, 6, 1)),
-            "n_estimators": scope.int(hp.quniform("x_n_estimators", 600, 1000, 1)),
-            "min_child_weight": scope.int(hp.quniform("x_min_child", 1, 4, 1)),
+    return {"max_depth": scope.int(hp.quniform("x_max_depth", 1, 3, 1)),
+            "n_estimators": scope.int(hp.quniform("x_n_estimators", 100, 1000, 1)),
+            "min_child_weight": scope.int(hp.quniform("x_min_child", 1, 10, 1)),
             "subsample": hp.uniform("x_subsample", 0.5, 0.9),
             "gamma": hp.uniform("x_gamma", 0.0, 0.2),
-            "colsample_bytree": hp.uniform("x_colsample_bytree", 0.5, 0.9),
+            "colsample_bytree": hp.uniform("x_colsample_bytree", 0.5, 1.),
+            "colsample_bylevel": hp.uniform("x_colsample_bylevel", 0.5, 1.),
+            "colsample_bynode": hp.uniform("x_colsample_bynode", 0.5, 1.),
+            #"max_delta_step": scope.int(hp.quniform("x_max_delta_step", 0, 8, 1)),
             "reg_lambda": hp.uniform("x_reg_lambda", 0, 1),
             "reg_alpha": hp.uniform("x_reg_alpha", 0, 1),
-            "learning_rate": hp.uniform("x_learning_rate", 0.05, 0.35),
-            "max_delta_step": scope.int(hp.quniform("x_max_delta_step", 0, 8, 2))}
+            "learning_rate": hp.uniform("x_learning_rate", 0.01, 0.5)}
 
 
 class XGBoostClassifierBayesianOpt(BayesianOpt):
@@ -65,4 +67,5 @@ def xgboost_classifier_bayesian_opt(model_config):
     bayesian_opt.scoring_opt = "AUC"
     bayesian_opt.low_is_better = False
     bayesian_opt.n_trials = 100
+    bayesian_opt.score_train_test_diff = 0.01
     return bayesian_opt

--- a/machine_learning_hep/utilities.py
+++ b/machine_learning_hep/utilities.py
@@ -51,6 +51,21 @@ def openfile(filename, attr):
         return lz4.frame.open(filename, attr)
     return open(filename, attr)
 
+def mask_df(df_to_mask, mask_config):
+    """
+    Mask potential values
+    """
+    for mc in mask_config:
+        if mc["name"] not in df_to_mask:
+            print(f"Nothing to mask for {mc['name']}, skip...")
+            continue
+        # find indices to mask which fulfil the query
+        print(f"Mask column {mc['name']} where '{mc['query']} with {mc['value']}")
+        df_to_mask[mc["name"]] = df_to_mask[mc["name"]].astype(float)
+        mask_indices = df_to_mask.query(mc["query"]).index
+        # Mask the at the column name with mask value
+        df_to_mask.loc[mask_indices, [mc["name"]]] = mc["value"]
+
 def selectdfquery(dfr, selection):
     """
     Query on dataframe
@@ -69,6 +84,17 @@ def selectdfrunlist(dfr, runlist, runvar):
         issel = select_runs(runlist_np, array_run_np)
         dfr = dfr[issel]
     return dfr
+
+def count_df_length_pkl(*pkls):
+    """
+    Count all entries in all pkls
+    """
+    count = 0
+    for pkl in pkls:
+        myfile = openfile(pkl, "rb")
+        df = pickle.load(myfile)
+        count += len(df.index)
+    return count
 
 def merge_method(listfiles, namemerged):
     """
@@ -150,20 +176,22 @@ def checkdir(mydir):
         exfolders = -1
     return exfolders
 
+def checkmakedir(mydir):
+    """
+    Makes directory using 'mkdir'
+    """
+    if os.path.exists(mydir):
+        print(f"Using already created folder {mydir}")
+        return
+    print("creating folder ", mydir)
+    os.makedirs(mydir)
+
 def checkmakedirlist(dirlist):
     """
     Makes directories from list using 'mkdir'
     """
     for mydir in dirlist:
-        print("creating folder ", mydir)
-        os.makedirs(mydir)
-
-def checkmakedir(mydir):
-    """
-    Makes directory using 'mkdir'
-    """
-    print("creating folder ", mydir)
-    os.makedirs(mydir)
+        checkmakedir(mydir)
 
 def delete_dir(path: str):
     """

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ numpy==1.17.4
 pandas==0.24.2
 scipy==1.2.1
 matplotlib==3.0.3
-seaborn==0.9.0
+seaborn==0.11.1
 uproot==3.4.18
 scikit-learn==0.20.3
 xgboost==0.90

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
   # requirements files see:
   # https://packaging.python.org/en/latest/requirements.html
   install_requires=[ "numpy==1.17.4", "pandas==0.24.2", "scipy==1.4.1", "matplotlib==3.0.3",
-                     "seaborn==0.9.0", "uproot==3.4.18", "scikit-learn==0.20.3", "xgboost==0.90",
+                     "seaborn==0.11.1", "uproot==3.4.18", "scikit-learn==0.20.3", "xgboost==0.90",
                      "keras==2.3.1", "tensorflow==2.3.1", "PyYaml==5.1", "pylint",
                      "twisted==19.2.0", "klein==17.10.0", "Jinja2==2.10.3", "numba==0.48.0",
                      "pyarrow==0.13.0", "lz4==2.1.10", "hyperopt==0.2.3", "shap==v0.23.0"],


### PR DESCRIPTION


* possibility of masking values in a dataframe (see K0s dtabase of this
  commit). If masked set, training, testing is masked and also
  application application is masked

* each ML step can be repeated as often as the user wants. no forcing of
  deleting the ML directories anymore. However, what has been done is
  skipped but can be repeated by removing the corresponding entry in
  $MLDIR/steps_done.yaml
  Controllable PER pT bin

* prepared train and test dataframes are stored -> faster execution of
  most ML steps. If preparation should be done again, simply remove step
  for desired pT bin in $MLDIR/steps_done.yaml

* trained models are read back from disk if they exist. If training to
  be done again, simply remove in $MLDIR/steps_done.yaml

* choose as many bkg candidates as signal automatically

* possibility of latex labels for performance plots (correlation and
  feature separation plots and SHAP plots atm) Are defined in the
  database (see K0s database of this commit)

* add scaling by branching ratio back in significance optimisation

![CorrMatrix_Signal_selected_vars_nVar13_2 0_4 0](https://user-images.githubusercontent.com/22372527/112386216-e5c71000-8cf0-11eb-99b7-6ff0433d888a.png)

![importanceplotall_shap_LcpK0spp_dfselection_pt_cand_1 0_2 0](https://user-images.githubusercontent.com/22372527/112386255-f6778600-8cf0-11eb-97b7-1e3e3ccfccbe.png)

![ROCtraintestLcpK0spp_dfselection_pt_cand_6 0_8 0](https://user-images.githubusercontent.com/22372527/112386271-fe372a80-8cf0-11eb-8cf4-6bba1ba60ff2.png)

![variablesDistribution_nVar13_46](https://user-images.githubusercontent.com/22372527/112386304-08f1bf80-8cf1-11eb-8151-c2dfa94e9c27.png)
