### PR TITLE
Multiclass: adjusted plots in models.py and correlations.py

### DIFF
--- a/machine_learning_hep/correlations.py
+++ b/machine_learning_hep/correlations.py
@@ -18,24 +18,25 @@ Methods for correlation and variable plots
 import pickle
 from collections import deque
 import numpy as np
+import matplotlib as mpl
 import matplotlib.pyplot as plt
 from matplotlib.gridspec import GridSpec
 import seaborn as sns
 
 from machine_learning_hep.logger import get_logger
 
-#import matplotlib as mpl
 #mpl.use('Agg')
+
+HIST_COLORS = ['g', 'b', 'r']
 
 def vardistplot(dfs_input_, mylistvariables_, output_,
                 binmin, binmax, plot_options_):
+    mpl.rcParams.update({"text.usetex": True})
     plot_type_name = "prob_cut_scan"
     plot_options = plot_options_.get(plot_type_name, {}) \
             if isinstance(plot_options_, dict) else {}
 
-    colors = ['r', 'b', 'g']
     figure = plt.figure(figsize=(20, 15))
-
     figure.suptitle(f"Separation plots for ${binmin} < p_\\mathrm{{T}}/(\\mathrm{{GeV}}/c) < " \
                     f"{binmax}$", fontsize=30)
     for ind, var in enumerate(mylistvariables_, start=1):
@@ -46,7 +47,7 @@ def vardistplot(dfs_input_, mylistvariables_, output_,
         if "xlim" in po:
             kwargs["range"] = (po["xlim"][0], po["xlim"][1])
 
-        for label, color in zip(dfs_input_, colors):
+        for label, color in zip(dfs_input_, HIST_COLORS):
             plt.hist(dfs_input_[label][var], facecolor=color, label=label, **kwargs)
 
         var_tex = var.replace("_", ":")
@@ -58,7 +59,8 @@ def vardistplot(dfs_input_, mylistvariables_, output_,
         plt.ylabel(po.get("ylabel", "entries"), fontsize=11)
         ax.legend()
     plotname = f"{output_}/variablesDistribution_nVar{len(mylistvariables_)}_{binmin}{binmax}.png"
-    plt.savefig(plotname, bbox_inches='tight')
+    figure.savefig(plotname, bbox_inches='tight')
+    mpl.rcParams.update({"text.usetex": False})
     plt.close(figure)
 
 def vardistplot_probscan(dataframe_, mylistvariables_, modelname_, thresharray_, # pylint: disable=too-many-statements
@@ -127,7 +129,7 @@ def vardistplot_probscan(dataframe_, mylistvariables_, modelname_, thresharray_,
             axes[i].bar(center, his, align='center', width=width, facecolor=clr, label=lbl)
             axes[i].legend(fontsize=10)
     plotname = f"{output_}/variables_distribution_{suffix_}_ratio{opt}.png"
-    plt.savefig(plotname, bbox_inches='tight')
+    figure.savefig(plotname, bbox_inches='tight')
     plt.close(figure)
 
 def efficiency_cutscan(dataframe_, mylistvariables_, modelname_, threshold, # pylint: disable=too-many-statements
@@ -202,7 +204,7 @@ def efficiency_cutscan(dataframe_, mylistvariables_, modelname_, threshold, # py
         axes[i].bar(center, ratios, align='center', width=width, label=lbl)
         axes[i].legend(fontsize=30)
     plotname = f"{output_}/variables_effscan_prob{threshold}_{suffix_}.png"
-    plt.savefig(plotname, bbox_inches='tight')
+    figure.savefig(plotname, bbox_inches='tight')
     plt.close(figure)
 
 def picklesize_cutscan(dataframe_, mylistvariables_, output_, suffix_, plot_options_=None): # pylint: disable=too-many-statements
@@ -272,28 +274,27 @@ def picklesize_cutscan(dataframe_, mylistvariables_, output_, suffix_, plot_opti
                     alpha=0.5)
         axes[i].legend(fontsize=30)
     plotname = f"{output_}/variables_cutscan_picklesize_{suffix_}.png"
-    plt.savefig(plotname, bbox_inches='tight')
+    figure.savefig(plotname, bbox_inches='tight')
     plt.close(figure)
 
 
 def scatterplot(dfs_input_, mylistvariablesx_,
                 mylistvariablesy_, output_, binmin, binmax):
-    colors = ['r', 'b', 'g']
     figurecorr = plt.figure(figsize=(30, 20)) # pylint: disable=unused-variable
     for ind, (var_x, var_y) in enumerate(zip(mylistvariablesx_, mylistvariablesy_), start=1):
         axcorr = plt.subplot(3, int(len(mylistvariablesx_)/3+1), ind)
         plt.xlabel(var_x, fontsize=11)
         plt.ylabel(var_y, fontsize=11)
         title_str = 'Pearson coef. '
-        for label, color in zip(dfs_input_, colors):
+        for label, color in zip(dfs_input_, HIST_COLORS):
             plt.scatter(dfs_input_[label][var_x], dfs_input_[label][var_y],
                         alpha=0.4, c=color, label=label)
             pearson = dfs_input_[label].corr(numeric_only=True)[var_x][var_y].round(2)
             title_str += f'{label}: {pearson}, '
-        plt.title(title_str)
+        plt.title(title_str[:-2])
         axcorr.legend()
     plotname = f"{output_}/variablesScatterPlot{binmin}{binmax}.png"
-    plt.savefig(plotname, bbox_inches='tight')
+    figurecorr.savefig(plotname, bbox_inches='tight')
     plt.close(figurecorr)
 
 
@@ -304,6 +305,7 @@ def correlationmatrix(dataframe, mylistvariables, label, output, binmin, binmax,
     mask = np.triu(np.ones_like(corr, dtype=bool))
     _, ax = plt.subplots(figsize=(10, 8))
     #sns.heatmap(corr, mask=np.zeros_like(corr, dtype=np.bool),
+    mpl.rcParams.update({"text.usetex": True})
     plot_type_name = "prob_cut_scan"
     plot_options = plot_options_.get(plot_type_name, {}) \
             if isinstance(plot_options_, dict) else {}
@@ -323,4 +325,5 @@ def correlationmatrix(dataframe, mylistvariables, label, output, binmin, binmax,
     ax.text(0.7, 0.9, f"${binmin} < p_\\mathrm{{T}}/(\\mathrm{{GeV}}/c) < {binmax}$\n{label}",
             verticalalignment='center', transform=ax.transAxes, fontsize=13)
     plt.savefig(output, bbox_inches='tight')
+    mpl.rcParams.update({"text.usetex": False})
     plt.close()

--- a/machine_learning_hep/correlations.py
+++ b/machine_learning_hep/correlations.py
@@ -18,24 +18,23 @@ Methods for correlation and variable plots
 import pickle
 from collections import deque
 import numpy as np
-import matplotlib as mpl
 import matplotlib.pyplot as plt
 from matplotlib.gridspec import GridSpec
 import seaborn as sns
 
 from machine_learning_hep.logger import get_logger
 
+#import matplotlib as mpl
 #mpl.use('Agg')
 
 def vardistplot(dfs_input_, mylistvariables_, output_,
                 binmin, binmax, plot_options_):
-    mpl.rcParams.update({"text.usetex": True})
     plot_type_name = "prob_cut_scan"
     plot_options = plot_options_.get(plot_type_name, {}) \
             if isinstance(plot_options_, dict) else {}
 
     colors = ['r', 'b', 'g']
-    figure = plt.figure(figsize=(20, 15)) # pylint: disable=unused-variable
+    figure = plt.figure(figsize=(20, 15))
 
     figure.suptitle(f"Separation plots for ${binmin} < p_\\mathrm{{T}}/(\\mathrm{{GeV}}/c) < " \
                     f"{binmax}$", fontsize=30)
@@ -60,7 +59,6 @@ def vardistplot(dfs_input_, mylistvariables_, output_,
         ax.legend()
     plotname = f"{output_}/variablesDistribution_nVar{len(mylistvariables_)}_{binmin}{binmax}.png"
     plt.savefig(plotname, bbox_inches='tight')
-    mpl.rcParams.update({"text.usetex": False})
     plt.close(figure)
 
 def vardistplot_probscan(dataframe_, mylistvariables_, modelname_, thresharray_, # pylint: disable=too-many-statements
@@ -72,9 +70,9 @@ def vardistplot_probscan(dataframe_, mylistvariables_, modelname_, thresharray_,
         plot_options = plot_options_.get(plot_type_name, {})
     color = ['C0', 'C1', 'C2', 'C3', 'C4', 'C5', 'C6', 'C7', 'C8', 'C9']
 
-    fig = plt.figure(figsize=(60, 25))
+    figure = plt.figure(figsize=(60, 25))
     gs = GridSpec(3, int(len(mylistvariables_)/3+1))
-    axes = [fig.add_subplot(gs[i]) for i in range(len(mylistvariables_))]
+    axes = [figure.add_subplot(gs[i]) for i in range(len(mylistvariables_))]
 
     # Sort the thresharray_
     thresharray_.sort()
@@ -130,6 +128,7 @@ def vardistplot_probscan(dataframe_, mylistvariables_, modelname_, thresharray_,
             axes[i].legend(fontsize=10)
     plotname = f"{output_}/variables_distribution_{suffix_}_ratio{opt}.png"
     plt.savefig(plotname, bbox_inches='tight')
+    plt.close(figure)
 
 def efficiency_cutscan(dataframe_, mylistvariables_, modelname_, threshold, # pylint: disable=too-many-statements
                        output_, suffix_, plot_options_=None):
@@ -141,9 +140,9 @@ def efficiency_cutscan(dataframe_, mylistvariables_, modelname_, threshold, # py
     selml = f"y_test_prob{modelname_}>{threshold}"
     dataframe_ = dataframe_.query(selml)
 
-    fig = plt.figure(figsize=(60, 25))
+    figure = plt.figure(figsize=(60, 25))
     gs = GridSpec(3, int(len(mylistvariables_)/3+1))
-    axes = [fig.add_subplot(gs[i]) for i in range(len(mylistvariables_))]
+    axes = [figure.add_subplot(gs[i]) for i in range(len(mylistvariables_))]
 
     # Available cut options
     cut_options = ["lt", "st", "abslt", "absst"]
@@ -204,7 +203,7 @@ def efficiency_cutscan(dataframe_, mylistvariables_, modelname_, threshold, # py
         axes[i].legend(fontsize=30)
     plotname = f"{output_}/variables_effscan_prob{threshold}_{suffix_}.png"
     plt.savefig(plotname, bbox_inches='tight')
-    plt.savefig(plotname, bbox_inches='tight')
+    plt.close(figure)
 
 def picklesize_cutscan(dataframe_, mylistvariables_, output_, suffix_, plot_options_=None): # pylint: disable=too-many-statements
 
@@ -213,9 +212,9 @@ def picklesize_cutscan(dataframe_, mylistvariables_, output_, suffix_, plot_opti
     if isinstance(plot_options_, dict):
         plot_options = plot_options_.get(plot_type_name, {})
 
-    fig = plt.figure(figsize=(60, 25))
+    figure = plt.figure(figsize=(60, 25))
     gs = GridSpec(3, int(len(mylistvariables_)/3+1))
-    axes = [fig.add_subplot(gs[i]) for i in range(len(mylistvariables_))]
+    axes = [figure.add_subplot(gs[i]) for i in range(len(mylistvariables_))]
 
     df_reference_pkl_size = len(pickle.dumps(dataframe_, protocol=4))
     df_reference_size = dataframe_.shape[0] * dataframe_.shape[1]
@@ -274,6 +273,7 @@ def picklesize_cutscan(dataframe_, mylistvariables_, output_, suffix_, plot_opti
         axes[i].legend(fontsize=30)
     plotname = f"{output_}/variables_cutscan_picklesize_{suffix_}.png"
     plt.savefig(plotname, bbox_inches='tight')
+    plt.close(figure)
 
 
 def scatterplot(dfs_input_, mylistvariablesx_,
@@ -304,7 +304,6 @@ def correlationmatrix(dataframe, mylistvariables, label, output, binmin, binmax,
     mask = np.triu(np.ones_like(corr, dtype=bool))
     _, ax = plt.subplots(figsize=(10, 8))
     #sns.heatmap(corr, mask=np.zeros_like(corr, dtype=np.bool),
-    mpl.rcParams.update({"text.usetex": True})
     plot_type_name = "prob_cut_scan"
     plot_options = plot_options_.get(plot_type_name, {}) \
             if isinstance(plot_options_, dict) else {}
@@ -324,5 +323,4 @@ def correlationmatrix(dataframe, mylistvariables, label, output, binmin, binmax,
     ax.text(0.7, 0.9, f"${binmin} < p_\\mathrm{{T}}/(\\mathrm{{GeV}}/c) < {binmax}$\n{label}",
             verticalalignment='center', transform=ax.transAxes, fontsize=13)
     plt.savefig(output, bbox_inches='tight')
-    mpl.rcParams.update({"text.usetex": False})
     plt.close()

--- a/machine_learning_hep/correlations.py
+++ b/machine_learning_hep/correlations.py
@@ -1,5 +1,5 @@
 #############################################################################
-##  © Copyright CERN 2018. All rights not expressly granted are reserved.  ##
+##  © Copyright CERN 2023. All rights not expressly granted are reserved.  ##
 ##                 Author: Gian.Michele.Innocenti@cern.ch                  ##
 ## This program is free software: you can redistribute it and/or modify it ##
 ##  under the terms of the GNU General Public License as published by the  ##

--- a/machine_learning_hep/correlations.py
+++ b/machine_learning_hep/correlations.py
@@ -16,9 +16,7 @@
 Methods for correlation and variable plots
 """
 import pickle
-from os.path import join
 from collections import deque
-from io import BytesIO
 import numpy as np
 import matplotlib as mpl
 import matplotlib.pyplot as plt
@@ -29,29 +27,28 @@ from machine_learning_hep.logger import get_logger
 
 #mpl.use('Agg')
 
-def vardistplot(dataframe_sig_, dataframe_bkg_, mylistvariables_, output_,
+def vardistplot(dfs_input_, mylistvariables_, output_,
                 binmin, binmax, plot_options_):
     mpl.rcParams.update({"text.usetex": True})
     plot_type_name = "prob_cut_scan"
     plot_options = plot_options_.get(plot_type_name, {}) \
             if isinstance(plot_options_, dict) else {}
 
-
+    colors = ['r', 'b', 'g']
     figure = plt.figure(figsize=(20, 15)) # pylint: disable=unused-variable
 
     figure.suptitle(f"Separation plots for ${binmin} < p_\\mathrm{{T}}/(\\mathrm{{GeV}}/c) < " \
                     f"{binmax}$", fontsize=30)
-    i = 1
-    for var in mylistvariables_:
-        ax = plt.subplot(3, int(len(mylistvariables_)/3+1), i)
+    for ind, var in enumerate(mylistvariables_, start=1):
+        ax = plt.subplot(3, int(len(mylistvariables_)/3+1), ind)
         plt.yscale('log')
-        kwargs = dict(alpha=0.3, density=True, bins=100)
+        kwargs = {"alpha": 0.3, "density": True, "bins": 100}
         po = plot_options.get(var, {})
         if "xlim" in po:
             kwargs["range"] = (po["xlim"][0], po["xlim"][1])
 
-        plt.hist(dataframe_sig_[var], facecolor='b', label='signal', **kwargs)
-        plt.hist(dataframe_bkg_[var], facecolor='g', label='background', **kwargs)
+        for label, color in zip(dfs_input_, colors):
+            plt.hist(dfs_input_[label][var], facecolor=color, label=label, **kwargs)
 
         var_tex = var.replace("_", ":")
         if "xlim" in po:
@@ -61,16 +58,10 @@ def vardistplot(dataframe_sig_, dataframe_bkg_, mylistvariables_, output_,
         plt.xlabel(var_tex, fontsize=11)
         plt.ylabel(po.get("ylabel", "entries"), fontsize=11)
         ax.legend()
-        i = i+1
-    plotname = output_+'/variablesDistribution_nVar%d_%d%d.png' % \
-                            (len(mylistvariables_), binmin, binmax)
+    plotname = f"{output_}/variablesDistribution_nVar{len(mylistvariables_)}_{binmin}{binmax}.png"
     plt.savefig(plotname, bbox_inches='tight')
-    imagebytesIO = BytesIO()
-    plt.savefig(imagebytesIO, format='png')
-    imagebytesIO.seek(0)
     mpl.rcParams.update({"text.usetex": False})
     plt.close(figure)
-    return imagebytesIO
 
 def vardistplot_probscan(dataframe_, mylistvariables_, modelname_, thresharray_, # pylint: disable=too-many-statements
                          output_, suffix_, opt=1, plot_options_=None):
@@ -137,7 +128,7 @@ def vardistplot_probscan(dataframe_, mylistvariables_, modelname_, thresharray_,
                 axes[i].set_ylim(0.001, 1.1)
             axes[i].bar(center, his, align='center', width=width, facecolor=clr, label=lbl)
             axes[i].legend(fontsize=10)
-    plotname = join(output_, f"variables_distribution_{suffix_}_ratio{opt}.png")
+    plotname = f"{output_}/variables_distribution_{suffix_}_ratio{opt}.png"
     plt.savefig(plotname, bbox_inches='tight')
 
 def efficiency_cutscan(dataframe_, mylistvariables_, modelname_, threshold, # pylint: disable=too-many-statements
@@ -147,7 +138,7 @@ def efficiency_cutscan(dataframe_, mylistvariables_, modelname_, threshold, # py
     plot_options = {}
     if isinstance(plot_options_, dict):
         plot_options = plot_options_.get(plot_type_name, {})
-    selml = "y_test_prob%s>%s" % (modelname_, threshold)
+    selml = f"y_test_prob{modelname_}>{threshold}"
     dataframe_ = dataframe_.query(selml)
 
     fig = plt.figure(figsize=(60, 25))
@@ -211,7 +202,7 @@ def efficiency_cutscan(dataframe_, mylistvariables_, modelname_, threshold, # py
         lbl = f'prob > {threshold}'
         axes[i].bar(center, ratios, align='center', width=width, label=lbl)
         axes[i].legend(fontsize=30)
-    plotname = join(output_, f"variables_effscan_prob{threshold}_{suffix_}.png")
+    plotname = f"{output_}/variables_effscan_prob{threshold}_{suffix_}.png"
     plt.savefig(plotname, bbox_inches='tight')
     plt.savefig(plotname, bbox_inches='tight')
 
@@ -281,37 +272,29 @@ def picklesize_cutscan(dataframe_, mylistvariables_, output_, suffix_, plot_opti
         axes[i].bar(center, ratios_df_size, align='center', width=width, label="rel. df length",
                     alpha=0.5)
         axes[i].legend(fontsize=30)
-    plotname = join(output_, f"variables_cutscan_picklesize_{suffix_}.png")
+    plotname = f"{output_}/variables_cutscan_picklesize_{suffix_}.png"
     plt.savefig(plotname, bbox_inches='tight')
 
-def scatterplot(dataframe_sig_, dataframe_bkg_, mylistvariablesx_,
+
+def scatterplot(dfs_input_, mylistvariablesx_,
                 mylistvariablesy_, output_, binmin, binmax):
+    colors = ['r', 'b', 'g']
     figurecorr = plt.figure(figsize=(30, 20)) # pylint: disable=unused-variable
-    i = 1
-    for j, _ in enumerate(mylistvariablesx_):
-        axcorr = plt.subplot(3, int(len(mylistvariablesx_)/3+1), i)
-        plt.xlabel(mylistvariablesx_[j], fontsize=11)
-        plt.ylabel(mylistvariablesy_[j], fontsize=11)
-        plt.scatter(
-            dataframe_bkg_[mylistvariablesx_[j]], dataframe_bkg_[mylistvariablesy_[j]],
-            alpha=0.4, c="g", label="background")
-        plt.scatter(
-            dataframe_sig_[mylistvariablesx_[j]], dataframe_sig_[mylistvariablesy_[j]],
-            alpha=0.4, c="b", label="signal")
-        plt.title(
-            'Pearson sgn: %s' %
-            dataframe_sig_.corr().loc[mylistvariablesx_[j]][mylistvariablesy_[j]].round(2)+
-            ',  Pearson bkg: %s' %
-            dataframe_bkg_.corr().loc[mylistvariablesx_[j]][mylistvariablesy_[j]].round(2))
+    for ind, (var_x, var_y) in enumerate(zip(mylistvariablesx_, mylistvariablesy_), start=1):
+        axcorr = plt.subplot(3, int(len(mylistvariablesx_)/3+1), ind)
+        plt.xlabel(var_x, fontsize=11)
+        plt.ylabel(var_y, fontsize=11)
+        title_str = 'Pearson coef. '
+        for label, color in zip(dfs_input_, colors):
+            plt.scatter(dfs_input_[label][var_x], dfs_input_[label][var_y],
+                        alpha=0.4, c=color, label=label)
+            pearson = dfs_input_[label].corr(numeric_only=True)[var_x][var_y].round(2)
+            title_str += f'{label}: {pearson}, '
+        plt.title(title_str)
         axcorr.legend()
-        i = i+1
-    plotname = output_+'/variablesScatterPlot%d%d.png' % (binmin, binmax)
+    plotname = f"{output_}/variablesScatterPlot{binmin}{binmax}.png"
     plt.savefig(plotname, bbox_inches='tight')
-    imagebytesIO = BytesIO()
-    plt.savefig(imagebytesIO, format='png')
-    imagebytesIO.seek(0)
     plt.close(figurecorr)
-    return imagebytesIO
 
 
 def correlationmatrix(dataframe, mylistvariables, label, output, binmin, binmax,
@@ -341,9 +324,5 @@ def correlationmatrix(dataframe, mylistvariables, label, output, binmin, binmax,
     ax.text(0.7, 0.9, f"${binmin} < p_\\mathrm{{T}}/(\\mathrm{{GeV}}/c) < {binmax}$\n{label}",
             verticalalignment='center', transform=ax.transAxes, fontsize=13)
     plt.savefig(output, bbox_inches='tight')
-    imagebytesIO = BytesIO()
-    plt.savefig(imagebytesIO, format='png')
-    imagebytesIO.seek(0)
     mpl.rcParams.update({"text.usetex": False})
     plt.close()
-    return imagebytesIO

--- a/machine_learning_hep/data/data_run3/database_ml_parameters_LcToPKPi.yml
+++ b/machine_learning_hep/data/data_run3/database_ml_parameters_LcToPKPi.yml
@@ -253,7 +253,7 @@ LcpKpi:
     binmax: [2,4,6,8,12,24] # must be equal to sel_skim_binmax (sel_skim_binmin bins)
     mltype: BinaryClassification
     ncorescrossval: 10
-    prefix_dir_ml: /data2/mkabus/MLHEP/results-refactor-test-corr/
+    prefix_dir_ml: /data2/MLhep/
     mlplot: mlplot # to be removed
     mlout: mlout # to be removed
 
@@ -277,11 +277,11 @@ LcpKpi:
 
   mlapplication:
     data:
-      prefix_dir_app: /data2/mkabus/MLHEP/results-refactor-test-corr/
+      prefix_dir_app: /data2/MLhep/
       pkl_skimmed_dec: [LHC22pp/MLapplication/prod_LHC22o/skpkldecdata] #list of periods
       pkl_skimmed_decmerged: [LHC22pp/MLapplication/prod_LHC22o/skpkldecdatamerged] #list of periods
     mc:
-      prefix_dir_app: /data2/mkabus/MLHEP/results-refactor-test-corr/
+      prefix_dir_app: /data2/MLhep/
       pkl_skimmed_dec: [LHC22pp_mc/MLapplication/prod_LHC22b1b/skpkldecmc,
                         LHC22pp_mc/MLapplication/prod_LHC22b1a/skpkldecmc,] #list of periods
       pkl_skimmed_decmerged: [LHC22pp_mc/MLapplication/prod_LHC22b1b/skpkldecmcmerged,
@@ -337,12 +337,12 @@ LcpKpi:
 
       data:
         runselection: [null] #FIXME
-        prefix_dir_res: /data2/mkabus/MLHEP/results-refactor-test-corr/
+        prefix_dir_res: /data2/MLhep/
         results: [LHC22pp/Results/prod_LHC22o/resultsdata] #list of periods
         resultsallp: LHC22pp/Results/resultsdatatot
       mc:
         runselection: [null, null] #FIXME
-        prefix_dir_res: /data2/mkabus/MLHEP/results-refactor-test-corr/
+        prefix_dir_res: /data2/MLhep/
         results: [LHC22pp_mc/Results/prod_LHC22b1b/resultsmc,
                   LHC22pp_mc/Results/prod_LHC22b1a/resultsmc] #list of periods
         resultsallp: LHC22pp_mc/Results/prod_LHC22/resultsmctot

--- a/machine_learning_hep/data/data_run3/database_ml_parameters_LcToPKPi.yml
+++ b/machine_learning_hep/data/data_run3/database_ml_parameters_LcToPKPi.yml
@@ -253,7 +253,7 @@ LcpKpi:
     binmax: [2,4,6,8,12,24] # must be equal to sel_skim_binmax (sel_skim_binmin bins)
     mltype: BinaryClassification
     ncorescrossval: 10
-    prefix_dir_ml: /data2/MLhep/
+    prefix_dir_ml: /data2/mkabus/MLHEP/results-myrun3-baseline/
     mlplot: mlplot # to be removed
     mlout: mlout # to be removed
 
@@ -277,11 +277,11 @@ LcpKpi:
 
   mlapplication:
     data:
-      prefix_dir_app: /data2/MLhep/
+      prefix_dir_app: /data2/mkabus/MLHEP/results-myrun3-baseline/
       pkl_skimmed_dec: [LHC22pp/MLapplication/prod_LHC22o/skpkldecdata] #list of periods
       pkl_skimmed_decmerged: [LHC22pp/MLapplication/prod_LHC22o/skpkldecdatamerged] #list of periods
     mc:
-      prefix_dir_app: /data2/MLhep/
+      prefix_dir_app: /data2/mkabus/MLHEP/results-myrun3-baseline/
       pkl_skimmed_dec: [LHC22pp_mc/MLapplication/prod_LHC22b1b/skpkldecmc,
                         LHC22pp_mc/MLapplication/prod_LHC22b1a/skpkldecmc,] #list of periods
       pkl_skimmed_decmerged: [LHC22pp_mc/MLapplication/prod_LHC22b1b/skpkldecmcmerged,
@@ -341,12 +341,12 @@ LcpKpi:
 
       data:
         runselection: [null] #FIXME
-        prefix_dir_res: /data2/MLhep/
+        prefix_dir_res: /data2/mkabus/MLHEP/results-myrun3-baseline/
         results: [LHC22pp/Results/prod_LHC22o/resultsdata] #list of periods
         resultsallp: LHC22pp/Results/resultsdatatot
       mc:
         runselection: [null, null] #FIXME
-        prefix_dir_res: /data2/MLhep/
+        prefix_dir_res: /data2/mkabus/MLHEP/results-myrun3-baseline/
         results: [LHC22pp_mc/Results/prod_LHC22b1b/resultsmc,
                   LHC22pp_mc/Results/prod_LHC22b1a/resultsmc] #list of periods
         resultsallp: LHC22pp_mc/Results/prod_LHC22/resultsmctot

--- a/machine_learning_hep/data/data_run3/database_ml_parameters_LcToPKPi.yml
+++ b/machine_learning_hep/data/data_run3/database_ml_parameters_LcToPKPi.yml
@@ -325,10 +325,6 @@ LcpKpi:
         - "fDecayLength > 0.02"
 
 
-      # To initialize the individual fits in pT bins
-      # Decide whether to take the sigma from MC or data for individual fits
-      init_fits_from: mc # data # data or mc
-
       sel_an_binmin: [1,2,4,6,8,12]
       sel_an_binmax: [2,4,6,8,12,24]
       binning_matching: [0,1,2,3,4,5]
@@ -353,6 +349,8 @@ LcpKpi:
 
       mass_fit_lim: [2.14, 2.436] # region for the fit of the invariant mass distribution [GeV/c^2]
       bin_width: 0.001 # bin width of the invariant mass histogram
+      # To initialize the individual fits in pT bins
+      # Decide whether to take the sigma from MC or data for individual fits
       init_fits_from: [mc,mc,mc,mc,mc,mc] # data or mc
       sgnfunc: [kGaus,kGaus,kGaus,kGaus,kGaus,kGaus]
       bkgfunc: [Pol2,Pol2,Pol2,Pol2,Pol2,Pol2]

--- a/machine_learning_hep/data/data_run3/database_ml_parameters_LcToPKPi.yml
+++ b/machine_learning_hep/data/data_run3/database_ml_parameters_LcToPKPi.yml
@@ -253,7 +253,7 @@ LcpKpi:
     binmax: [2,4,6,8,12,24] # must be equal to sel_skim_binmax (sel_skim_binmin bins)
     mltype: BinaryClassification
     ncorescrossval: 10
-    prefix_dir_ml: /data2/mkabus/MLHEP/results-myrun3-baseline/
+    prefix_dir_ml: /data2/mkabus/MLHEP/results-refactor-preprocess/
     mlplot: mlplot # to be removed
     mlout: mlout # to be removed
 
@@ -277,11 +277,11 @@ LcpKpi:
 
   mlapplication:
     data:
-      prefix_dir_app: /data2/mkabus/MLHEP/results-myrun3-baseline/
+      prefix_dir_app: /data2/mkabus/MLHEP/results-refactor-preprocess/
       pkl_skimmed_dec: [LHC22pp/MLapplication/prod_LHC22o/skpkldecdata] #list of periods
       pkl_skimmed_decmerged: [LHC22pp/MLapplication/prod_LHC22o/skpkldecdatamerged] #list of periods
     mc:
-      prefix_dir_app: /data2/mkabus/MLHEP/results-myrun3-baseline/
+      prefix_dir_app: /data2/mkabus/MLHEP/results-refactor-preprocess/
       pkl_skimmed_dec: [LHC22pp_mc/MLapplication/prod_LHC22b1b/skpkldecmc,
                         LHC22pp_mc/MLapplication/prod_LHC22b1a/skpkldecmc,] #list of periods
       pkl_skimmed_decmerged: [LHC22pp_mc/MLapplication/prod_LHC22b1b/skpkldecmcmerged,
@@ -341,12 +341,12 @@ LcpKpi:
 
       data:
         runselection: [null] #FIXME
-        prefix_dir_res: /data2/mkabus/MLHEP/results-myrun3-baseline/
+        prefix_dir_res: /data2/mkabus/MLHEP/results-refactor-preprocess/
         results: [LHC22pp/Results/prod_LHC22o/resultsdata] #list of periods
         resultsallp: LHC22pp/Results/resultsdatatot
       mc:
         runselection: [null, null] #FIXME
-        prefix_dir_res: /data2/mkabus/MLHEP/results-myrun3-baseline/
+        prefix_dir_res: /data2/mkabus/MLHEP/results-refactor-preprocess/
         results: [LHC22pp_mc/Results/prod_LHC22b1b/resultsmc,
                   LHC22pp_mc/Results/prod_LHC22b1a/resultsmc] #list of periods
         resultsallp: LHC22pp_mc/Results/prod_LHC22/resultsmctot

--- a/machine_learning_hep/data/data_run3/database_ml_parameters_LcToPKPi.yml
+++ b/machine_learning_hep/data/data_run3/database_ml_parameters_LcToPKPi.yml
@@ -253,7 +253,7 @@ LcpKpi:
     binmax: [2,4,6,8,12,24] # must be equal to sel_skim_binmax (sel_skim_binmin bins)
     mltype: BinaryClassification
     ncorescrossval: 10
-    prefix_dir_ml: /data2/mkabus/MLHEP/results-refactor-preprocess/
+    prefix_dir_ml: /data2/mkabus/MLHEP/results-refactor-test-corr/
     mlplot: mlplot # to be removed
     mlout: mlout # to be removed
 
@@ -277,11 +277,11 @@ LcpKpi:
 
   mlapplication:
     data:
-      prefix_dir_app: /data2/mkabus/MLHEP/results-refactor-preprocess/
+      prefix_dir_app: /data2/mkabus/MLHEP/results-refactor-test-corr/
       pkl_skimmed_dec: [LHC22pp/MLapplication/prod_LHC22o/skpkldecdata] #list of periods
       pkl_skimmed_decmerged: [LHC22pp/MLapplication/prod_LHC22o/skpkldecdatamerged] #list of periods
     mc:
-      prefix_dir_app: /data2/mkabus/MLHEP/results-refactor-preprocess/
+      prefix_dir_app: /data2/mkabus/MLHEP/results-refactor-test-corr/
       pkl_skimmed_dec: [LHC22pp_mc/MLapplication/prod_LHC22b1b/skpkldecmc,
                         LHC22pp_mc/MLapplication/prod_LHC22b1a/skpkldecmc,] #list of periods
       pkl_skimmed_decmerged: [LHC22pp_mc/MLapplication/prod_LHC22b1b/skpkldecmcmerged,
@@ -337,12 +337,12 @@ LcpKpi:
 
       data:
         runselection: [null] #FIXME
-        prefix_dir_res: /data2/mkabus/MLHEP/results-refactor-preprocess/
+        prefix_dir_res: /data2/mkabus/MLHEP/results-refactor-test-corr/
         results: [LHC22pp/Results/prod_LHC22o/resultsdata] #list of periods
         resultsallp: LHC22pp/Results/resultsdatatot
       mc:
         runselection: [null, null] #FIXME
-        prefix_dir_res: /data2/mkabus/MLHEP/results-refactor-preprocess/
+        prefix_dir_res: /data2/mkabus/MLHEP/results-refactor-test-corr/
         results: [LHC22pp_mc/Results/prod_LHC22b1b/resultsmc,
                   LHC22pp_mc/Results/prod_LHC22b1a/resultsmc] #list of periods
         resultsallp: LHC22pp_mc/Results/prod_LHC22/resultsmctot

--- a/machine_learning_hep/data/data_run3/database_ml_parameters_LcToPKPi_mult.yml
+++ b/machine_learning_hep/data/data_run3/database_ml_parameters_LcToPKPi_mult.yml
@@ -332,10 +332,6 @@ LcpKpi:
         - "fDecayLength > 0.02"
         - "fDecayLength > 0.02"
 
-      # To initialize the individual fits in pT bins
-      # Decide whether to take the sigma from MC or data for individual fits
-      init_fits_from: mc # data # data or mc
-
       sel_an_binmin: [1,2,4,6,8,12]
       sel_an_binmax: [2,4,6,8,12,24]
       binning_matching: [0,1,2,3,4,5]
@@ -360,6 +356,8 @@ LcpKpi:
 
       mass_fit_lim: [2.14, 2.436] # region for the fit of the invariant mass distribution [GeV/c^2]
       bin_width: 0.001 # bin width of the invariant mass histogram
+      # To initialize the individual fits in pT bins
+      # Decide whether to take the sigma from MC or data for individual fits
       init_fits_from: [mc,mc,mc,mc,mc,mc] # data or mc
       sgnfunc: [kGaus,kGaus,kGaus,kGaus,kGaus,kGaus]
       bkgfunc: [Pol2,Pol2,Pol2,Pol2,Pol2,Pol2]

--- a/machine_learning_hep/models.py
+++ b/machine_learning_hep/models.py
@@ -22,6 +22,7 @@ import pickle
 import pandas as pd
 import numpy as np
 import matplotlib.pyplot as plt
+import matplotlib as mpl
 from matplotlib.colors import ListedColormap
 
 from sklearn.feature_extraction import DictVectorizer
@@ -199,10 +200,10 @@ def importanceplotall(mylistvariables_, names_, trainedmodels_, suffix_, folder)
     names_models = [(name, model) for name, model in zip(names_, trainedmodels_) \
             if not any(mname in name for mname in ("SVC", "Logistic", "Keras"))]
     if len(names_models) == 1:
-        plt.figure(figsize=(18, 15))
+        figure = plt.figure(figsize=(18, 15))
         nrows, ncols = (1, 1)
     else:
-        plt.figure(figsize=(25, 15))
+        figure = plt.figure(figsize=(25, 15))
         nrows, ncols = (2, (len(names_models) + 1) / 2)
     for ind, (name, model) in enumerate(names_models, start=1):
         ax = plt.subplot(nrows, ncols, ind)
@@ -217,9 +218,10 @@ def importanceplotall(mylistvariables_, names_, trainedmodels_, suffix_, folder)
         ax.set_title(f"Importance features {name}", fontsize=17)
         ax.xaxis.set_tick_params(labelsize=17)
         plt.xlim(0, 0.7)
-    plt.subplots_adjust(wspace=0.5)
+    if len(names_models) > 1:
+        plt.subplots_adjust(wspace=0.5)
     plotname = f"{folder}/importanceplotall{suffix_}.png"
-    plt.savefig(plotname)
+    figure.savefig(plotname, bbox_inches='tight')
     plt.close()
 
 def shap_study(names_, trainedmodels_, x_train_, suffix_, folder, plot_options_):
@@ -236,6 +238,7 @@ def shap_study(names_, trainedmodels_, x_train_, suffix_, folder, plot_options_)
         folder: str
             Where to be saved
     """
+    mpl.rcParams.update({"text.usetex": True})
     plot_type_name = "prob_cut_scan"
     plot_options = plot_options_.get(plot_type_name, {}) \
             if isinstance(plot_options_, dict) else {}
@@ -263,7 +266,8 @@ def shap_study(names_, trainedmodels_, x_train_, suffix_, folder, plot_options_)
         shap.summary_plot(shap_values, x_train_, show=False, feature_names=feature_names)
     plotname = f"{folder}/importanceplotall_shap_{suffix_}.png"
     figure.tight_layout()
-    figure.savefig(plotname)
+    figure.savefig(plotname, bbox_inches='tight')
+    mpl.rcParams.update({"text.usetex": False})
     plt.close(figure)
 
 
@@ -308,5 +312,5 @@ def decisionboundaries(names_, trainedmodels_, suffix_, x_train_, y_train_, fold
         figure.subplots_adjust(hspace=.5)
         i += 1
     plotname = f"{folder}/decisionboundaries{suffix_}.png"
-    plt.savefig(plotname)
+    figure.savefig(plotname, bbox_inches='tight')
     plt.close(figure)

--- a/machine_learning_hep/models.py
+++ b/machine_learning_hep/models.py
@@ -1,5 +1,5 @@
 #############################################################################
-##  © Copyright CERN 2018. All rights not expressly granted are reserved.  ##
+##  © Copyright CERN 2023. All rights not expressly granted are reserved.  ##
 ##                 Author: Gian.Michele.Innocenti@cern.ch                  ##
 ## This program is free software: you can redistribute it and/or modify it ##
 ##  under the terms of the GNU General Public License as published by the  ##

--- a/machine_learning_hep/optimiser.py
+++ b/machine_learning_hep/optimiser.py
@@ -423,7 +423,7 @@ class Optimiser: # pylint: disable=too-many-public-methods, consider-using-f-str
 
         self.logger.info("Testing")
         self.df_mltest_applied = apply(self.p_mltype, self.p_classname, self.p_trainedmod,
-                                       self.df_mltest, self.v_train, self.p_multiclass_labels)
+                                       self.df_mltest, self.v_train, self.p_class_labels)
         pickle.dump(self.df_mltest_applied, openfile(self.f_mltest_applied, "wb"), protocol=4)
         # df_ml_test_to_root = self.dirmlout+"/testsample_%s_mldecision.root" % (self.s_suffix)
         # write_tree(df_ml_test_to_root, self.n_treetest, self.df_mltest_applied)
@@ -440,9 +440,9 @@ class Optimiser: # pylint: disable=too-many-public-methods, consider-using-f-str
         for df, filename in zip((self.df_data, self.df_mc),
                                 (self.f_reco_applieddata, self.f_reco_appliedmc)):
             df_res = apply(self.p_mltype, self.p_classname, self.p_trainedmod,
-                           df, self.v_train, self.p_multiclass_labels)
+                           df, self.v_train, self.p_class_labels)
             with openfile(filename, "wb") as out_file:
-                pickle.dump(df, out_file, protocol=4)
+                pickle.dump(df_res, out_file, protocol=4)
 
     def do_crossval(self):
         if self.step_done("cross_validation"):

--- a/machine_learning_hep/optimiser.py
+++ b/machine_learning_hep/optimiser.py
@@ -31,7 +31,7 @@ from machine_learning_hep.utilities import seldf_singlevar, split_df_classes, cr
 from machine_learning_hep.utilities import openfile, selectdfquery, mask_df
 from machine_learning_hep.correlations import vardistplot, scatterplot, correlationmatrix
 from machine_learning_hep.models import getclf_scikit, getclf_xgboost, getclf_keras
-from machine_learning_hep.models import fit, savemodels, readmodels, test, apply, decisionboundaries
+from machine_learning_hep.models import fit, savemodels, readmodels, apply, decisionboundaries
 # from machine_learning_hep.root import write_tree
 from machine_learning_hep.mlperformance import cross_validation_mse, plot_cross_validation_mse
 from machine_learning_hep.mlperformance import plot_learning_curves, precision_recall
@@ -372,13 +372,11 @@ class Optimiser: # pylint: disable=too-many-public-methods, consider-using-f-str
                 if self.v_selected else {"all_vars": self.v_all, "features": self.v_train}
 
         for _, variables in var_set.items():
-            vardistplot(self.dfs_train[self.p_class_labels[1]],
-                        self.dfs_train[self.p_class_labels[0]],
+            vardistplot(self.dfs_train,
                         variables, self.dirmlplot,
                         self.p_binmin, self.p_binmax, self.p_plot_options)
 
-        scatterplot(self.dfs_train[self.p_class_labels[1]],
-                    self.dfs_train[self.p_class_labels[0]],
+        scatterplot(self.dfs_train,
                     self.v_corrx, self.v_corry,
                     self.dirmlplot, self.p_binmin, self.p_binmax)
 
@@ -424,8 +422,8 @@ class Optimiser: # pylint: disable=too-many-public-methods, consider-using-f-str
             return
 
         self.logger.info("Testing")
-        self.df_mltest_applied = test(self.p_mltype, self.p_classname, self.p_trainedmod,
-                                      self.df_mltest, self.v_train, self.v_class)
+        self.df_mltest_applied = apply(self.p_mltype, self.p_classname, self.p_trainedmod,
+                                       self.df_mltest, self.v_train, self.p_multiclass_labels)
         pickle.dump(self.df_mltest_applied, openfile(self.f_mltest_applied, "wb"), protocol=4)
         # df_ml_test_to_root = self.dirmlout+"/testsample_%s_mldecision.root" % (self.s_suffix)
         # write_tree(df_ml_test_to_root, self.n_treetest, self.df_mltest_applied)
@@ -439,15 +437,12 @@ class Optimiser: # pylint: disable=too-many-public-methods, consider-using-f-str
         self.do_train()
 
         self.logger.info("Application")
-
-        df_data = apply(self.p_mltype, self.p_classname, self.p_trainedmod,
-                        self.df_data, self.v_train)
-        df_mc = apply(self.p_mltype, self.p_classname, self.p_trainedmod,
-                      self.df_mc, self.v_train)
-        with openfile(self.f_reco_applieddata, "wb") as out_file_data:
-            pickle.dump(df_data, out_file_data, protocol=4)
-        with openfile(self.f_reco_appliedmc, "wb") as out_file_mc:
-            pickle.dump(df_mc, out_file_mc, protocol=4)
+        for df, filename in zip((self.df_data, self.df_mc),
+                                (self.f_reco_applieddata, self.f_reco_appliedmc)):
+            df_res = apply(self.p_mltype, self.p_classname, self.p_trainedmod,
+                           df, self.v_train, self.p_multiclass_labels)
+            with openfile(filename, "wb") as out_file:
+                pickle.dump(df, out_file, protocol=4)
 
     def do_crossval(self):
         if self.step_done("cross_validation"):

--- a/machine_learning_hep/submission/default_complete.yml
+++ b/machine_learning_hep/submission/default_complete.yml
@@ -30,9 +30,9 @@ ml_study: # mlout, mlplot
   doplotdistr: true
   doroc: true
   doroctraintest: true
-  doimportance: false
-  doimportanceshap: false
-  docorrelation: false
+  doimportance: true
+  doimportanceshap: true
+  docorrelation: true
   dolearningcurve: false
   doapplytodatamc: false
   doscancuts: false

--- a/machine_learning_hep/submission/default_complete.yml
+++ b/machine_learning_hep/submission/default_complete.yml
@@ -24,16 +24,16 @@ mergingperiods: # pkl_skimmed_merge_for_ml_all
     activate: false
 
 ml_study: # mlout, mlplot
-  activate: false
-  dotraining: false
-  dotesting: false
-  doplotdistr: false
-  doroc: false
-  doroctraintest: false
-  doimportance: false
-  doimportanceshap: false
-  docorrelation: false
-  dolearningcurve: false
+  activate: true
+  dotraining: true
+  dotesting: true
+  doplotdistr: true
+  doroc: true
+  doroctraintest: true
+  doimportance: true
+  doimportanceshap: true
+  docorrelation: true
+  dolearningcurve: true
   doapplytodatamc: false
   doscancuts: false
   doefficiency: false
@@ -54,7 +54,7 @@ mlapplication:
     docontinueafterstop: false # set to true to resume interrupted processing (existing corrupted output will be overwritten)
 
 analysis:
-  type: "YYYY" # used unless specified explicitly as do_entire_analysis -a type_ana
+  type: "Run3analysis" # used unless specified explicitly as do_entire_analysis -a type_ana
   # Do each period separately including merged (true)
   # Do only merged (false)
   doperperiod: false

--- a/machine_learning_hep/submission/default_complete.yml
+++ b/machine_learning_hep/submission/default_complete.yml
@@ -30,10 +30,10 @@ ml_study: # mlout, mlplot
   doplotdistr: true
   doroc: true
   doroctraintest: true
-  doimportance: true
-  doimportanceshap: true
-  docorrelation: true
-  dolearningcurve: true
+  doimportance: false
+  doimportanceshap: false
+  docorrelation: false
+  dolearningcurve: false
   doapplytodatamc: false
   doscancuts: false
   doefficiency: false

--- a/machine_learning_hep/submission/default_complete.yml
+++ b/machine_learning_hep/submission/default_complete.yml
@@ -24,15 +24,15 @@ mergingperiods: # pkl_skimmed_merge_for_ml_all
     activate: false
 
 ml_study: # mlout, mlplot
-  activate: true
-  dotraining: true
-  dotesting: true
-  doplotdistr: true
-  doroc: true
-  doroctraintest: true
-  doimportance: true
-  doimportanceshap: true
-  docorrelation: true
+  activate: false
+  dotraining: false
+  dotesting: false
+  doplotdistr: false
+  doroc: false
+  doroctraintest: false
+  doimportance: false
+  doimportanceshap: false
+  docorrelation: false
   dolearningcurve: false
   doapplytodatamc: false
   doscancuts: false
@@ -54,7 +54,7 @@ mlapplication:
     docontinueafterstop: false # set to true to resume interrupted processing (existing corrupted output will be overwritten)
 
 analysis:
-  type: "Run3analysis" # used unless specified explicitly as do_entire_analysis -a type_ana
+  type: "YYYY" # used unless specified explicitly as do_entire_analysis -a type_ana
   # Do each period separately including merged (true)
   # Do only merged (false)
   doperperiod: false

--- a/machine_learning_hep/utilities_plot.py
+++ b/machine_learning_hep/utilities_plot.py
@@ -74,13 +74,13 @@ def buildhisto(h_name, h_tit, arrayx, arrayy=None, arrayz=None):
     histo.Sumw2()
     return histo
 
-def makefill1dhist(df_, h_name, h_tit, arrayx, nvar1):
-    """
-    Create a TH1F histogram and fill it with one variables from a dataframe.
-    """
-    histo = buildhisto(h_name, h_tit, arrayx)
-    fill_hist(histo, df_[nvar1])
-    return histo
+#def makefill1dhist(df_, h_name, h_tit, arrayx, nvar1):
+#    """
+#    Create a TH1F histogram and fill it with one variables from a dataframe.
+#    """
+#    histo = buildhisto(h_name, h_tit, arrayx)
+#    fill_hist(histo, df_[nvar1])
+#    return histo
 
 def build2dhisto(titlehist, arrayx, arrayy):
     """
@@ -88,15 +88,15 @@ def build2dhisto(titlehist, arrayx, arrayy):
     """
     return buildhisto(titlehist, titlehist, arrayx, arrayy)
 
-def makefill2dhist(df_, titlehist, arrayx, arrayy, nvar1, nvar2):
-    """
-    Create a TH2F histogram and fill it with two variables from a dataframe.
-    """
-    histo = build2dhisto(titlehist, arrayx, arrayy)
-    df_rd = df_[[nvar1, nvar2]]
-    arr2 = df_rd.to_numpy()
-    fill_hist(histo, arr2)
-    return histo
+#def makefill2dhist(df_, titlehist, arrayx, arrayy, nvar1, nvar2):
+#    """
+#    Create a TH2F histogram and fill it with two variables from a dataframe.
+#    """
+#    histo = build2dhisto(titlehist, arrayx, arrayy)
+#    df_rd = df_[[nvar1, nvar2]]
+#    arr2 = df_rd.to_numpy()
+#    fill_hist(histo, arr2)
+#    return histo
 
 def makefill2dweighed(df_, titlehist, arrayx, arrayy, nvar1, nvar2, weight):
     """
@@ -134,14 +134,14 @@ def makefill3dweighed(df_, titlehist, arrayx, arrayy, arrayz, nvar1, nvar2, nvar
                    getattr(row, nvar3), getattr(row, weight))
     return histo
 
-def fill2dhist(df_, histo, nvar1, nvar2):
-    """
-    Fill a TH2 histogram with two variables from a dataframe.
-    """
-    df_rd = df_[[nvar1, nvar2]]
-    arr2 = df_rd.values
-    fill_hist(histo, arr2)
-    return histo
+#def fill2dhist(df_, histo, nvar1, nvar2):
+#    """
+#    Fill a TH2 histogram with two variables from a dataframe.
+#    """
+#    df_rd = df_[[nvar1, nvar2]]
+#    arr2 = df_rd.values
+#    fill_hist(histo, arr2)
+#    return histo
 
 def fill2dweighed(df_, histo, nvar1, nvar2, weight):
     """
@@ -240,15 +240,15 @@ def load_root_style():
     gStyle.SetPadTickX(1)
     gStyle.SetPadTickY(1)
 
-def scatterplotroot(dfevt, nvar1, nvar2, nbins1, min1, max1, nbins2, min2, max2):
-    """
-    Make TH2F scatterplot between two variables from dataframe
-    """
-    hmult1_mult2 = TH2F(nvar1 + nvar2, nvar1 + nvar2, nbins1, min1, max1, nbins2, min2, max2)
-    dfevt_rd = dfevt[[nvar1, nvar2]]
-    arr2 = dfevt_rd.values
-    fill_hist(hmult1_mult2, arr2)
-    return hmult1_mult2
+#def scatterplotroot(dfevt, nvar1, nvar2, nbins1, min1, max1, nbins2, min2, max2):
+#    """
+#    Make TH2F scatterplot between two variables from dataframe
+#    """
+#    hmult1_mult2 = TH2F(nvar1 + nvar2, nvar1 + nvar2, nbins1, min1, max1, nbins2, min2, max2)
+#    dfevt_rd = dfevt[[nvar1, nvar2]]
+#    arr2 = dfevt_rd.values
+#    fill_hist(hmult1_mult2, arr2)
+#    return hmult1_mult2
 
 def find_axes_limits(histos, use_log_y=False):
     """
@@ -256,26 +256,12 @@ def find_axes_limits(histos, use_log_y=False):
     """
     # That might be considered to be a hack since it now only has a chance to work
     # reasonably well if there is at least one histogram.
-    max_y = min([h.GetMinimum() for h in histos if isinstance(h, TH1)])
-    min_y = min([h.GetMaximum() for h in histos if isinstance(h, TH1)])
+    max_y = max((h.GetMaximum() for h in histos if isinstance(h, TH1)))
+    min_y = min((h.GetMinimum() for h in histos if isinstance(h, TH1)))
     if not min_y > 0. and use_log_y:
         min_y = 10.e-9
-
-    max_x = max([h.GetXaxis().GetXmax() for h in histos])
-    min_x = max([h.GetXaxis().GetXmin() for h in histos])
-
-    for h in histos:
-        if not isinstance(h, TH1):
-            # That might be considered to be a hack since it now only has a chance to work
-            # reasonably well if there is at least one histogram.
-            continue
-        min_x = min(min_x, h.GetXaxis().GetXmin())
-        max_x = max(max_x, h.GetXaxis().GetXmax())
-        min_y_tmp = h.GetBinContent(h.GetMinimumBin())
-        if min_y_tmp > 0. and use_log_y or not use_log_y:
-            min_y = min(min_y, h.GetBinContent(h.GetMinimumBin()))
-        max_y = max(max_y, h.GetBinContent(h.GetMaximumBin()))
-
+    max_x = max((h.GetXaxis().GetXmax() for h in histos))
+    min_x = min((h.GetXaxis().GetXmin() for h in histos))
     return min_x, max_x, min_y, max_y
 
 def style_histograms(histos, linestyles=None, markerstyles=None, colors=None, linewidths=None,

--- a/machine_learning_hep/utilities_plot.py
+++ b/machine_learning_hep/utilities_plot.py
@@ -22,6 +22,7 @@ replace AliHFSystErr from AliPhysics).
 from array import array
 import math
 import numpy as np
+import matplotlib.pyplot as plt
 # from root_numpy import fill_hist # pylint: disable=import-error, no-name-in-module
 # pylint: disable=import-error, no-name-in-module
 from ROOT import TH1F, TH2F, TH2, TFile, TH1, TH3F, TGraphAsymmErrors
@@ -29,6 +30,19 @@ from ROOT import TPad, TCanvas, TLegend, kBlack, kGreen, kRed, kBlue, kWhite
 from ROOT import gStyle, gROOT, TMatrixD
 from machine_learning_hep.io import parse_yaml, dump_yaml_from_dict
 from machine_learning_hep.logger import get_logger
+
+def prepare_fig(plot_count):
+    """
+    Prepare figure for ML optimiser plots
+    """
+    if plot_count == 1:
+        figure = plt.figure(figsize=(20, 15))
+        nrows, ncols = (1, 1)
+    else:
+        figure = plt.figure(figsize=(25, 15))
+        nrows, ncols = (2, (plot_count + 1) / 2)
+        figure.subplots_adjust(hspace=0.5)
+    return figure, nrows, ncols
 
 def buildarray(listnumber):
     """

--- a/machine_learning_hep/utilities_plot.py
+++ b/machine_learning_hep/utilities_plot.py
@@ -1,5 +1,5 @@
 #############################################################################
-##  © Copyright CERN 2018. All rights not expressly granted are reserved.  ##
+##  © Copyright CERN 2023. All rights not expressly granted are reserved.  ##
 ##                 Author: Gian.Michele.Innocenti@cern.ch                  ##
 ## This program is free software: you can redistribute it and/or modify it ##
 ##  under the terms of the GNU General Public License as published by the  ##


### PR DESCRIPTION
1. Plotting functions in models.py and correlations.py generalized to multiclass
    a. **Not adjusted (unused?):** `vardistplot_probscan`, `efficiency_cutscan`, `picklesize_cutscan` in correlations.py, `decisionboundaries` in models.py
2. Merge test and apply into a single function, as they are identical
3. Remove BytesIO from plots -- apparently redundant
4. Remove duplicate keys from Lc databases
5. Pythonization of correlations.py and models.py

This PR doesn't change anything in BinaryClassifier results.