### PR TITLE
 Add collcnt file name to Lc multiclass database

### DIFF
--- a/machine_learning_hep/data/data_run3/database_ml_parameters_LcToPKPi_multiclass.yml
+++ b/machine_learning_hep/data/data_run3/database_ml_parameters_LcToPKPi_multiclass.yml
@@ -245,8 +245,7 @@ LcpKpi:
             - 20.
   files_names:
     namefile_unmerged_tree: AO2D.root
-    namefile_reco: AnalysisResultsReco.parquet
-    namefile_evt: AnalysisResultsEvt.parquet
+    namefile_collcnt: AnalysisResultsCollCnt.parquet
     namefile_evtvalroot: AnalysisResultsROOTEvtVal.root
     namefile_evtorig: AnalysisResultsEvtOrig.parquet
     namefile_gen: AnalysisResultsGen.parquet


### PR DESCRIPTION
Collcnt file is now used only by jets, but configuration is read in processer.py, and it crashes when it cannot find namefile_collcnt in yml.