### PR TITLE
Fix bug with wrongly matched analysis and skimming bins

### DIFF
--- a/machine_learning_hep/processer.py
+++ b/machine_learning_hep/processer.py
@@ -193,7 +193,7 @@ class Processer: # pylint: disable=too-many-instance-attributes
         self.bins_skimming = np.array(list(zip(self.lpt_anbinmin, self.lpt_anbinmax)), 'd')
         self.bins_analysis = np.array(list(zip(self.lpt_finbinmin, self.lpt_finbinmax)), 'd')
         bin_matching = [
-            [ptrange[0] <= bin[0] and ptrange[1] >= bin[0] for ptrange in self.bins_skimming].index(True)
+            [ptrange[0] <= bin[0] and ptrange[1] >= bin[1] for ptrange in self.bins_skimming].index(True)
             for bin in self.bins_analysis
         ]
 


### PR DESCRIPTION
Wrong bin matching between analysis and skimming bins. As a result, histomass step produces histograms with wrong names (suffixes based on cuts from wrong bins).
The old fitter calculates suffixes from analysis bins only, so, it gets confused with histomass output and crashes.