### PR TITLE
Pylint: Disable `too-` errors, report useless suppressions

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -13,7 +13,19 @@ max-args=10
 max-locals=40
 
 [MESSAGES CONTROL]
-disable=missing-docstring
+disable=
+    useless-suppression,
+    too-few-public-methods,
+    too-many-arguments,
+    too-many-branches,
+    too-many-instance-attributes,
+    too-many-lines,
+    too-many-locals,
+    too-many-nested-blocks,
+    too-many-positional-arguments,
+    too-many-public-methods,
+    too-many-return-statements,
+    too-many-statements
 
 [MISCELLANEOUS]
 notes=FIXME,XXX


### PR DESCRIPTION
- Silence `too-...` errors.
- Report useless suppressions.
- Remove suppression of legacy error `missing-docstring`. (We should add the missing documentation anyway.)