### PR TITLE
Rename io to io_ml_utils to avoid name clashes

### DIFF
--- a/machine_learning_hep/analysis/analyzer.py
+++ b/machine_learning_hep/analysis/analyzer.py
@@ -16,7 +16,7 @@ import os
 from os import makedirs
 from os.path import exists, join
 
-from machine_learning_hep.io import dump_yaml_from_dict
+from machine_learning_hep.io_ml_utils import dump_yaml_from_dict
 
 # HF specific imports
 from machine_learning_hep.workflow.workflow_base import WorkflowBase

--- a/machine_learning_hep/analysis/systematics.py
+++ b/machine_learning_hep/analysis/systematics.py
@@ -32,7 +32,7 @@ from time import sleep
 from ROOT import TCanvas, TFile, TGraphErrors, TLegend, kAzure, kBlack, kBlue, kGreen, kOrange, kRed, kViolet, kYellow
 
 from machine_learning_hep.fitting.helpers import MLFitter
-from machine_learning_hep.io import dump_yaml_from_dict, parse_yaml
+from machine_learning_hep.io_ml_utils import dump_yaml_from_dict, parse_yaml
 from machine_learning_hep.logger import get_logger
 from machine_learning_hep.multiprocesser import MultiProcesser
 from machine_learning_hep.utilities_plot import load_root_style

--- a/machine_learning_hep/fitting/simple_fit.py
+++ b/machine_learning_hep/fitting/simple_fit.py
@@ -24,7 +24,7 @@ from ROOT import TCanvas, TFile  # pylint: disable=import-error, no-name-in-modu
 
 from machine_learning_hep.fitting.fitters import FitAliHF, FitROOTGauss
 from machine_learning_hep.fitting.utils import save_fit
-from machine_learning_hep.io import parse_yaml
+from machine_learning_hep.io_ml_utils import parse_yaml
 from machine_learning_hep.logger import configure_logger  # , get_logger
 
 #############################################################################

--- a/machine_learning_hep/fitting/utils.py
+++ b/machine_learning_hep/fitting/utils.py
@@ -28,7 +28,7 @@ from os.path import join
 # pylint: disable=import-error, no-name-in-module, unused-import
 from ROOT import TFile
 
-from machine_learning_hep.io import checkdir, dump_yaml_from_dict, parse_yaml
+from machine_learning_hep.io_ml_utils import checkdir, dump_yaml_from_dict, parse_yaml
 from machine_learning_hep.logger import get_logger
 
 

--- a/machine_learning_hep/io_ml_utils.py
+++ b/machine_learning_hep/io_ml_utils.py
@@ -1,14 +1,16 @@
-#  © Copyright CERN 2018. All rights not expressly granted are reserved.  #
-#                 Author: Gian.Michele.Innocenti@cern.ch                  #
-# This program is free software: you can redistribute it and/or modify it #
-#  under the terms of the GNU General Public License as published by the  #
-# Free Software Foundation, either version 3 of the License, or (at your  #
-# option) any later version. This program is distributed in the hope that #
-#  it will be useful, but WITHOUT ANY WARRANTY; without even the implied  #
-#     warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.    #
-#           See the GNU General Public License for more details.          #
-#    You should have received a copy of the GNU General Public License    #
-#   along with this program. if not, see <https://www.gnu.org/licenses/>. #
+#############################################################################
+##  © Copyright CERN 2024. All rights not expressly granted are reserved.  ##
+##                 Author: Gian.Michele.Innocenti@cern.ch                  ##
+## This program is free software: you can redistribute it and/or modify it ##
+##  under the terms of the GNU General Public License as published by the  ##
+## Free Software Foundation, either version 3 of the License, or (at your  ##
+## option) any later version. This program is distributed in the hope that ##
+##  it will be useful, but WITHOUT ANY WARRANTY; without even the implied  ##
+##     warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.    ##
+##           See the GNU General Public License for more details.          ##
+##    You should have received a copy of the GNU General Public License    ##
+##   along with this program. if not, see <https://www.gnu.org/licenses/>. ##
+#############################################################################
 
 """
 Methods to: manage input/output

--- a/machine_learning_hep/multiprocesser.py
+++ b/machine_learning_hep/multiprocesser.py
@@ -19,7 +19,7 @@ main script for doing data processing, machine learning and analysis
 import os
 import tempfile
 
-from machine_learning_hep.io import dump_yaml_from_dict, parse_yaml
+from machine_learning_hep.io_ml_utils import dump_yaml_from_dict, parse_yaml
 from machine_learning_hep.logger import get_logger
 from machine_learning_hep.utilities import merge_method, mergerootfiles
 

--- a/machine_learning_hep/optimisation/bayesian_opt.py
+++ b/machine_learning_hep/optimisation/bayesian_opt.py
@@ -27,7 +27,7 @@ from sklearn.model_selection import cross_validate
 from yaml.representer import RepresenterError
 
 # from shap.plots.colors import red_blue as shap_cmap_red_blue
-from machine_learning_hep.io import dict_yamlable, dump_yaml_from_dict, parse_yaml
+from machine_learning_hep.io_ml_utils import dict_yamlable, dump_yaml_from_dict, parse_yaml
 
 # Change to that backend to not have problems with saving fgures
 # when X11 connection got lost

--- a/machine_learning_hep/optimisation/grid_search.py
+++ b/machine_learning_hep/optimisation/grid_search.py
@@ -24,7 +24,7 @@ import matplotlib.pyplot as plt
 import pandas as pd
 from sklearn.model_selection import GridSearchCV
 
-from machine_learning_hep.io import dump_yaml_from_dict, parse_yaml, print_dict
+from machine_learning_hep.io_ml_utils import dump_yaml_from_dict, parse_yaml, print_dict
 from machine_learning_hep.logger import get_logger
 from machine_learning_hep.models import savemodels
 from machine_learning_hep.optimisation.metrics import get_scorers

--- a/machine_learning_hep/optimiser.py
+++ b/machine_learning_hep/optimiser.py
@@ -44,7 +44,7 @@ from machine_learning_hep.correlations import (
     vardistplot,
     vardistplot_probscan,
 )
-from machine_learning_hep.io import dump_yaml_from_dict, parse_yaml
+from machine_learning_hep.io_ml_utils import dump_yaml_from_dict, parse_yaml
 from machine_learning_hep.logger import get_logger
 from machine_learning_hep.models import (
     apply,

--- a/machine_learning_hep/processer.py
+++ b/machine_learning_hep/processer.py
@@ -33,7 +33,7 @@ import uproot
 from pandas.api.types import is_numeric_dtype
 
 from .bitwise import tag_bit_df
-from .io import dump_yaml_from_dict
+from .io_ml_utils import dump_yaml_from_dict
 from .logger import get_logger
 from .utilities import (
     count_df_length_pkl,

--- a/machine_learning_hep/utilities_plot.py
+++ b/machine_learning_hep/utilities_plot.py
@@ -49,7 +49,7 @@ from ROOT import (
     kWhite,
 )
 
-from machine_learning_hep.io import dump_yaml_from_dict, parse_yaml
+from machine_learning_hep.io_ml_utils import dump_yaml_from_dict, parse_yaml
 from machine_learning_hep.logger import get_logger
 
 


### PR DESCRIPTION
There exists `io` module in Python core, and with pylint I got warnings about possible name clashes.
Maybe it is better to rename the MLHEP module.

@qgp @vkucera What do you think?