### PR TITLE
Restrict mega linter to run locally only on the branch changes

### DIFF
--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -4,6 +4,7 @@
 
 APPLY_FIXES: all # all, none, or list of linter keys
 DEFAULT_BRANCH: run3 # Usually master or main
+VALIDATE_ALL_CODEBASE: false
 # ENABLE: # If you use ENABLE variable, all other languages/formats/tooling-formats will be disabled by default
 # ENABLE_LINTERS: # If you use ENABLE_LINTERS variable, all other linters will be disabled by default
 DISABLE:


### PR DESCRIPTION
@vkucera based on our MegaLinter discussion.
This makes the local MegaLinter runs consider only the files that were modified compared to the run3 branch.